### PR TITLE
Clarify 0.15 upgrade instructions

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -33,7 +33,7 @@ Compatibility notes:
 
 - To let regex compilation be cached, each parser are now generated as a struct
   with a `parse` method instead of just a function.
-  To upgrade, change each parse call from `parse_X(..)` to `X::new().parse(..)`.
+  To upgrade, change each parse call from `parse_X(..)` to `XParser::new().parse(..)`.
 
 Thanks to the following contributors for this release:
 


### PR DESCRIPTION
The X in `parse_X` is not the same X as in `X::new()` -- for example in my code I needed to go from `parse_Expr` to `ExprParser::new()`.