### PR TITLE
Remove confusing "ok" message printed to stdout

### DIFF
--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -85,8 +85,6 @@ impl<'grammar> Validator<'grammar> {
                                     || item_idx != &match_contents.items.len() - 1)
                             {
                                 return_err!(item.span(), "Catch all must be final item");
-                            } else {
-                                println!("ok");
                             }
                         }
                     }


### PR DESCRIPTION
I guess it has been left in there for debugging?