### PR TITLE
Add rustfmt_skip attribute.

### DIFF
--- a/lalrpop/src/rust/mod.rs
+++ b/lalrpop/src/rust/mod.rs
@@ -178,6 +178,7 @@ impl<W:Write> RustWrite<W> {
     }
 
     pub fn write_module_attributes(&mut self, grammar: &Grammar) -> io::Result<()> {
+        rust!(self, "#![cfg_attr(rustfmt, rustfmt_skip)]");
         for attribute in grammar.module_attributes.iter() {
             rust!(self, "{}", attribute);
         }


### PR DESCRIPTION
Fixes #233.