### PR TITLE
Correctly anchor regex at the begining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ lalrpop-test/src/unit.rs
 lalrpop-test/src/use_super.rs
 lalrpop-test/src/no_clone_tok.rs
 lalrpop-test/src/partial_parse.rs
+lalrpop-test/src/match_alternatives.rs
 lalrpop-test/src/match_section.rs
 lalrpop-test/src/expr_module_attributes.rs
 lalrpop-test/src/associated_types.rs

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -99,6 +99,7 @@ mod unit;
 
 /// test for match section
 mod match_section;
+mod match_alternatives;
 
 /// regression test for issue #253.
 mod partial_parse;
@@ -842,6 +843,20 @@ fn test_match_section() {
         match_section::QueryParser::new()
             .parse("UPDATE update")
             .is_err()
+    );
+}
+
+#[test]
+fn test_match_alternatives() {
+    assert_eq!(
+        match_alternatives::FileParser::new()
+            .parse("foo true"),
+        Ok("foo true".to_string())
+    );
+    assert_eq!(
+        match_alternatives::FileParser::new()
+            .parse("bar false"),
+        Ok("bar false".to_string())
     );
 }
 

--- a/lalrpop-test/src/match_alternatives.lalrpop
+++ b/lalrpop-test/src/match_alternatives.lalrpop
@@ -1,0 +1,9 @@
+grammar;
+
+pub File: String = bare_key bool => format!("{} {}", <>);
+
+match {
+    r"false|true" => bool,
+} else {
+    r"[a-z]+" => bare_key,
+}

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -102,7 +102,7 @@ pub fn compile<W: Write>(
             })
             .map(|regex| {
                 // make sure all regex are anchored at the beginning of the input
-                format!("^{}", regex)
+                format!("^({})", regex)
             })
             .map(|regex_str| {
                 // create a rust string with text of the regex; the Debug impl


### PR DESCRIPTION
^foo|bar is (^foo)|bar, and not ^(foo|bar). Adding parens should
fix it.

closes #358 

Funny how this is the second time I fix this bug in a parser generator, the fist fix was for fall: https://github.com/matklad/fall/commit/02b7fe1f471aeeb836b414caa3fe8a9235dc131c =P