### PR TITLE
Remove warning about hidden lifetime parameter

### DIFF
--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -74,7 +74,7 @@ pub fn compile<W: Write>(
     rust!(out, "impl<'a> {}fmt::Display for Token<'a> {{", prefix);
     rust!(
         out,
-        "fn fmt(&self, formatter: &mut {}fmt::Formatter) -> Result<(), {}fmt::Error> {{",
+        "fn fmt<'f>(&self, formatter: &mut {}fmt::Formatter<'f>) -> Result<(), {}fmt::Error> {{",
         prefix,
         prefix
     );


### PR DESCRIPTION
On Rust 1.33, the current generated code emits a warning because hidden lifetime parameters in types are deprecated. This occurs in the `impl Display for Token`, and happens because `fmt::Formatter` has a lifetime parameter.

This PR adds an explicit lifetime parameter `'f` to the generated code, so it will work on all supported versions of Rust.