### PR TITLE
Update docs for 0.15

### DIFF
--- a/doc/calculator/src/main.rs
+++ b/doc/calculator/src/main.rs
@@ -1,6 +1,6 @@
 extern crate lalrpop_util;
 
-pub mod calculator1; // syntesized by LALRPOP
+pub mod calculator1; // synthesized by LALRPOP
 
 #[test]
 fn calculator1() {

--- a/doc/src/tutorial/002_paren_numbers.md
+++ b/doc/src/tutorial/002_paren_numbers.md
@@ -81,7 +81,7 @@ pub Term: i32 = {
 ```
 
 First, this nonterminal is declared as `pub`. That means that LALRPOP
-will generate a public function (named, as we will see, `parse_Term`)
+will generate a public struct (named, as we will see, `TermParser`)
 that you can use to parse strings as `Term`. Private nonterminals
 (like `Num`) can only be used within the grammar itself, not from
 outside.
@@ -95,9 +95,9 @@ number; so `22` is a term. The second alternative is `"(" <t:Term>
 
 **Invoking the parser.** OK, so we wrote our parser, how do we use it?
 For every nonterminal `Foo` declared as `pub`, LALRPOP will export a
-`parse_Foo` fn that you can call to parse a string as that
-nonterminal. Here is a simple test that we've added to our
-[`main.rs`][main] file which uses this function to test our `Term`
+`FooParser` struct with a `parse` method that you can call to parse a
+string as that nonterminal. Here is a simple test that we've added to 
+our [`main.rs`][main] file which uses this struct to test our `Term`
 nonterminal:
 
 ```rust
@@ -105,17 +105,17 @@ pub mod calculator1; // synthesized by LALRPOP
 
 #[test]
 fn calculator1() {
-    assert!(calculator1::parse_Term("22").is_ok());
-    assert!(calculator1::parse_Term("(22)").is_ok());
-    assert!(calculator1::parse_Term("((((22))))").is_ok());
-    assert!(calculator1::parse_Term("((22)").is_err());
+    assert!(calculator1::TermParser::new().parse("22").is_ok());
+    assert!(calculator1::TermParser::new().parse("(22)").is_ok());
+    assert!(calculator1::TermParser::new().parse("((((22))))").is_ok());
+    assert!(calculator1::TermParser::new().parse("((22)").is_err());
 }
 ```
 
-The full signature of the parse function looks like this:
+The full signature of the parse method looks like this:
 
 ```rust
-fn parse_Term<'input>(input: &'input str)
+fn parse<'input>(&self, input: &'input str)
                      -> Result<i32, ParseError<usize,(usize, &'input str),()>>
                      //        ~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                      //         |                       |

--- a/doc/src/tutorial/004_controlling_lexer.md
+++ b/doc/src/tutorial/004_controlling_lexer.md
@@ -139,9 +139,14 @@ two matches of equal length, it prefers the fixed string:
 ```rust
 #[test]
 fn calculator2b() {
-    assert_eq!(calculator2b::parse_Term("33").unwrap(), "33");
-    assert_eq!(calculator2b::parse_Term("(22)").unwrap(), "Twenty-two!");
-    assert_eq!(calculator2b::parse_Term("(222)").unwrap(), "222");
+    let result = calculator2b::TermParser::new().parse("33").unwrap();
+    assert_eq!(result, "33");
+
+    let result = calculator2b::TermParser::new().parse("(22)").unwrap();
+    assert_eq!(result, "Twenty-two!");
+
+    let result = calculator2b::TermParser::new().parse("(222)").unwrap();
+    assert_eq!(result, "222");
 }
 ```
 
@@ -226,12 +231,20 @@ unit test a bit to include some identifier examples::
 #[test]
 fn calculator2b() {
     // These will all work:
-    assert_eq!(calculator2b::parse_Term("33").unwrap(), "33");
-    assert_eq!(calculator2b::parse_Term("foo33").unwrap(), "Id(foo33)");
-    assert_eq!(calculator2b::parse_Term("(foo33)").unwrap(), "Id(foo33)");
+
+    let result = calculator2b::TermParser::new().parse("33").unwrap();
+    assert_eq!(result, "33");
+
+    let result = calculator2b::TermParser::new().parse("foo33").unwrap();
+    assert_eq!(result, "Id(foo33)");
+
+    let result = calculator2b::TermParser::new().parse("(foo33)").unwrap();
+    assert_eq!(result, "Id(foo33)");
     
-    // This line will fail:
-    assert_eq!(calculator2b::parse_Term("(22)").unwrap(), "Twenty-two!");
+    // This one will fail:
+
+    let result = calculator2b::TermParser::new().parse("(22)").unwrap();
+    assert_eq!(result, "Twenty-two!");
 }
 ```
 

--- a/doc/src/tutorial/006_building_asts.md
+++ b/doc/src/tutorial/006_building_asts.md
@@ -93,8 +93,10 @@ pub mod ast;
 
 #[test]
 fn calculator4() {
-    assert_eq!(&format!("{:?}", calculator4::parse_Expr("22 * 44 + 66").unwrap()),
-               "((22 * 44) + 66)");
+    let expr = calculator4::ExprParser::new()
+        .parse("22 * 44 + 66")
+        .unwrap();
+    assert_eq!(&format!("{:?}", expr), "((22 * 44) + 66)");
 }
 ```
 

--- a/doc/src/tutorial/007_macros.md
+++ b/doc/src/tutorial/007_macros.md
@@ -107,16 +107,28 @@ pub mod calculator5;
 
 #[test]
 fn calculator5() {
-    assert_eq!(&format!("{:?}", calculator5::parse_Exprs("").unwrap()),
-               "[]");
-    assert_eq!(&format!("{:?}", calculator5::parse_Exprs("22 * 44 + 66").unwrap()),
-               "[((22 * 44) + 66)]");
-    assert_eq!(&format!("{:?}", calculator5::parse_Exprs("22 * 44 + 66,").unwrap()),
-               "[((22 * 44) + 66)]");
-    assert_eq!(&format!("{:?}", calculator5::parse_Exprs("22 * 44 + 66, 13*3").unwrap()),
-               "[((22 * 44) + 66), (13 * 3)]");
-    assert_eq!(&format!("{:?}", calculator5::parse_Exprs("22 * 44 + 66, 13*3,").unwrap()),
-               "[((22 * 44) + 66), (13 * 3)]");
+    let expr = calculator5::ExprsParser::new().parse("").unwrap();
+    assert_eq!(&format!("{:?}", expr), "[]");
+
+    let expr = calculator5::ExprsParser::new()
+        .parse("22 * 44 + 66")
+        .unwrap();
+    assert_eq!(&format!("{:?}", expr), "[((22 * 44) + 66)]");
+
+    let expr = calculator5::ExprsParser::new()
+        .parse("22 * 44 + 66,")
+        .unwrap();
+    assert_eq!(&format!("{:?}", expr), "[((22 * 44) + 66)]");
+
+    let expr = calculator5::ExprsParser::new()
+        .parse("22 * 44 + 66, 13*3")
+        .unwrap();
+    assert_eq!(&format!("{:?}", expr), "[((22 * 44) + 66), (13 * 3)]");
+
+    let expr = calculator5::ExprsParser::new()
+        .parse("22 * 44 + 66, 13*3,")
+        .unwrap();
+    assert_eq!(&format!("{:?}", expr), "[((22 * 44) + 66), (13 * 3)]");
 }
 ```
 

--- a/doc/src/tutorial/008_error_recovery.md
+++ b/doc/src/tutorial/008_error_recovery.md
@@ -54,12 +54,21 @@ by inserting this `!` token where necessary.
 #[test]
 fn calculator6() {
     let mut errors = Vec::new();
-    assert_eq!(&format!("{:?}", calculator6::parse_Exprs(&mut errors, "22 * + 3").unwrap()),
-               "[((22 * error) + 3)]");
-    assert_eq!(&format!("{:?}", calculator6::parse_Exprs(&mut errors, "22 * 44 + 66, *3").unwrap()),
-               "[((22 * 44) + 66), (error * 3)]");
-    assert_eq!(&format!("{:?}", calculator6::parse_Exprs(&mut errors, "*").unwrap()),
-               "[(error * error)]");
+
+    let expr = calculator6::ExprsParser::new()
+        .parse(&mut errors, "22 * + 3")
+        .unwrap();
+    assert_eq!(&format!("{:?}", expr), "[((22 * error) + 3)]");
+
+    let expr = calculator6::ExprsParser::new()
+        .parse(&mut errors, "22 * 44 + 66, *3")
+        .unwrap();
+    assert_eq!(&format!("{:?}", expr), "[((22 * 44) + 66), (error * 3)]");
+
+    let expr = calculator6::ExprsParser::new()
+        .parse(&mut errors, "*")
+        .unwrap();
+    assert_eq!(&format!("{:?}", expr), "[(error * error)]");
 
     assert_eq!(errors.len(), 4);
 }


### PR DESCRIPTION
I wrote my first proper LALRPOP parser last night (loving the library so far!) and I was slightly tripped up by the fact that [the book](http://lalrpop.github.io/lalrpop/) hadn't been updated to reflect the API changes from the most recent release. I was able to get by, since the code examples in the repo had been updated a while back (#317), but I thought I'd submit a PR to avoid other people running into that confusion 😄 

For the most part, I've just copied and pasted the code samples across from [`main.rs`](https://github.com/17cupsofcoffee/lalrpop/blob/0eb0082a556ed33e653a9e867daf78ce9f0922bc/doc/calculator/src/main.rs) - the only place I had to make changes to the prose was in [the second chapter](https://github.com/17cupsofcoffee/lalrpop/blob/0eb0082a556ed33e653a9e867daf78ce9f0922bc/doc/src/tutorial/002_paren_numbers.md).

If any of the changes look dodgy or I've missed something, let me know 👍 