### PR TITLE
fix error on parsing a single-quote char literal

### DIFF
--- a/lalrpop/src/tok/mod.rs
+++ b/lalrpop/src/tok/mod.rs
@@ -548,6 +548,9 @@ impl<'input> Tokenizer<'input> {
         self.lookahead.and_then( |(_, c)| {
             if c == '\\' {
                 // escape after `'` => it had to be character literal token, consume
+                // the backslash and escaped character, then consume until `'`
+                self.bump();
+                self.bump();
                 self.take_until_and_consume_terminating_character(|c:char| { c == '\'' })
             } else {
                 // no escape, then we require to see next `'` or we assume it was lifetime

--- a/lalrpop/src/tok/test.rs
+++ b/lalrpop/src/tok/test.rs
@@ -331,6 +331,14 @@ fn equalsgreaterthancode_error_end_of_input_instead_of_closing_normal_character_
 }
 
 #[test]
+fn equalsgreaterthancode_single_quote_literal() {
+    test(r#"=> { println!('\''); },"#, vec![
+        (r#"~~~~~~~~~~~~~~~~~~~~~~ "#, EqualsGreaterThanCode(r#" { println!('\''); }"#)),
+        (r#"                      ~"#, Comma),
+    ]);
+}
+
+#[test]
 fn code_paren() { // Issue #25
     test(r#"=> a("(", c),"#, vec![
         (r#"~~~~~~~~~~~~ "#, EqualsGreaterThanCode(r#" a("(", c)"#)),


### PR DESCRIPTION
Fixes #307

When encountering the sequence `'\` only search for the closing `'` after the character following the `\`.
