### PR TITLE
Detect when we are building our own workspace.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "workspace-build 0.1.0 (git+https://github.com/alercah/lalrpop.git?branch=workspace-build-no)",
 ]
 
 [[package]]
@@ -560,6 +561,17 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "workspace-build"
+version = "0.1.0"
+source = "git+https://github.com/alercah/lalrpop.git?branch=workspace-build-no#8d1dc1d1d5f72fc46bc537d06d1ac45974b06e33"
+replace = "workspace-build 0.1.0 (git+https://github.com/alercah/lalrpop.git?branch=workspace-build-yes)"
+
+[[package]]
+name = "workspace-build"
+version = "0.1.0"
+source = "git+https://github.com/alercah/lalrpop.git?branch=workspace-build-yes#7ad84d21a4bd2eaf8d9a2fb0d4e346686e02428d"
+
 [metadata]
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b385d69402821a1c254533a011a312531cbcc0e3e24f19bbb4747a5a2daf37e2"
@@ -629,3 +641,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum workspace-build 0.1.0 (git+https://github.com/alercah/lalrpop.git?branch=workspace-build-no)" = "<none>"
+"checksum workspace-build 0.1.0 (git+https://github.com/alercah/lalrpop.git?branch=workspace-build-yes)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ members = [
         "doc/pascal/lalrpop",
         "doc/whitespace",
 ]
+
+[replace."https://github.com/alercah/lalrpop.git#workspace-build:0.1.0"]
+git = "https://github.com/alercah/lalrpop.git"
+branch = "workspace-build-yes"

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -36,6 +36,10 @@ sha2 = "0.8.0"
 [dev-dependencies]
 rand = "0.5"
 
+[build-dependencies.workspace-build]
+git = "https://github.com/alercah/lalrpop.git"
+branch = "workspace-build-no"
+
 [dependencies.lalrpop-util]
 path = "../lalrpop-util"
 version = "0.16.2" # LALRPOP

--- a/lalrpop/build.rs
+++ b/lalrpop/build.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command};
+extern crate workspace_build;
 
 fn main() {
     if let Err(err) = main_() {
@@ -28,11 +29,12 @@ fn main_() -> Result<(), Box<Error>> {
     let lalrpop_path = target_dir
         .join("debug/lalrpop")
         .with_extension(env::consts::EXE_EXTENSION);
-    println!(r#"cargo:rerun-if-changed={}"#, lalrpop_path.display());
+    if workspace_build::WORKSPACE_BUILD {
+        println!(r#"cargo:rerun-if-changed={}"#, lalrpop_path.display());
+    }
 
     if lalrpop_path.exists() {
-        // If compiling lalrpop itself, enable test parsers
-        if target_dir.exists() {
+        if workspace_build::WORKSPACE_BUILD {
             env::set_var("CARGO_FEATURE_TEST", "1");
             println!(r#"cargo:rustc-cfg=feature="test""#);
         }


### PR DESCRIPTION
This is possibly one of the most horrifying things I have ever come up
with. By putting two versions of a crate into different branches, and
using [replace] in Cargo.toml to override the dependency onto the other
branch, we can detect whether the root build is in the lalrpop
workspace.

This ensures that lalrpop does not get built more than once when used as
a dependency. This is clearly "better" than the old system.