### PR TITLE
 perf: Use the minimum integer size necessary to represent states 

### DIFF
--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -1264,7 +1264,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
               "for {p}top in (0..{p}states_len).rev() {{",
               p = self.prefix);
         rust!(self.out,
-              "let {p}state = {p}states[{p}top];",
+              "let {p}state = {p}states[{p}top] as usize;",
               p = self.prefix);
         if DEBUG_PRINT {
             rust!(
@@ -1274,7 +1274,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
             );
         }
         // ...fetch action for error token...
-        rust!(self.out, "let {p}action = {p}ACTION[({p}state * {} + {}) as usize];",
+        rust!(self.out, "let {p}action = {p}ACTION[{p}state * {} + {}];",
               actions_per_state,
               actions_per_state - 1,
               p = self.prefix);
@@ -1496,11 +1496,11 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
 
         // Now load the new top state.
         rust!(self.out,
-              "let {p}recover_state = {p}states[{p}top];",
+              "let {p}recover_state = {p}states[{p}top] as usize;",
               p = self.prefix);
 
         // Load the error action, which must be a shift.
-        rust!(self.out, "let {p}error_action = {p}ACTION[({p}recover_state * {} + {}) as usize];",
+        rust!(self.out, "let {p}error_action = {p}ACTION[{p}recover_state * {} + {}];",
               actions_per_state,
               actions_per_state - 1,
               p = self.prefix);
@@ -1617,7 +1617,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
               self.prefix,
               self.prefix);
 
-        rust!(self.out, "let {p}top = {p}states[{p}states_len - 1];", p = self.prefix);
+        rust!(self.out, "let {p}top = {p}states[{p}states_len - 1] as usize;", p = self.prefix);
 
         if DEBUG_PRINT {
             rust!(self.out,
@@ -1629,7 +1629,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
         rust!(self.out, "None => {p}EOF_ACTION[{p}top as usize],", p = self.prefix);
         rust!(
             self.out,
-            "Some({p}integer) => {p}ACTION[({p}top * {actions_per_state}) as usize + {p}integer],",
+            "Some({p}integer) => {p}ACTION[{p}top * {actions_per_state} + {p}integer],",
             p = self.prefix,
             actions_per_state = actions_per_state,
         );
@@ -1686,7 +1686,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
 
         rust!(self.out, "{p}states_len -= {p}to_pop;", p = self.prefix);
         rust!(self.out, "{p}states.truncate({p}states_len);", p = self.prefix);
-        rust!(self.out, "let {p}top = {p}states[{p}states_len - 1];", p = self.prefix);
+        rust!(self.out, "let {p}top = {p}states[{p}states_len - 1] as usize;", p = self.prefix);
 
         if DEBUG_PRINT {
             rust!(self.out,
@@ -1700,7 +1700,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
 
         rust!(
             self.out,
-            "let {p}next_state = {p}GOTO[({p}top * {num_non_terminals} + {p}nt) as usize] - 1;",
+            "let {p}next_state = {p}GOTO[{p}top * {num_non_terminals} + {p}nt] - 1;",
             p = self.prefix,
             num_non_terminals = self.grammar.nonterminals.len(),
         );

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -335,9 +335,12 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
                                                                       .collect();
 
         let state_type = {
-            if states.len() <= ::std::i8::MAX as usize && reduce_indices.len() <= (::std::i8::MAX as usize + 1) {
+            // `reduce_indices` are allowed to be +1 since the negative maximum of any integer type
+            // is one larger than the positive maximum
+            let max_value = ::std::cmp::max(states.len(), reduce_indices.len() - 1);
+            if max_value <= ::std::i8::MAX as usize {
                 "i8"
-            } else if states.len() <= ::std::i16::MAX as usize && reduce_indices.len() <= (::std::i16::MAX as usize + 1) {
+            } else if max_value <= ::std::i16::MAX as usize {
                 "i16"
             } else {
                 "i32"


### PR DESCRIPTION
Part of #304 . We detect how many reductions and states that is needed before generating any code and then use the minimum necessary integer size to hold all of these. Most grammars likely fit within `i16` but smaller ones may fit within `i8`
.
The first commit simplifies the generated code a bit but did not help reduce the binary code in any way. Might make it a bit less work for LLVM at least.