### PR TITLE
Always use the 'input lifetime inside Symbol.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ doc/calculator/src/calculator6.rs
 doc/pascal/lalrpop/src/pascal.rs
 doc/whitespace/src/parser.rs
 
+lalrpop-test/src/empty.rs
+lalrpop-test/src/empty_tok.rs
 lalrpop-test/src/error.rs
 lalrpop-test/src/error_issue_113.rs
 lalrpop-test/src/error_issue_278.rs

--- a/lalrpop-test/src/empty.lalrpop
+++ b/lalrpop-test/src/empty.lalrpop
@@ -1,0 +1,3 @@
+grammar;
+
+pub Empty: () = ();

--- a/lalrpop-test/src/empty_tok.lalrpop
+++ b/lalrpop-test/src/empty_tok.lalrpop
@@ -1,0 +1,13 @@
+grammar;
+
+pub Empty: () = ();
+
+use empty_tok_lib;
+
+extern {
+    type Location = usize;
+    type Error = ();
+
+    enum empty_tok_lib::Tok {
+    }
+}

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -22,6 +22,12 @@ lalrpop_mod!(sub);
 lalrpop_mod!(sub_ascent);
 lalrpop_mod!(sub_table);
 
+/// test matching empty string
+mod empty;
+
+/// test matching empty string
+mod empty_tok;
+
 /// more interesting demonstration of parsing full expressions
 lalrpop_mod!(expr);
 
@@ -891,4 +897,19 @@ fn error_issue_278() {
             panic!("unexpected response from parser: {:?}", r);
         }
     }
+}
+
+#[test]
+fn test_empty() {
+    empty::parse_Empty("").unwrap();
+}
+
+mod empty_tok_lib {
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub struct Tok;
+}
+
+#[test]
+fn test_empty_tok() {
+    empty_tok::parse_Empty(Vec::<empty_tok_lib::Tok>::new()).unwrap();
 }

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -452,6 +452,9 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
                 .variant_names
                 .insert(Symbol::Nonterminal(nt.clone()), name.clone());
         }
+        if self.grammar.intern_token.is_some() {
+            rust!(self.out, "{}phantom_data(::std::marker::PhantomData<&'input ()>),", self.prefix);
+        }
         rust!(self.out, "}}");
         Ok(())
     }


### PR DESCRIPTION
Fixes #188.