### PR TITLE
fix: Use the correct type for `!` in macro expanded productions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ lalrpop-test/src/error_recovery_issue_240.rs
 lalrpop-test/src/error_recovery_lock_in.rs
 lalrpop-test/src/error_recovery_lalr_loop.rs
 lalrpop-test/src/error_recovery_span.rs
+lalrpop-test/src/error_recovery_type_in_macro.rs
 lalrpop-test/src/expr.rs
 lalrpop-test/src/expr_arena.rs
 lalrpop-test/src/expr_generic.rs

--- a/lalrpop-test/src/error_recovery_type_in_macro.lalrpop
+++ b/lalrpop-test/src/error_recovery_type_in_macro.lalrpop
@@ -1,0 +1,21 @@
+
+use util::tok::Tok;
+
+#[LALR]
+grammar<'input>();
+
+extern {
+    type Location = usize;
+    enum Tok {
+        "(" => Tok::LParen,
+    }
+}
+
+Macro<T>: T = {
+    <T>
+};
+
+pub Expr: ()  = {
+    Macro<!> => (),
+};
+

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -89,6 +89,7 @@ mod error_recovery_issue_240;
 mod error_recovery_lalr_loop;
 mod error_recovery_lock_in;
 mod error_recovery_span;
+mod error_recovery_type_in_macro;
 
 /// test for inlining expansion issue #55
 mod issue_55;

--- a/lalrpop/src/grammar/repr.rs
+++ b/lalrpop/src/grammar/repr.rs
@@ -357,6 +357,10 @@ impl Types {
         &self.parse_error_type
     }
 
+    pub fn error_recovery_type(&self) -> &TypeRepr {
+        &self.error_recovery_type
+    }
+
     /// Returns a type `(L, T, L)` where L is the location type and T
     /// is the token type.
     pub fn triple_type(&self) -> TypeRepr {

--- a/lalrpop/src/normalize/tyinfer/mod.rs
+++ b/lalrpop/src/normalize/tyinfer/mod.rs
@@ -323,7 +323,7 @@ impl<'grammar> TypeInferencer<'grammar> {
             SymbolKind::Nonterminal(ref id) => self.nonterminal_type(id),
             SymbolKind::Choose(ref s) => self.symbol_type(&s.kind),
             SymbolKind::Name(_, ref s) => self.symbol_type(&s.kind),
-            SymbolKind::Error => Ok(self.types.parse_error_type().clone()),
+            SymbolKind::Error => Ok(self.types.error_recovery_type().clone()),
 
             SymbolKind::Repeat(..)
             | SymbolKind::Expr(..)

--- a/lalrpop/src/normalize/tyinfer/test.rs
+++ b/lalrpop/src/normalize/tyinfer/test.rs
@@ -236,7 +236,7 @@ grammar;
         vec![
             (
                 "Z",
-                "__lalrpop_util::ParseError<usize, Token<'input>, &'static str>",
+                "__lalrpop_util::ErrorRecovery<usize, Token<'input>, &'static str>",
             ),
         ],
     )


### PR DESCRIPTION
I had missed updating this place in https://github.com/lalrpop/lalrpop/commit/6bf1c9e940c51ec1a74bbfee3df894b871ea5b01 and it appears this type mismatch only occurs when `!` occurs in macro.