### PR TITLE
Update tutorial for Cargo build script change

### DIFF
--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -26,9 +26,8 @@ look something like:
 name = "calculator"
 version = "0.1.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
-build = "build.rs" # <-- We added this and everything after!
 
-[build-dependencies]
+[build-dependencies] # <-- We added this and everything after!
 lalrpop = "0.15.0"
 
 [dependencies]
@@ -36,10 +35,12 @@ lalrpop-util = "0.15.0"
 regex = "0.2.1"
 ```
 
-Adding a `build` directive to the `[package]` section tells Cargo to
-run `build.rs` as a pre-processing step. The `[build-dependencies]`
-section that specifies the dependencies for `build.rs` -- in this
+Cargo can run [build scripts] as a pre-processing step,
+named `build.rs` by default. The `[build-dependencies]`
+section specifies the dependencies for build scripts -- in this
 case, just LALRPOP.
+
+[build scripts]: https://doc.rust-lang.org/cargo/reference/build-scripts.html
 
 The `[dependencies]` section describes the dependencies that LALRPOP
 needs at runtime. All LALRPOP parsers require at least the


### PR DESCRIPTION
Cargo used to require `build = "build.rs"` line but it no longer does. Update accordingly.