### PR TITLE
Use str::trim_start instead of str::trim_left

### DIFF
--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -176,7 +176,7 @@ pub fn compile<W: Write>(
 
     // start by trimming whitespace from left
     rust!(out, "#[allow(deprecated)]");
-    rust!(out, "let {}text = self.text.trim_left();", prefix);
+    rust!(out, "let {}text = self.text.trim_start();", prefix);
     rust!(
         out,
         "let {}whitespace = self.text.len() - {}text.len();",

--- a/lalrpop/src/lr1/lane_table/test.rs
+++ b/lalrpop/src/lr1/lane_table/test.rs
@@ -164,7 +164,7 @@ fn g0_conflict_1() {
 | S0    |       | ["c"] | ["d"] | {S3}       |
 | S3    | ["e"] | []    | []    | {S3}       |
 "#
-        .trim_left(),
+        .trim_start(),
     );
 }
 
@@ -188,7 +188,7 @@ fn paper_example_g1_conflict_1() {
 | S2    |       | ["c"] | ["d"] | {S5}       |
 | S5    | ["e"] | []    | []    | {S5}       |
 "#
-        .trim_left(),
+        .trim_start(),
     );
 }
 
@@ -326,7 +326,7 @@ fn large_conflict_1() {
 | S27   | ["s"] | ["k"] |            |       | {S32}      |
 | S32   |       |       | ["z"]      | ["u"] | {S16}      |
 "#
-        .trim_left(),
+        .trim_start(),
     );
 
     // ^^ This differs in some particulars from what appears in the


### PR DESCRIPTION
The method `str::trim_left` has been deprecated in favor of
`str::trim_start` and now throws a warning. Use `str::trim_start` instead of
`str::trim_left` and update test cases.