### PR TITLE
Process escape sequences in string literals appearing as terminals.

### DIFF
--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -255,7 +255,7 @@ fn parse_and_normalize_grammar(session: &Session, file_text: &FileText) -> io::R
             let string = match error.code {
                 tok::ErrorCode::UnrecognizedToken => "unrecognized token",
                 tok::ErrorCode::UnterminatedEscape => "unterminated escape; missing '`'?",
-                tok::ErrorCode::UnrecognizedEscape => "unrecognized escape; only \\n, \\t, \\\" and \\\\ are recognized",
+                tok::ErrorCode::UnrecognizedEscape => "unrecognized escape; only \\n, \\r, \\t, \\\" and \\\\ are recognized",
                 tok::ErrorCode::UnterminatedStringLiteral => {
                     "unterminated string literal; missing `\"`?"
                 }

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -255,6 +255,7 @@ fn parse_and_normalize_grammar(session: &Session, file_text: &FileText) -> io::R
             let string = match error.code {
                 tok::ErrorCode::UnrecognizedToken => "unrecognized token",
                 tok::ErrorCode::UnterminatedEscape => "unterminated escape; missing '`'?",
+                tok::ErrorCode::UnrecognizedEscape => "unrecognized escape; only \\n, \\t, \\\" and \\\\ are recognized",
                 tok::ErrorCode::UnterminatedStringLiteral => {
                     "unterminated string literal; missing `\"`?"
                 }

--- a/lalrpop/src/parser/lrgrammar.lalrpop
+++ b/lalrpop/src/parser/lrgrammar.lalrpop
@@ -4,6 +4,7 @@ use grammar::pattern::*;
 use std::iter::once;
 use tok::{self, Tok};
 use util::strip;
+use lalrpop_util::ParseError;
 
 grammar<'input>(text: &'input str);
 
@@ -394,7 +395,11 @@ QuotedLiteral: TerminalLiteral = {
 };
 
 StringLiteral: Atom =
-    <s:"StringLiteral"> => Atom::from(s);
+    <lo:@L> <s:"StringLiteral"> =>? {
+        let text = tok::apply_string_escapes(s, lo + 1)
+            .map_err(|e| ParseError::User { error: e })?;
+        Ok(Atom::from(text))
+    };
 
 RegexLiteral: Atom =
     <s:"RegexLiteral"> => Atom::from(s);

--- a/lalrpop/src/tok/mod.rs
+++ b/lalrpop/src/tok/mod.rs
@@ -757,6 +757,7 @@ pub fn apply_string_escapes(code: &str, idx0: usize) -> Result<Cow<str>, Error> 
                 ch = match next_ch {
                     '\\' | '\"' => next_ch,
                     'n' => '\n',
+                    'r' => '\r',
                     't' => '\t',
                     _ => { return error(UnrecognizedEscape, idx0 + offset); }
                 }

--- a/lalrpop/src/tok/mod.rs
+++ b/lalrpop/src/tok/mod.rs
@@ -430,7 +430,7 @@ impl<'input> Tokenizer<'input> {
         // we have to scan ahead, matching (), [], and {}, and looking
         // for a suitable terminator: `,`, `;`, `]`, `}`, or `)`.
         // Additionaly we had to take into account that we can encounter an character literal
-        // equal to one of delimeters.
+        // equal to one of delimiters.
         let mut balance = 0; // number of unclosed `(` etc
         loop {
             if let Some((idx, c)) = self.lookahead {
@@ -498,7 +498,7 @@ impl<'input> Tokenizer<'input> {
     }
 
     fn take_lifetime_or_character_literal(&mut self) -> Option<usize> {
-        // try to decide if `'` is for lifetime or it oppens a character literal
+        // Try to decide whether `'` is the start of a lifetime or a character literal.
 
         let forget_character = |p: (usize, char)| p.0;
 

--- a/lalrpop/src/tok/test.rs
+++ b/lalrpop/src/tok/test.rs
@@ -716,6 +716,8 @@ fn string_escapes() {
     assert_eq!(apply_string_escapes(r#"\""#, 15), Ok(Cow::Owned::<str>(r#"""#.into())));
     assert_eq!(apply_string_escapes(r#"up\ndown"#, 25),
                Ok(Cow::Owned::<str>("up\ndown".into())));
+    assert_eq!(apply_string_escapes(r#"forth\rback"#, 25),
+               Ok(Cow::Owned::<str>("forth\rback".into())));
     assert_eq!(apply_string_escapes(r#"left\tright"#, 40),
                Ok(Cow::Owned::<str>("left\tright".into())));
 

--- a/lalrpop/src/tok/test.rs
+++ b/lalrpop/src/tok/test.rs
@@ -705,3 +705,24 @@ fn char_literals() {
         ],
     );
 }
+
+#[test]
+fn string_escapes() {
+    use std::borrow::Cow;
+    use super::apply_string_escapes;
+
+    assert_eq!(apply_string_escapes(r#"foo"#, 5), Ok(Cow::Borrowed("foo")));
+    assert_eq!(apply_string_escapes(r#"\\"#, 10), Ok(Cow::Owned::<str>(r#"\"#.into())));
+    assert_eq!(apply_string_escapes(r#"\""#, 15), Ok(Cow::Owned::<str>(r#"""#.into())));
+    assert_eq!(apply_string_escapes(r#"up\ndown"#, 25),
+               Ok(Cow::Owned::<str>("up\ndown".into())));
+    assert_eq!(apply_string_escapes(r#"left\tright"#, 40),
+               Ok(Cow::Owned::<str>("left\tright".into())));
+
+    // Errors.
+    assert_eq!(apply_string_escapes("\u{192}\\oo", 65), // "ƒ\oo"
+               Err(Error { location: 68, code: ErrorCode::UnrecognizedEscape }));
+    // LALRPOP doesn't support the other Rust escape sequences.
+    assert_eq!(apply_string_escapes(r#"star: \u{2a}"#, 105),
+               Err(Error { location: 112, code: ErrorCode::UnrecognizedEscape }));
+}


### PR DESCRIPTION
The "\\" and "\"" escapes are necessary to make it possible to put arbitrary text in a string literal at all. We have to support "\t" and "\n" to compile the `whitespace` example from the book. But the other Rust escape sequences like "\u{2a}" don't really seem necessary.

Fixes #405.
