### PR TITLE
Order of string for error message confusing

### DIFF
--- a/lalrpop/src/normalize/resolve/mod.rs
+++ b/lalrpop/src/normalize/resolve/mod.rs
@@ -234,8 +234,8 @@ impl Validator {
                     Def::Nonterminal(0) | Def::Terminal | Def::MacroArg => return_err!(
                         symbol.span,
                         "`{}` is a {}, not a macro",
-                        def.description(),
-                        msym.name
+                        msym.name,
+                        def.description()
                     ),
                     Def::Nonterminal(arity) => {
                         if arity != msym.args.len() {


### PR DESCRIPTION
Before this patch, I was told:

```
src/cypher.lalrpop:309:37: 309:54 error: `nonterminal` is a AndExpression, not a macro
```

I think it should be the other way around ;-)
