### PR TITLE
Support conditional execution by Cargo.

### DIFF
--- a/lalrpop/src/api/mod.rs
+++ b/lalrpop/src/api/mod.rs
@@ -96,6 +96,22 @@ impl Configuration {
         self
     }
 
+    /// If true, print `rerun-if-changed` directives to standard output, so that
+    /// Cargo will only rerun the build script if any of the processed
+    /// `.lalrpop` files are changed. This option is independent of
+    /// [`force_build`], although it would be usual to set [`force_build`] and
+    /// [`emit_rerun_directives`] at the same time.
+    ///
+    /// While many build scripts will want to set this to `true`, the default is
+    /// false, because emitting any rerun directives to Cargo will cause the
+    /// script to only be rerun when Cargo thinks it is needed. This could lead
+    /// to hard-to-find bugs if other parts of the build script do not emit
+    /// directives correctly, or need to be rerun unconditionally.
+    pub fn emit_rerun_directives(&mut self, val: bool) -> &mut Configuration {
+        self.session.emit_rerun_directives = val;
+        self
+    }
+
     /// If true, emit comments into the generated code. This makes the
     /// generated code significantly larger. Default is false.
     pub fn emit_comments(&mut self, val: bool) -> &mut Configuration {

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -98,6 +98,7 @@ fn process_file_into(
     rs_file: &Path,
     report_file: &Path,
 ) -> io::Result<()> {
+    session.emit_rerun_directive(lalrpop_file);
     if session.force_build || try!(needs_rebuild(&lalrpop_file, &rs_file)) {
         log!(
             session,

--- a/lalrpop/src/session.rs
+++ b/lalrpop/src/session.rs
@@ -37,6 +37,9 @@ pub struct Session {
 
     pub out_dir: Option<path::PathBuf>,
 
+    /// Emit `rerun-if-changed` directives for Cargo
+    pub emit_rerun_directives: bool,
+
     /// Emit comments in generated code explaining the states and so
     /// forth.
     pub emit_comments: bool,
@@ -94,6 +97,7 @@ impl Session {
             in_dir: None,
             out_dir: None,
             force_build: false,
+            emit_rerun_directives: false,
             emit_comments: false,
             emit_whitespace: true,
             emit_report: false,
@@ -120,6 +124,7 @@ impl Session {
             in_dir: None,
             out_dir: None,
             force_build: false,
+            emit_rerun_directives: false,
             emit_comments: false,
             emit_whitespace: true,
             emit_report: false,
@@ -149,6 +154,16 @@ impl Session {
         M: FnOnce() -> String,
     {
         self.log.log(level, message)
+    }
+
+    pub fn emit_rerun_directive(&self, path: &path::Path) {
+        if self.emit_rerun_directives {
+            if let Some(display) = path.to_str() {
+                println!("cargo:rerun-if-changed={}", display)
+            } else {
+                println!("cargo:warning=LALRPOP is unable to inform Cargo that {} is a dependency because its filename cannot be represented in UTF-8. This is probably because it contains an unpaired surrogate character on Windows. As a result, your build script will not be rerun when it changes.", path.to_string_lossy());
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Cargo allows build scripts to emit directives to specify their
dependencies, so that modifying other files does not cause them to be
rerun. This adds a configuration option to emit those directives,
defaulting to false to avoid interfering with other parts of the build
script and leading to hard-to-debug issues.

On Windows, some files cannot be represented in the UTF-8 used by Cargo,
and a build warning is emitted instead.

I've tested this change manually, but didn't see an easy way to test
it programmatically as part of the codebase, especially because
`to_string_lossy()` can never return `None` on Unix platforms.