### PR TITLE
fix: Allow lalrpop parsers to be used with include!

### DIFF
--- a/doc/pascal/lalrpop/build.rs
+++ b/doc/pascal/lalrpop/build.rs
@@ -3,6 +3,7 @@ extern crate lalrpop;
 fn main() {
     lalrpop::Configuration::new()
         .emit_comments(true)
+        .use_cargo_dir_conventions()
         .process_current_dir()
         .unwrap();
 }

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -59,6 +59,7 @@ pub fn compile<W: Write>(
 ) -> io::Result<()> {
     let prefix = &grammar.prefix;
 
+    rust!(out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
     rust!(out, "mod {}intern_token {{", prefix);
     rust!(out, "#![allow(unused_imports)]");
     try!(out.write_uses("", &grammar));

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -71,6 +71,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         F: FnOnce(&mut Self) -> io::Result<()>,
     {
         rust!(self.out, "");
+        rust!(self.out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
         rust!(self.out, "mod {}parse{} {{", self.prefix, self.start_symbol);
 
         // these stylistic lints are annoying for the generated code,

--- a/lalrpop/src/lr1/codegen/test_all.rs
+++ b/lalrpop/src/lr1/codegen/test_all.rs
@@ -48,6 +48,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TestAll> {
         self.write_parse_mod(|this| {
             try!(this.write_parser_fn());
 
+            rust!(this.out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
             rust!(this.out, "mod {}ascent {{", this.prefix);
             try!(super::ascent::compile(
                 this.grammar,
@@ -67,6 +68,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TestAll> {
             rust!(this.out, "{}", pub_use);
             rust!(this.out, "}}");
 
+            rust!(this.out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
             rust!(this.out, "mod {}parse_table {{", this.prefix);
             try!(super::parse_table::compile(
                 this.grammar,

--- a/lalrpop/src/rust/mod.rs
+++ b/lalrpop/src/rust/mod.rs
@@ -161,7 +161,6 @@ impl<W: Write> RustWrite<W> {
     }
 
     pub fn write_module_attributes(&mut self, grammar: &Grammar) -> io::Result<()> {
-        rust!(self, "#![cfg_attr(rustfmt, rustfmt_skip)]");
         for attribute in grammar.module_attributes.iter() {
             rust!(self, "{}", attribute);
         }


### PR DESCRIPTION
Due to https://github.com/rust-lang/rust/issues/18810 (https://github.com/rust-lang/rfcs/issues/752)
it is not possible to have an inner attribute in a file that gets
used with `include!`.

Specifying the attribute on each parser module is less precise and more
duplication but it will at least work for that case. If a user wants to
apply the rustfmt on the whole module they can still add an outer
attribute manually as well.