### PR TITLE
chore: Don't try to infer whether we are building in the lalrpop work…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 - bash tools/ci-install.sh
 script:
 - RUST_BACKTRACE=1 CARGO_INCREMENTAL=0 cargo build -p lalrpop
-- RUST_BACKTRACE=1 CARGO_INCREMENTAL=0 cargo test --all
+- RUST_BACKTRACE=1 CARGO_INCREMENTAL=0 cargo test --all --all-features
 - bash tools/build-doc
 deploy:
   provider: pages

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ to! Here are some tips:
   how to add LALRPOP to your `Cargo.toml`.
 - The [advanced setup] chapter shows how to configure other aspects of LALRPOP's
   preprocessing.
-  
+
 ### Example Uses
 
 - [LALRPOP] is itself implemented in LALRPOP.
@@ -49,3 +49,7 @@ to! Here are some tips:
 [LALRPOP]: https://github.com/lalrpop/lalrpop/blob/8034f3dacc4b20581bd10c5cb0b4f9faae778bb5/lalrpop/src/parser/lrgrammar.lalrpop
 [Gluon]: https://github.com/gluon-lang/gluon/blob/d7ce3e81c1fcfdf25cdd6d1abde2b6e376b4bf50/parser/src/grammar.lalrpop
 
+
+### Contributing
+
+`cargo test` does not test that lalrpop generates a correct grammar for itself by default. So if you have made a change that would modify LALRPOP's own parser (`lalrpop/src/parser/lrgrammar.rs`) you need to run `cargo test --all-features` after making sure that a built lalrpop binary exists with `cargo build -p lalrpop` (see `.travis.yml` for the exact procedure).

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -41,4 +41,6 @@ path = "../lalrpop-util"
 version = "0.16.2" # LALRPOP
 
 [features]
+# Feature used when developing LALRPOP. Tells the build script to use an existing lalrpop binary to
+# generate LALRPOPs own parser instead of using the saved parser.
 test = []

--- a/lalrpop/build.rs
+++ b/lalrpop/build.rs
@@ -13,7 +13,9 @@ fn main() {
 
 fn find_lalrpop_binary(prefix: &str) -> Option<PathBuf> {
     let lalrpop_path = Path::new(prefix)
-        .join("target/debug/lalrpop")
+        .join("target")
+        .join(env::var("PROFILE").unwrap())
+        .join("lalrpop")
         .with_extension(env::consts::EXE_EXTENSION);
     if lalrpop_path.exists() {
         Some(lalrpop_path)
@@ -31,7 +33,13 @@ fn main_() -> Result<(), Box<Error>> {
     fs::create_dir_all(out_dir.join("src/parser"))?;
 
     if env::var("CARGO_FEATURE_TEST").is_ok() {
-        let lalrpop_path = find_lalrpop_binary("..").or_else(|| find_lalrpop_binary(".")).expect("Can't find a lalrpop binary to use for the snapshot. Make sure it is built and exists at target/debug/lalrpop!");
+        let lalrpop_path = find_lalrpop_binary("..").or_else(|| find_lalrpop_binary("."))
+            .unwrap_or_else(|| {
+                panic!(
+                    "Can't find a lalrpop binary to use for the snapshot. Make sure it is built and exists at target/{}/lalrpop!", 
+                    env::var("PROFILE").unwrap()
+                )
+            });
 
         let copied_grammar = out_dir.join("src/parser/lrgrammar.lalrpop");
         fs::copy(grammar_file, &copied_grammar)

--- a/lalrpop/build.rs
+++ b/lalrpop/build.rs
@@ -11,6 +11,17 @@ fn main() {
     }
 }
 
+fn find_lalrpop_binary(prefix: &str) -> Option<PathBuf> {
+    let lalrpop_path = Path::new(prefix)
+        .join("target/debug/lalrpop")
+        .with_extension(env::consts::EXE_EXTENSION);
+    if lalrpop_path.exists() {
+        Some(lalrpop_path)
+    } else {
+        None
+    }
+}
+
 fn main_() -> Result<(), Box<Error>> {
     let grammar_file = "src/parser/lrgrammar.lalrpop";
     println!(r#"cargo:rerun-if-changed={}"#, grammar_file);
@@ -19,23 +30,8 @@ fn main_() -> Result<(), Box<Error>> {
 
     fs::create_dir_all(out_dir.join("src/parser"))?;
 
-    let target_dir = if Path::new("target").exists() {
-        Path::new("target")
-    } else {
-        Path::new("../target")
-    };
-
-    let lalrpop_path = target_dir
-        .join("debug/lalrpop")
-        .with_extension(env::consts::EXE_EXTENSION);
-    println!(r#"cargo:rerun-if-changed={}"#, lalrpop_path.display());
-
-    if lalrpop_path.exists() {
-        // If compiling lalrpop itself, enable test parsers
-        if target_dir.exists() {
-            env::set_var("CARGO_FEATURE_TEST", "1");
-            println!(r#"cargo:rustc-cfg=feature="test""#);
-        }
+    if env::var("CARGO_FEATURE_TEST").is_ok() {
+        let lalrpop_path = find_lalrpop_binary("..").or_else(|| find_lalrpop_binary(".")).expect("Can't find a lalrpop binary to use for the snapshot. Make sure it is built and exists at target/debug/lalrpop!");
 
         let copied_grammar = out_dir.join("src/parser/lrgrammar.lalrpop");
         fs::copy(grammar_file, &copied_grammar)

--- a/lalrpop/src/lib.rs
+++ b/lalrpop/src/lib.rs
@@ -12,7 +12,7 @@ extern crate bit_set;
 extern crate diff;
 extern crate ena;
 extern crate itertools;
-#[cfg_attr(any(feature = "test", test), macro_use)]
+#[cfg_attr(feature = "test", macro_use)]
 extern crate lalrpop_util;
 extern crate petgraph;
 extern crate regex;

--- a/lalrpop/src/parser/mod.rs
+++ b/lalrpop/src/parser/mod.rs
@@ -5,15 +5,12 @@ use grammar::pattern::*;
 use lalrpop_util;
 use tok;
 
-#[cfg(not(any(feature = "test", test)))]
+#[cfg(not(feature = "test"))]
 #[allow(dead_code)]
 mod lrgrammar;
 
-#[cfg(any(feature = "test", test))]
+#[cfg(feature = "test")]
 lalrpop_mod!(
-    // ---------------------------------------------------------------------------------------
-    // NOTE: Run `cargo build -p lalrpop` once before running `cargo test` to create this file
-    // ---------------------------------------------------------------------------------------
     #[allow(dead_code)]
     lrgrammar,
     "/src/parser/lrgrammar.rs"


### PR DESCRIPTION
…space

Instead we use --all-features to enable a special `test` feature to run tests with a freshly generated lrgrammar.rs. Since we also have a test to check that the saved lrgrammar.rs is identical to what lalrpop generates we should be ok with this approach.

Closes #436