### PR TITLE
feat: De-duplicate symbol variants for parse tables

### DIFF
--- a/lalrpop/src/collections/map.rs
+++ b/lalrpop/src/collections/map.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+pub use std::collections::btree_map::Entry;
+
 /// In general, we avoid coding directly against any particular map,
 /// but rather build against `util::Map` (and `util::map` to construct
 /// an instance). This should be a deterministic map, such that two

--- a/lalrpop/src/collections/mod.rs
+++ b/lalrpop/src/collections/mod.rs
@@ -2,6 +2,6 @@ mod map;
 mod multimap;
 mod set;
 
-pub use self::map::{map, Map};
+pub use self::map::{map, Map, Entry};
 pub use self::multimap::{Collection, Multimap};
 pub use self::set::{set, Set};


### PR DESCRIPTION
This attempts to merge all symbol variants which would contain the same
type into one, letting us reduce the number of `pop_` functions being
generated.

Reduces the number of lines for `lrgrammar.lalrpop` from 67k to 57k
(a reduction of about 15%)