### PR TITLE
Add a custom lexer to the lalrpop-util crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,9 @@ dependencies = [
 [[package]]
 name = "lalrpop-util"
 version = "0.15.2"
+dependencies = [
+ "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "lazy_static"
@@ -342,6 +345,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +364,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "regex-syntax"
 version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -573,8 +596,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
+"checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
 "checksum regex-syntax 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2550876c31dc914696a6c2e01cbce8afba79a93c8ae979d2fe051c0230b3756"
+"checksum regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b"
 "checksum serde 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)" = "0e100d00fb985a5bf16b857a436450e404fa613de3321b2e383947a93cbd75df"
 "checksum serde_derive 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)" = "86daebd995aa948b069d886f2105f2425cd66103049855e45c15c58c573f12c5"
 "checksum serde_derive_internals 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3f714f52a41e371c5e141e9dafcead60921349bec76b44d79000c88aba3cfc"

--- a/doc/src/lexer_tutorial/index.md
+++ b/doc/src/lexer_tutorial/index.md
@@ -188,6 +188,32 @@ FlowCtrl: ast::Stmt = {
 
 The complete grammar is available in `whitespace/src/parser.lalrpop`.
 
+## Helpful Utilities
+
+For convenience a custom lexer is provided in the `lalrpop-util` crate (hidden 
+behind the `lexer` feature flag) which lets you use simple regular expressions
+to tokenize the source code. It also lets you skip custom patterns (e.g. 
+whitespace **and** comments).
+
+The following example will tokenize to the sequence 
+`Word("Hello"), Integer(5), Word("world")` and ignore everything from the `#`
+to the end of the line.
+
+```rust
+#[derive(Debug, PartialEq)]
+pub enum Token<'input> {
+  Integer(i64),
+  Word(&'input str),
+}
+
+let src = "Hello 5 world # this is a comment\n";
+
+let mut lexer = Lexer::new(src).skipping(r"^(?m)\s+|#.*$");
+
+lexer.register_pattern(r"^\d+", |s| Ok(Token::Integer(s.parse().unwrap())));
+lexer.register_pattern(r"^\w+", |s| Ok(Token::Word(s)));
+```
+
 ## Where to go from here
 
 Things to try that apply to lexers in general:

--- a/lalrpop-util/Cargo.toml
+++ b/lalrpop-util/Cargo.toml
@@ -16,3 +16,4 @@ regex = { version = "1", optional = true }
 [features]
 default = []
 lexer = ["regex"]
+

--- a/lalrpop-util/Cargo.toml
+++ b/lalrpop-util/Cargo.toml
@@ -7,8 +7,12 @@ version = "0.15.2" # LALRPOP
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 workspace = ".."
 
+[package.metadata.docs.rs]
+features = ["lexer"]
+
 [dependencies]
 regex = { version = "1", optional = true }
 
 [features]
+default = []
 lexer = ["regex"]

--- a/lalrpop-util/Cargo.toml
+++ b/lalrpop-util/Cargo.toml
@@ -6,3 +6,9 @@ license = "Apache-2.0/MIT"
 version = "0.15.2" # LALRPOP
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 workspace = ".."
+
+[dependencies]
+regex = { version = "1", optional = true }
+
+[features]
+lexer = ["regex"]

--- a/lalrpop-util/src/lexer.rs
+++ b/lalrpop-util/src/lexer.rs
@@ -1,6 +1,6 @@
+use regex::Regex;
 use std::error::Error as StdError;
 use std::fmt::{self, Display, Formatter};
-use regex::Regex;
 
 /// A generic table-based lexer.
 ///
@@ -200,13 +200,13 @@ impl<'input, Token: 'input> Iterator for Lexer<'input, Token> {
             }
         }
 
-        Some(Err(LexError{ location: self.ix }))
+        Some(Err(LexError { location: self.ix }))
     }
 }
 
 #[derive(Debug)]
 pub struct LexError {
-     location: usize,
+    location: usize,
 }
 
 impl StdError for LexError {

--- a/lalrpop-util/src/lexer.rs
+++ b/lalrpop-util/src/lexer.rs
@@ -1,0 +1,207 @@
+use regex::Regex;
+use ParseError;
+
+/// A generic table-based lexer.
+///
+/// This works by registering a bunch of token patterns and *Token Constructors*
+/// which let you convert the matched text into a custom `Token` type. When
+/// tokenizing, the lexer will try each pattern in turn until it finds a match
+/// and use the corresponding token constructor to create a token and return it.
+///
+/// # Examples
+///
+/// Here's how you would tokenize a trivial language consisting of just integers
+/// and words, where all whitespace is ignored.
+///
+/// ```rust
+/// # extern crate lalrpop_util;
+/// # use lalrpop_util::Lexer;
+/// #[derive(Debug, PartialEq)]
+/// pub enum Token {
+///   Integer(i64),
+///   Word(String),
+/// }
+///
+/// # fn run() -> Result<(), lalrpop_util::ParseError<usize, Token, ()>> {
+/// let src = "Hello 5 world";
+///
+/// // create the lexer
+/// let mut lexer = Lexer::new(src);
+///
+/// // register a bunch of patterns so it knows how to create tokens
+/// lexer.register_pattern(r"^\d+", |s| Ok(Token::Integer(s.parse().unwrap())));
+/// lexer.register_pattern(r"^\w+", |s| Ok(Token::Word(s.to_string())));
+///
+/// // then run the lexer to completion, bailing on the first error
+/// let got = lexer.collect::<Result<Vec<_>, _>>()?;
+///
+/// // Extract just the tokens out of the resulting list of positions and tokens
+/// let tokens: Vec<Token> = got.into_iter()
+///                             .map(|(_start, tok, _end)| tok)
+///                             .collect();
+///
+/// let should_be = vec![Token::Word(String::from("Hello")),
+///                      Token::Integer(5),
+///                      Token::Word(String::from("world"))];
+///
+/// // as a sanity check, make sure we got back what we expected
+/// assert_eq!(tokens, should_be);
+/// # Ok(())
+/// # }
+/// # fn main() { run().unwrap() }
+/// ```
+///
+/// If you want to avoid unnecessary copies, the `Token` type can contain
+/// references to the original source code.
+///
+/// ```rust
+
+/// # extern crate lalrpop_util;
+/// # use lalrpop_util::Lexer;
+/// #[derive(Debug, PartialEq)]
+/// pub enum Token<'input> {
+///   Integer(i64),
+///   Word(&'input str), // <-- borrowing part of the original string
+/// }
+///
+/// # fn run() -> Result<(), lalrpop_util::ParseError<usize, Token<'static>, ()>> {
+/// let src = "Hello 5 world";
+///
+/// let mut lexer = Lexer::new(src);
+///
+/// lexer.register_pattern(r"^\d+", |s| Ok(Token::Integer(s.parse().unwrap())));
+/// lexer.register_pattern(r"^\w+", |s| Ok(Token::Word(s)));  // <-- no "to_string()"!
+///
+/// let got = lexer.collect::<Result<Vec<_>, _>>()?;
+/// # Ok(())
+/// # }
+/// # fn main() { run().unwrap() }
+/// ```
+///
+/// This is completely safe because the `Token: 'input` lifetime on `Lexer` will
+/// ensure tokens can never outlive their source code.
+pub struct Lexer<'input, Token: 'input, Error> {
+    src: &'input str,
+    patterns: Vec<(Regex, Box<Fn(&'input str) -> Result<Token, Error>>)>,
+    skips: Regex,
+    ix: usize,
+}
+
+impl<'input, Token: 'input, Error> Lexer<'input, Token, Error> {
+    /// Create a new `Lexer` with an empty pattern table and which ignores all
+    /// whitespace by default.
+    pub fn new(src: &'input str) -> Lexer<'input, Token, Error> {
+        Lexer {
+            src: src,
+            patterns: Vec::new(),
+            skips: Regex::new(r"^\s+").unwrap(),
+            ix: 0,
+        }
+    }
+
+    /// Register a token pattern and a function for turning the matched text
+    /// into its corresponding `Token`.
+    ///
+    /// # Note
+    ///
+    /// The order in which you register patterns **is important**. Patterns
+    /// registered earlier will take precedence over later patterns.
+    ///
+    /// # Panics
+    ///
+    /// All patterns must begin with a `^` to ensure they match the start of a
+    /// string.
+    ///
+    /// This function will also `panic!()` if an invalid regex pattern is passed
+    /// in.
+    pub fn register_pattern<F>(&mut self, pattern: &str, constructor: F)
+    where
+        F: Fn(&'input str) -> Result<Token, Error> + 'static,
+    {
+        assert!(
+            pattern.starts_with("^"),
+            "All patterns must match the beginning of the text"
+        );
+
+        let re = Regex::new(pattern).expect("Invalid regex");
+        let constructor = Box::new(constructor);
+
+        self.patterns.push((re, constructor));
+    }
+
+    /// Set a custom skip pattern.
+    ///
+    /// # Examples
+    ///
+    /// A common desire is the ability to have a lexer which skips whitespace
+    /// and ignores the rest of the line when encountering a specific character
+    /// (e.g. `#`).
+    ///
+    /// ```rust
+    /// # use lalrpop_util::Lexer;
+    /// # fn make_lexer() -> Lexer<'static, &'static str, ()> {
+    /// # let some_source_text = "# this is a comment\ntext";
+    /// let lexer = Lexer::new(some_source_text).skipping(r"^\s+|(?m)#.*$");
+    /// # lexer
+    /// # }
+    /// # // make sure our pattern actually does what it says it does
+    /// # fn main() {
+    /// #  let mut l = make_lexer();
+    /// #  l.register_pattern(r"^\w+", |s| Ok(s));
+    /// #  assert_eq!(l.next().unwrap().unwrap().1, "text");
+    /// # }
+    /// ```
+    ///
+    /// Note that you need to enable multiline regex patterns (`(?m)`) when
+    /// skipping to the end of a line.
+    pub fn skipping(self, pattern: &str) -> Lexer<'input, Token, Error> {
+        assert!(
+            pattern.starts_with("^"),
+            "All patterns must match the beginning of the text"
+        );
+        let skips = Regex::new(pattern).expect("Invalid regex");
+
+        Lexer { skips, ..self }
+    }
+
+    fn skip(&mut self) {
+        while let Some(skipped) = self.skips.find(self.remaining()) {
+            self.ix += skipped.as_str().len();
+        }
+    }
+
+    fn remaining(&self) -> &'input str {
+        &self.src[self.ix..]
+    }
+
+    fn is_finished(&self) -> bool {
+        self.src.len() <= self.ix
+    }
+}
+
+impl<'input, Token: 'input, Error> Iterator for Lexer<'input, Token, Error> {
+    type Item = Result<(usize, Token, usize), ParseError<usize, Token, Error>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.skip();
+
+        if self.is_finished() {
+            return None;
+        }
+
+        let start = self.ix;
+
+        for &(ref pattern, ref constructor) in &self.patterns {
+            if let Some(found) = pattern.find(self.remaining()) {
+                self.ix += found.end();
+
+                let ret = constructor(found.as_str())
+                    .map(|t| (start, t, self.ix))
+                    .map_err(|error| ParseError::User { error });
+                return Some(ret);
+            }
+        }
+
+        Some(Err(ParseError::InvalidToken { location: self.ix }))
+    }
+}

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -1,3 +1,16 @@
+//! Extra `lalrpop` utilities.
+//!
+//! # Crate Feature Flags
+//!
+//! The following crate feature flags are available for enabling extra
+//! functionality. They are configured in your Cargo.toml.
+//!
+//! - `lexer`
+//!   - Enable a custom lexer which uses a provided list of regex
+//!     patterns during tokenization
+//!   - Useful when you need tighter control over the lexing process (i.e.
+//!     adding the ability to skip whitespace **and** comments)
+
 #[cfg(feature = "lexer")]
 extern crate regex;
 

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -20,7 +20,7 @@ use std::fmt;
 #[cfg(feature = "lexer")]
 mod lexer;
 #[cfg(feature = "lexer")]
-pub use lexer::{Lexer, LexError};
+pub use lexer::{LexError, Lexer};
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ParseError<L, T, E> {

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -20,7 +20,7 @@ use std::fmt;
 #[cfg(feature = "lexer")]
 mod lexer;
 #[cfg(feature = "lexer")]
-pub use lexer::Lexer;
+pub use lexer::{Lexer, LexError};
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ParseError<L, T, E> {

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -1,5 +1,13 @@
+#[cfg(feature = "lexer")]
+extern crate regex;
+
 use std::error::Error;
 use std::fmt;
+
+#[cfg(feature = "lexer")]
+mod lexer;
+#[cfg(feature = "lexer")]
+pub use lexer::Lexer;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ParseError<L, T, E> {


### PR DESCRIPTION
Following from my comment on #14 I'd like to add a custom table-based lexer to the `lalrpop_util` crate, hidden behind a cargo feature flag.

My use case is that 90% of the time you'll want the ability to add some form of comments to the code being parsed, but getting everyone to create their own full-blown custom lexer is massively overkill. This PR adds a custom lexer which should be flexible enough to fit most people's uses.

I've copied this lexer around to two or three projects so far, so it should be fairly well documented. I *think* the doctests are enough to cover everything but let me know if it needs more tests.