### PR TITLE
Allow #![] attributes to work in 0.16

### DIFF
--- a/lalrpop-snap/src/build/mod.rs
+++ b/lalrpop-snap/src/build/mod.rs
@@ -339,11 +339,17 @@ fn report_content(content: &Content) -> term::Result<()> {
     canvas.write_to(&mut stdout)
 }
 
-fn emit_module_attributes<W: Write>(
+pub fn emit_module_attributes<W: Write>(
     grammar: &r::Grammar,
     rust: &mut RustWrite<W>,
 ) -> io::Result<()> {
-    rust.write_module_attributes(grammar)
+    rust!(rust, "#[cfg_attr(rustfmt, rustfmt_skip)]");
+
+    for attribute in grammar.module_attributes.iter() {
+        rust!(rust, "#{}", &attribute[2..]);
+    }
+
+    Ok(())
 }
 
 fn emit_uses<W: Write>(grammar: &r::Grammar, rust: &mut RustWrite<W>) -> io::Result<()> {
@@ -376,7 +382,6 @@ fn emit_recursive_ascent(
     // includes things like `super::` it will resolve in the natural
     // way.
 
-    try!(emit_module_attributes(grammar, &mut rust));
     try!(emit_uses(grammar, &mut rust));
 
     if grammar.start_nonterminals.is_empty() {

--- a/lalrpop-snap/src/lexer/intern_token/mod.rs
+++ b/lalrpop-snap/src/lexer/intern_token/mod.rs
@@ -49,7 +49,8 @@ mod intern_token {
 use lexer::re;
 use grammar::parse_tree::InternToken;
 use grammar::repr::{Grammar, TerminalLiteral};
-use rust::RustWrite;
+use rust::{RustWrite};
+use build::emit_module_attributes;
 use std::io::{self, Write};
 
 pub fn compile<W: Write>(
@@ -59,7 +60,7 @@ pub fn compile<W: Write>(
 ) -> io::Result<()> {
     let prefix = &grammar.prefix;
 
-    rust!(out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
+    emit_module_attributes(grammar, out)?;
     rust!(out, "mod {}intern_token {{", prefix);
     rust!(out, "#![allow(unused_imports)]");
     try!(out.write_uses("", &grammar));

--- a/lalrpop-snap/src/lr1/codegen/base.rs
+++ b/lalrpop-snap/src/lr1/codegen/base.rs
@@ -1,5 +1,6 @@
 //! Base helper routines for a code generator.
 
+use build::emit_module_attributes;
 use grammar::repr::*;
 use lr1::core::*;
 use rust::RustWrite;
@@ -71,7 +72,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         F: FnOnce(&mut Self) -> io::Result<()>,
     {
         rust!(self.out, "");
-        rust!(self.out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
+        self.emit_module_attributes()?;
         rust!(self.out, "mod {}parse{} {{", self.prefix, self.start_symbol);
 
         // these stylistic lints are annoying for the generated code,
@@ -89,6 +90,10 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
 
         rust!(self.out, "}}");
         Ok(())
+    }
+
+    pub fn emit_module_attributes(&mut self) -> io::Result<()> {
+        emit_module_attributes(self.grammar, self.out)
     }
 
     pub fn write_uses(&mut self) -> io::Result<()> {

--- a/lalrpop-snap/src/lr1/codegen/test_all.rs
+++ b/lalrpop-snap/src/lr1/codegen/test_all.rs
@@ -48,7 +48,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TestAll> {
         self.write_parse_mod(|this| {
             try!(this.write_parser_fn());
 
-            rust!(this.out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
+            this.emit_module_attributes()?;
             rust!(this.out, "mod {}ascent {{", this.prefix);
             try!(super::ascent::compile(
                 this.grammar,
@@ -68,7 +68,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TestAll> {
             rust!(this.out, "{}", pub_use);
             rust!(this.out, "}}");
 
-            rust!(this.out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
+            this.emit_module_attributes()?;
             rust!(this.out, "mod {}parse_table {{", this.prefix);
             try!(super::parse_table::compile(
                 this.grammar,

--- a/lalrpop-snap/src/rust/mod.rs
+++ b/lalrpop-snap/src/rust/mod.rs
@@ -160,13 +160,6 @@ impl<W: Write> RustWrite<W> {
         Ok(())
     }
 
-    pub fn write_module_attributes(&mut self, grammar: &Grammar) -> io::Result<()> {
-        for attribute in grammar.module_attributes.iter() {
-            rust!(self, "{}", attribute);
-        }
-        Ok(())
-    }
-
     pub fn write_uses(&mut self, super_prefix: &str, grammar: &Grammar) -> io::Result<()> {
         // things the user wrote
         for u in &grammar.uses {

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -111,6 +111,8 @@ lalrpop_mod!(error_issue_278);
 #[allow(unused)]
 lalrpop_mod!(no_clone_tok);
 
+lalrpop_mod!(module_attributes);
+
 mod util;
 
 /// This constant is here so that some of the generator parsers can
@@ -891,4 +893,14 @@ fn error_issue_278() {
             panic!("unexpected response from parser: {:?}", r);
         }
     }
+}
+
+#[test]
+fn test_module_attributes() {
+    assert!(
+        module_attributes::TokParser::new()
+            .parse("hello")
+            .is_ok()
+    );
+
 }

--- a/lalrpop-test/src/module_attributes.lalrpop
+++ b/lalrpop-test/src/module_attributes.lalrpop
@@ -1,0 +1,6 @@
+#![cfg(debug_assertions)]
+#![allow(unreachable_patterns)]
+
+grammar;
+
+pub Tok = "hello";

--- a/lalrpop-test/src/no_clone_tok.lalrpop
+++ b/lalrpop-test/src/no_clone_tok.lalrpop
@@ -1,3 +1,5 @@
+#![allow(unreachable_patterns)]
+
 use util::tok::{NoCloneTok, Tok};
 use lalrpop_util::ParseError;
 

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -322,11 +322,17 @@ fn report_content(content: &Content) -> term::Result<()> {
     canvas.write_to(&mut stdout)
 }
 
-fn emit_module_attributes<W: Write>(
+pub fn emit_module_attributes<W: Write>(
     grammar: &r::Grammar,
     rust: &mut RustWrite<W>,
 ) -> io::Result<()> {
-    rust.write_module_attributes(grammar)
+    rust!(rust, "#[cfg_attr(rustfmt, rustfmt_skip)]");
+
+    for attribute in grammar.module_attributes.iter() {
+        rust!(rust, "#{}", &attribute[2..]);
+    }
+
+    Ok(())
 }
 
 fn emit_uses<W: Write>(grammar: &r::Grammar, rust: &mut RustWrite<W>) -> io::Result<()> {
@@ -359,7 +365,6 @@ fn emit_recursive_ascent(
     // includes things like `super::` it will resolve in the natural
     // way.
 
-    try!(emit_module_attributes(grammar, &mut rust));
     try!(emit_uses(grammar, &mut rust));
 
     if grammar.start_nonterminals.is_empty() {

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -46,6 +46,7 @@ mod intern_token {
 
  */
 
+use build::emit_module_attributes;
 use lexer::re;
 use grammar::parse_tree::InternToken;
 use grammar::repr::{Grammar, TerminalLiteral};
@@ -59,7 +60,7 @@ pub fn compile<W: Write>(
 ) -> io::Result<()> {
     let prefix = &grammar.prefix;
 
-    rust!(out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
+    emit_module_attributes(grammar, out)?;
     rust!(out, "mod {}intern_token {{", prefix);
     rust!(out, "#![allow(unused_imports)]");
     try!(out.write_uses("", &grammar));

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -1,5 +1,6 @@
 //! Base helper routines for a code generator.
 
+use build::emit_module_attributes;
 use grammar::repr::*;
 use lr1::core::*;
 use rust::RustWrite;
@@ -71,7 +72,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         F: FnOnce(&mut Self) -> io::Result<()>,
     {
         rust!(self.out, "");
-        rust!(self.out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
+        self.emit_module_attributes()?;
         rust!(self.out, "mod {}parse{} {{", self.prefix, self.start_symbol);
 
         // these stylistic lints are annoying for the generated code,
@@ -89,6 +90,10 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
 
         rust!(self.out, "}}");
         Ok(())
+    }
+
+    pub fn emit_module_attributes(&mut self) -> io::Result<()> {
+        emit_module_attributes(self.grammar, self.out)
     }
 
     pub fn write_uses(&mut self) -> io::Result<()> {

--- a/lalrpop/src/lr1/codegen/test_all.rs
+++ b/lalrpop/src/lr1/codegen/test_all.rs
@@ -48,7 +48,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TestAll> {
         self.write_parse_mod(|this| {
             try!(this.write_parser_fn());
 
-            rust!(this.out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
+            this.emit_module_attributes()?;
             rust!(this.out, "mod {}ascent {{", this.prefix);
             try!(super::ascent::compile(
                 this.grammar,
@@ -68,7 +68,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TestAll> {
             rust!(this.out, "{}", pub_use);
             rust!(this.out, "}}");
 
-            rust!(this.out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
+            this.emit_module_attributes()?;
             rust!(this.out, "mod {}parse_table {{", this.prefix);
             try!(super::parse_table::compile(
                 this.grammar,

--- a/lalrpop/src/rust/mod.rs
+++ b/lalrpop/src/rust/mod.rs
@@ -160,13 +160,6 @@ impl<W: Write> RustWrite<W> {
         Ok(())
     }
 
-    pub fn write_module_attributes(&mut self, grammar: &Grammar) -> io::Result<()> {
-        for attribute in grammar.module_attributes.iter() {
-            rust!(self, "{}", attribute);
-        }
-        Ok(())
-    }
-
     pub fn write_uses(&mut self, super_prefix: &str, grammar: &Grammar) -> io::Result<()> {
         // things the user wrote
         for u in &grammar.uses {


### PR DESCRIPTION
In 0.16, the default mode for lalrpop will import the generated module
through a macro that `include!`s the contents.

PR #338 made it possible to use `include!` with vanilla modules by
moving all of the built-in whole-module attributes to individual
modules. However, #115 places user-generated outer attributes in the
same problematic location.

This PR moves user-supplied outer attributes to the same location as
the fix in #338.