### PR TITLE
Use hash to decide whether to recompile

### DIFF
--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -30,6 +30,8 @@ serde_derive = "1.0"
 string_cache = "0.7.1"
 term = "0.4.5"
 unicode-xid = "0.1"
+sha2 = "0.7.0"
+digest = { version = "0.7", features = ["std"]}
 
 [dev-dependencies]
 rand = "0.4"

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -16,6 +16,7 @@ use session::{ColorConfig, Session};
 use term;
 use tls::Tls;
 use tok;
+use sha2::{Sha256, Digest};
 
 use std::fs;
 use std::io::{self, BufRead, Write};
@@ -35,6 +36,17 @@ const LALRPOP_VERSION_HEADER: &'static str = concat!(
     env!("CARGO_PKG_VERSION"),
     "\""
 );
+
+fn hash_file(file: &Path) -> io::Result<String> {
+    let mut file = try!(fs::File::open(&file));
+    let hash = try!(Sha256::digest_reader(&mut file));
+
+    let mut hash_str = "// sha256: ".to_owned();
+    for byte in hash {
+        hash_str.push_str(&format!("{:x}", byte));
+    }
+    Ok(hash_str)
+}
 
 pub fn process_dir<P: AsRef<Path>>(session: Rc<Session>, root_dir: P) -> io::Result<()> {
     let lalrpop_files = try!(lalrpop_files(root_dir));
@@ -117,6 +129,7 @@ fn process_file_into(
             let buffer = try!(emit_recursive_ascent(&session, &grammar, &report_file));
             let mut output_file = try!(fs::File::create(&rs_file));
             try!(writeln!(output_file, "{}", LALRPOP_VERSION_HEADER));
+            try!(writeln!(output_file, "{}", try!(hash_file(&lalrpop_file))));
             try!(output_file.write_all(&buffer));
         }
 
@@ -139,53 +152,23 @@ fn remove_old_file(rs_file: &Path) -> io::Result<()> {
 }
 
 fn needs_rebuild(lalrpop_file: &Path, rs_file: &Path) -> io::Result<bool> {
-    return match fs::metadata(&rs_file) {
-        Ok(rs_metadata) => {
-            let lalrpop_metadata = try!(fs::metadata(&lalrpop_file));
-            if compare_modification_times(&lalrpop_metadata, &rs_metadata) {
-                return Ok(true);
-            }
+    match fs::File::open(&rs_file) {
+        Ok(rs_file) => {
+            let mut version_str = String::new();
+            let mut hash_str = String::new();
 
-            compare_lalrpop_version(rs_file)
+            let mut f = io::BufReader::new(rs_file);
+
+            try!(f.read_line(&mut version_str));
+            try!(f.read_line(&mut hash_str));
+
+            Ok(hash_str.trim() != try!(hash_file(&lalrpop_file)) 
+               || version_str.trim() != LALRPOP_VERSION_HEADER)
         }
         Err(e) => match e.kind() {
             io::ErrorKind::NotFound => Ok(true),
             _ => Err(e),
         },
-    };
-
-    #[cfg(unix)]
-    fn compare_modification_times(
-        lalrpop_metadata: &fs::Metadata,
-        rs_metadata: &fs::Metadata,
-    ) -> bool {
-        use std::os::unix::fs::MetadataExt;
-        lalrpop_metadata.mtime() >= rs_metadata.mtime()
-    }
-
-    #[cfg(windows)]
-    fn compare_modification_times(
-        lalrpop_metadata: &fs::Metadata,
-        rs_metadata: &fs::Metadata,
-    ) -> bool {
-        use std::os::windows::fs::MetadataExt;
-        lalrpop_metadata.last_write_time() >= rs_metadata.last_write_time()
-    }
-
-    #[cfg(not(any(unix, windows)))]
-    fn compare_modification_times(
-        lalrpop_metadata: &fs::Metadata,
-        rs_metadata: &fs::Metadata,
-    ) -> bool {
-        true
-    }
-
-    fn compare_lalrpop_version(rs_file: &Path) -> io::Result<bool> {
-        let mut input_str = String::new();
-        let mut f = io::BufReader::new(try!(fs::File::open(&rs_file)));
-        try!(f.read_line(&mut input_str));
-
-        Ok(input_str.trim() != LALRPOP_VERSION_HEADER)
     }
 }
 

--- a/lalrpop/src/lib.rs
+++ b/lalrpop/src/lib.rs
@@ -19,6 +19,7 @@ extern crate regex_syntax;
 extern crate string_cache;
 extern crate term;
 extern crate unicode_xid;
+extern crate sha2;
 
 #[cfg(test)]
 extern crate rand;


### PR DESCRIPTION
Computes the SHA256 hash of the lalrpop file and compares it to a
comment in the generated Rust file

Closes #347