### PR TITLE
Replace all uses of `try!` with `?`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-- 1.26.0
+- 1.31.0
 - beta
 - nightly
 cache:

--- a/doc/whitespace/src/ast.rs
+++ b/doc/whitespace/src/ast.rs
@@ -97,8 +97,8 @@ impl<'program> Interpreter<'program> {
                 &Stmt::Push(n) => self.stack.push(n),
 
                 &Stmt::PrintChar => {
-                    let top = try!(self.pop());
-                    let c = try!(num_to_char(top));
+                    let top = self.pop()?;
+                    let c = num_to_char(top)?;
                     print!("{}", c);
                 }
 

--- a/lalrpop-test/src/util/mod.rs
+++ b/lalrpop-test/src/util/mod.rs
@@ -66,7 +66,10 @@ struct ExpectedDebug<'a>(&'a str);
 
 impl<'a> Debug for ExpectedDebug<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        write!(fmt, "{}", self.0)
+        // Ignore trailing commas in multiline Debug representation.
+        // Needed to work around rust-lang/rust#59076.
+        let s = self.0.replace(",\n", "\n");
+        write!(fmt, "{}", s)
     }
 }
 

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -97,7 +97,7 @@ impl<L, T, E> ParseError<L, T, E> {
 /// Format a list of expected tokens.
 fn fmt_expected(f: &mut fmt::Formatter, expected: &[String]) -> fmt::Result {
     if !expected.is_empty() {
-        try!(writeln!(f, ""));
+        writeln!(f, "")?;
         for (i, e) in expected.iter().enumerate() {
             let sep = match i {
                 0 => "Expected one of",
@@ -105,7 +105,7 @@ fn fmt_expected(f: &mut fmt::Formatter, expected: &[String]) -> fmt::Result {
                 // Last expected message to be written
                 _ => " or",
             };
-            try!(write!(f, "{} {}", sep, e));
+            write!(f, "{} {}", sep, e)?;
         }
     }
     Ok(())
@@ -123,11 +123,11 @@ where
             User { ref error } => write!(f, "{}", error),
             InvalidToken { ref location } => write!(f, "Invalid token at {}", location),
             UnrecognizedEOF { ref location, ref expected } => {
-                try!(write!(f, "Unrecognized EOF found at {}", location));
+                write!(f, "Unrecognized EOF found at {}", location)?;
                 fmt_expected(f, expected)
             }
             UnrecognizedToken { token: (ref start, ref token, ref end), ref expected } => {
-                try!(write!(f, "Unrecognized token `{}` found at {}:{}", token, start, end));
+                write!(f, "Unrecognized token `{}` found at {}:{}", token, start, end)?;
                 fmt_expected(f, expected)
             }
             ExtraToken { token: (ref start, ref token, ref end), } => {

--- a/lalrpop/src/api/mod.rs
+++ b/lalrpop/src/api/mod.rs
@@ -190,7 +190,7 @@ impl Configuration {
     /// Process all files in the current directory, which -- unless you
     /// have changed it -- is typically the root of the crate being compiled.
     pub fn process_current_dir(&self) -> Result<(), Box<Error>> {
-        self.process_dir(try!(current_dir()))
+        self.process_dir(current_dir()?)
     }
 
     /// Process all `.lalrpop` files in `path`.
@@ -200,7 +200,7 @@ impl Configuration {
         // If in/out dir are empty, use cargo conventions by default.
         // See https://github.com/lalrpop/lalrpop/issues/280
         if session.in_dir.is_none() {
-            let mut in_dir = try!(env::current_dir());
+            let mut in_dir = env::current_dir()?;
             in_dir.push("src");
             session.in_dir = Some(in_dir);
         }
@@ -234,14 +234,14 @@ impl Configuration {
         }
 
         let session = Rc::new(session);
-        try!(build::process_dir(session, path));
+        build::process_dir(session, path)?;
         Ok(())
     }
 
     /// Process the given `.lalrpop` file.
     pub fn process_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Box<Error>> {
         let session = Rc::new(self.session.clone());
-        try!(build::process_file(session, path));
+        build::process_file(session, path)?;
         Ok(())
     }
 }

--- a/lalrpop/src/build/action.rs
+++ b/lalrpop/src/build/action.rs
@@ -47,13 +47,13 @@ pub fn emit_action_code<W: Write>(grammar: &r::Grammar, rust: &mut RustWrite<W>)
 
         match defn.kind {
             r::ActionFnDefnKind::User(ref data) => {
-                try!(emit_user_action_code(grammar, rust, i, defn, data))
+                emit_user_action_code(grammar, rust, i, defn, data)?
             }
             r::ActionFnDefnKind::Lookaround(ref variant) => {
-                try!(emit_lookaround_action_code(grammar, rust, i, defn, variant))
+                emit_lookaround_action_code(grammar, rust, i, defn, variant)?
             }
             r::ActionFnDefnKind::Inline(ref data) => {
-                try!(emit_inline_action_code(grammar, rust, i, defn, data))
+                emit_inline_action_code(grammar, rust, i, defn, data)?
             }
         }
     }
@@ -119,15 +119,14 @@ fn emit_user_action_code<W: Write>(
         ]);
     }
 
-    try!(
-        rust.fn_header(
-            &r::Visibility::Priv,
-            format!("{}action{}", grammar.prefix, index),
-        ).with_grammar(grammar)
-        .with_parameters(arguments)
-        .with_return_type(ret_type)
-        .emit()
-    );
+    rust.fn_header(
+        &r::Visibility::Priv,
+        format!("{}action{}", grammar.prefix, index),
+    ).with_grammar(grammar)
+    .with_parameters(arguments)
+    .with_return_type(ret_type)
+    .emit()?;
+
     rust!(rust, "{{");
     rust!(rust, "{}", data.code);
     rust!(rust, "}}");
@@ -141,25 +140,23 @@ fn emit_lookaround_action_code<W: Write>(
     _defn: &r::ActionFnDefn,
     data: &r::LookaroundActionFnDefn,
 ) -> io::Result<()> {
-    try!(
-        rust.fn_header(
-            &r::Visibility::Priv,
-            format!("{}action{}", grammar.prefix, index),
-        ).with_grammar(grammar)
-        .with_parameters(vec![
-            format!(
-                "{}lookbehind: &{}",
-                grammar.prefix,
-                grammar.types.terminal_loc_type()
-            ),
-            format!(
-                "{}lookahead: &{}",
-                grammar.prefix,
-                grammar.types.terminal_loc_type()
-            ),
-        ]).with_return_type(format!("{}", grammar.types.terminal_loc_type()))
-        .emit()
-    );
+    rust.fn_header(
+        &r::Visibility::Priv,
+        format!("{}action{}", grammar.prefix, index),
+    ).with_grammar(grammar)
+    .with_parameters(vec![
+        format!(
+            "{}lookbehind: &{}",
+            grammar.prefix,
+            grammar.types.terminal_loc_type()
+        ),
+        format!(
+            "{}lookahead: &{}",
+            grammar.prefix,
+            grammar.types.terminal_loc_type()
+        ),
+    ]).with_return_type(format!("{}", grammar.types.terminal_loc_type()))
+    .emit()?;
 
     rust!(rust, "{{");
     match *data {
@@ -226,15 +223,13 @@ fn emit_inline_action_code<W: Write>(
         ]);
     }
 
-    try!(
-        rust.fn_header(
-            &r::Visibility::Priv,
-            format!("{}action{}", grammar.prefix, index),
-        ).with_grammar(grammar)
-        .with_parameters(arguments)
-        .with_return_type(ret_type)
-        .emit()
-    );
+    rust.fn_header(
+        &r::Visibility::Priv,
+        format!("{}action{}", grammar.prefix, index),
+    ).with_grammar(grammar)
+    .with_parameters(arguments)
+    .with_return_type(ret_type)
+    .emit()?;
     rust!(rust, "{{");
 
     // For each inlined thing, compute the start/end locations.

--- a/lalrpop/src/file_text.rs
+++ b/lalrpop/src/file_text.rs
@@ -13,8 +13,8 @@ pub struct FileText {
 impl FileText {
     pub fn from_path(path: PathBuf) -> io::Result<FileText> {
         let mut input_str = String::new();
-        let mut f = try!(File::open(&path));
-        try!(f.read_to_string(&mut input_str));
+        let mut f = File::open(&path)?;
+        f.read_to_string(&mut input_str)?;
         Ok(FileText::new(path, input_str))
     }
 
@@ -96,18 +96,18 @@ impl FileText {
         // span is within one line:
         if start_line == end_line {
             let text = self.line_text(start_line);
-            try!(writeln!(out, "  {}", text));
+            writeln!(out, "  {}", text)?;
 
             if end_col - start_col <= 1 {
-                try!(writeln!(out, "  {}^", Repeat(' ', start_col)));
+                writeln!(out, "  {}^", Repeat(' ', start_col))?;
             } else {
                 let width = end_col - start_col;
-                try!(writeln!(
+                writeln!(
                     out,
                     "  {}~{}~",
                     Repeat(' ', start_col),
                     Repeat('~', width.saturating_sub(2))
-                ));
+                )?;
             }
         } else {
             // span is across many lines, find the maximal width of any of those
@@ -115,17 +115,17 @@ impl FileText {
                 .map(|i| self.line_text(i))
                 .collect();
             let max_len = line_strs.iter().map(|l| l.len()).max().unwrap();
-            try!(writeln!(
+            writeln!(
                 out,
                 "  {}{}~+",
                 Repeat(' ', start_col),
                 Repeat('~', max_len - start_col)
-            ));
+            )?;
             for line in &line_strs[..line_strs.len() - 1] {
-                try!(writeln!(out, "| {0:<1$} |", line, max_len));
+                writeln!(out, "| {0:<1$} |", line, max_len)?;
             }
-            try!(writeln!(out, "| {}", line_strs[line_strs.len() - 1]));
-            try!(writeln!(out, "+~{}", Repeat('~', end_col)));
+            writeln!(out, "| {}", line_strs[line_strs.len() - 1])?;
+            writeln!(out, "+~{}", Repeat('~', end_col))?;
         }
 
         Ok(())
@@ -137,7 +137,7 @@ struct Repeat(char, usize);
 impl Display for Repeat {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         for _ in 0..self.1 {
-            try!(write!(fmt, "{}", self.0));
+            write!(fmt, "{}", self.0)?;
         }
         Ok(())
     }

--- a/lalrpop/src/lexer/dfa/mod.rs
+++ b/lalrpop/src/lexer/dfa/mod.rs
@@ -41,23 +41,23 @@ pub fn build_dfa(
     precedences: &[Precedence],
 ) -> Result<DFA, DFAConstructionError> {
     assert_eq!(regexs.len(), precedences.len());
-    let nfas: Vec<_> = try! {
-        regexs.iter()
-              .enumerate()
-              .map(|(i, r)| match NFA::from_re(r) {
-                  Ok(nfa) => Ok(nfa),
-                  Err(e) => Err(DFAConstructionError::NFAConstructionError {
-                      index: NFAIndex(i),
-                      error: e
-                  }),
-              })
-              .collect()
-    };
+    let nfas = regexs
+        .iter()
+        .enumerate()
+        .map(|(i, r)| match NFA::from_re(r) {
+            Ok(nfa) => Ok(nfa),
+            Err(e) => Err(DFAConstructionError::NFAConstructionError {
+                index: NFAIndex(i),
+                error: e,
+            }),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
     let builder = DFABuilder {
         nfas: &nfas,
         precedences: precedences.to_vec(),
     };
-    let dfa = try!(builder.build());
+    let dfa = builder.build()?;
     Ok(dfa)
 }
 

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -62,7 +62,7 @@ pub fn compile<W: Write>(
     rust!(out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
     rust!(out, "mod {}intern_token {{", prefix);
     rust!(out, "#![allow(unused_imports)]");
-    try!(out.write_uses("", &grammar));
+    out.write_uses("", &grammar)?;
     rust!(out, "extern crate regex as {}regex;", prefix);
     rust!(out, "use std::fmt as {}fmt;", prefix);
     rust!(out, "");

--- a/lalrpop/src/lexer/nfa/mod.rs
+++ b/lalrpop/src/lexer/nfa/mod.rs
@@ -357,7 +357,7 @@ impl NFA {
         //         v
         //      [reject]
 
-        let s1 = try!(self.expr(expr, accept, reject));
+        let s1 = self.expr(expr, accept, reject)?;
 
         let s0 = self.new_state(StateKind::Neither);
         self.push_edge(s0, Noop, accept); // they might supply nothing
@@ -384,7 +384,7 @@ impl NFA {
 
         let s0 = self.new_state(StateKind::Neither);
 
-        let s1 = try!(self.expr(expr, s0, reject));
+        let s1 = self.expr(expr, s0, reject)?;
 
         self.push_edge(s0, Noop, accept);
         self.push_edge(s0, Noop, s1);
@@ -410,7 +410,7 @@ impl NFA {
 
         let s1 = self.new_state(StateKind::Neither);
 
-        let s0 = try!(self.expr(expr, s1, reject));
+        let s0 = self.expr(expr, s1, reject)?;
 
         self.push_edge(s1, Noop, accept);
         self.push_edge(s1, Noop, s0);

--- a/lalrpop/src/lr1/build_lalr/mod.rs
+++ b/lalrpop/src/lr1/build_lalr/mod.rs
@@ -29,7 +29,7 @@ pub fn build_lalr_states<'grammar>(
     start: NonterminalString,
 ) -> LR1Result<'grammar> {
     // First build the LR(1) states
-    let lr_states = try!(build::build_lr1_states(grammar, start));
+    let lr_states = build::build_lr1_states(grammar, start)?;
 
     // With lane table, there is no reason to do state collapse
     // for LALR. In fact, LALR is pointless!

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -168,19 +168,16 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         );
         rust!(self.out, "");
 
-        try!(self.write_uses());
+        self.write_uses()?;
 
-        try!(body(self));
+        body(self)?;
 
         rust!(self.out, "}}");
         Ok(())
     }
 
     pub fn write_uses(&mut self) -> io::Result<()> {
-        try!(
-            self.out
-                .write_uses(&format!("{}::", self.action_module), &self.grammar)
-        );
+        self.out.write_uses(&format!("{}::", self.action_module), &self.grammar)?;
 
         if self.grammar.intern_token.is_some() {
             rust!(
@@ -281,22 +278,20 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         rust!(self.out, "");
 
         rust!(self.out, "#[allow(dead_code)]");
-        try!(
-            self.out
-                .fn_header(
-                    &self.grammar.nonterminals[&self.start_symbol].visibility,
-                    "parse".to_owned(),
-                ).with_parameters(Some("&self".to_owned()))
-                .with_grammar(self.grammar)
-                .with_type_parameters(type_parameters)
-                .with_parameters(parameters)
-                .with_return_type(format!(
-                    "Result<{}, {}>",
-                    self.types.nonterminal_type(&self.start_symbol),
-                    parse_error_type
-                )).with_where_clauses(where_clauses)
-                .emit()
-        );
+        self.out
+            .fn_header(
+                &self.grammar.nonterminals[&self.start_symbol].visibility,
+                "parse".to_owned(),
+            ).with_parameters(Some("&self".to_owned()))
+            .with_grammar(self.grammar)
+            .with_type_parameters(type_parameters)
+            .with_parameters(parameters)
+            .with_return_type(format!(
+                "Result<{}, {}>",
+                self.types.nonterminal_type(&self.start_symbol),
+                parse_error_type
+            )).with_where_clauses(where_clauses)
+            .emit()?;
         rust!(self.out, "{{");
 
         Ok(())

--- a/lalrpop/src/lr1/codegen/test_all.rs
+++ b/lalrpop/src/lr1/codegen/test_all.rs
@@ -46,18 +46,18 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TestAll> {
 
     fn write(&mut self) -> io::Result<()> {
         self.write_parse_mod(|this| {
-            try!(this.write_parser_fn());
+            this.write_parser_fn()?;
 
             rust!(this.out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
             rust!(this.out, "mod {}ascent {{", this.prefix);
-            try!(super::ascent::compile(
+            super::ascent::compile(
                 this.grammar,
                 this.user_start_symbol.clone(),
                 this.start_symbol.clone(),
                 this.states,
                 "super::super::super",
                 this.out
-            ));
+            )?;
             let pub_use = format!(
                 "{}use self::{}parse{}::{}Parser;",
                 this.grammar.nonterminals[&this.user_start_symbol].visibility,
@@ -70,14 +70,14 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TestAll> {
 
             rust!(this.out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
             rust!(this.out, "mod {}parse_table {{", this.prefix);
-            try!(super::parse_table::compile(
+            super::parse_table::compile(
                 this.grammar,
                 this.user_start_symbol.clone(),
                 this.start_symbol.clone(),
                 this.states,
                 "super::super::super",
                 this.out
-            ));
+            )?;
             rust!(this.out, "{}", pub_use);
             rust!(this.out, "}}");
 
@@ -86,14 +86,14 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TestAll> {
     }
 
     fn write_parser_fn(&mut self) -> io::Result<()> {
-        try!(self.start_parser_fn());
+        self.start_parser_fn()?;
 
         if self.grammar.intern_token.is_some() {
             rust!(self.out, "let _ = self.builder;");
         }
         // parse input using both methods:
-        try!(self.call_delegate("ascent"));
-        try!(self.call_delegate("parse_table"));
+        self.call_delegate("ascent")?;
+        self.call_delegate("parse_table")?;
 
         // check that result is the same either way:
         rust!(
@@ -105,7 +105,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TestAll> {
 
         rust!(self.out, "return {}ascent;", self.prefix);
 
-        try!(self.end_parser_fn());
+        self.end_parser_fn()?;
 
         Ok(())
     }

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -186,13 +186,13 @@ pub type LR1Result<'grammar> = LRResult<'grammar, TokenSet>;
 
 impl<'grammar, L: Lookahead> Debug for Item<'grammar, L> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        try!(write!(
+        write!(
             fmt,
             "{} ={} (*){}",
             self.production.nonterminal,
             Prefix(" ", &self.production.symbols[..self.index]),
             Prefix(" ", &self.production.symbols[self.index..])
-        ));
+        )?;
 
         self.lookahead.fmt_as_item_suffix(fmt)
     }

--- a/lalrpop/src/lr1/interpret.rs
+++ b/lalrpop/src/lr1/interpret.rs
@@ -33,7 +33,7 @@ where
     L: LookaheadInterpret,
 {
     let mut m = Machine::new(states);
-    try!(m.execute_partial(tokens.into_iter()));
+    m.execute_partial(tokens.into_iter())?;
     Ok(m.state_stack)
 }
 
@@ -100,7 +100,7 @@ where
     where
         TOKENS: Iterator<Item = TerminalString>,
     {
-        try!(self.execute_partial(tokens));
+        self.execute_partial(tokens)?;
 
         // drain now for EOF
         loop {

--- a/lalrpop/src/lr1/lane_table/table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/table/mod.rs
@@ -190,14 +190,14 @@ impl<'grammar> Debug for LaneTable<'grammar> {
             .collect();
 
         for row in &table {
-            try!(write!(fmt, "| "));
+            write!(fmt, "| ")?;
             for (i, column) in row.iter().enumerate() {
                 if i > 0 {
-                    try!(write!(fmt, " | "));
+                    write!(fmt, " | ")?;
                 }
-                try!(write!(fmt, "{0:1$}", column, widths[i]));
+                write!(fmt, "{0:1$}", column, widths[i])?;
             }
-            try!(write!(fmt, " |\n"));
+            write!(fmt, " |\n")?;
         }
 
         Ok(())

--- a/lalrpop/src/lr1/report/mod.rs
+++ b/lalrpop/src/lr1/report/mod.rs
@@ -40,40 +40,40 @@ where
     where
         L: Lookahead + LookaheadPrinter<W>,
     {
-        try!(self.write_header());
-        try!(self.write_section_header("Summary"));
-        try!(writeln!(self.out, ""));
+        self.write_header()?;
+        self.write_section_header("Summary")?;
+        writeln!(self.out, "")?;
         match lr1result {
             &Ok(ref states) => {
-                try!(writeln!(self.out, "Constructed {} states", states.len()));
-                try!(self.report_states(&states, &Map::new()));
+                writeln!(self.out, "Constructed {} states", states.len())?;
+                self.report_states(&states, &Map::new())?;
             }
             &Err(ref table_construction_error) => {
-                try!(writeln!(self.out, "Failure"));
-                try!(writeln!(
+                writeln!(self.out, "Failure")?;
+                writeln!(
                     self.out,
                     "Constructed {} states",
                     table_construction_error.states.len()
-                ));
-                try!(writeln!(
+                )?;
+                writeln!(
                     self.out,
                     "Has {} conflicts",
                     table_construction_error.conflicts.len()
-                ));
+                )?;
                 let (sr, rr, conflict_map) =
                     self.process_conflicts(&table_construction_error.conflicts);
                 if (sr > 0) {
-                    try!(writeln!(self.out, "{}shift/reduce:  {}", INDENT_STRING, sr));
+                    writeln!(self.out, "{}shift/reduce:  {}", INDENT_STRING, sr)?;
                 }
                 if (rr > 0) {
-                    try!(writeln!(self.out, "{}reduce/reduce: {}", INDENT_STRING, rr));
+                    writeln!(self.out, "{}reduce/reduce: {}", INDENT_STRING, rr)?;
                 }
-                try!(write!(self.out, "States with conflicts: "));
+                write!(self.out, "States with conflicts: ")?;
                 for state in conflict_map.keys() {
-                    try!(write!(self.out, " {}", state));
+                    write!(self.out, " {}", state)?;
                 }
-                try!(writeln!(self.out, ""));
-                try!(self.report_states(&table_construction_error.states, &conflict_map));
+                writeln!(self.out, "")?;
+                self.report_states(&table_construction_error.states, &conflict_map)?;
             }
         };
         Ok(())
@@ -110,10 +110,10 @@ where
     where
         L: Lookahead + LookaheadPrinter<W>,
     {
-        try!(self.write_section_header("State Table"));
+        self.write_section_header("State Table")?;
         for ref state in states {
-            try!(writeln!(self.out, ""));
-            try!(self.report_state(&state, conflict_map.get(&state.index)));
+            writeln!(self.out, "")?;
+            self.report_state(&state, conflict_map.get(&state.index))?;
         }
         Ok(())
     }
@@ -126,32 +126,32 @@ where
     where
         L: Lookahead + LookaheadPrinter<W>,
     {
-        try!(writeln!(self.out, "State {} {{", state.index));
-        try!(self.write_items(&state.items));
+        writeln!(self.out, "State {} {{", state.index)?;
+        self.write_items(&state.items)?;
         if (state.reductions.len() > 0) {
-            try!(writeln!(self.out, ""));
-            try!(self.write_reductions(&state.reductions));
+            writeln!(self.out, "")?;
+            self.write_reductions(&state.reductions)?;
         }
 
         let max_width = get_width_for_gotos(state);
 
         if (!state.shifts.len() > 0) {
-            try!(writeln!(self.out, ""));
-            try!(self.write_shifts(&state.shifts, max_width));
+            writeln!(self.out, "")?;
+            self.write_shifts(&state.shifts, max_width)?;
         }
 
         if (!state.gotos.len() > 0) {
-            try!(writeln!(self.out, ""));
-            try!(self.write_gotos(&state.gotos, max_width));
+            writeln!(self.out, "")?;
+            self.write_gotos(&state.gotos, max_width)?;
         }
 
         if let Some(conflicts) = conflicts_opt {
             for conflict in conflicts.iter() {
-                try!(self.write_conflict(conflict));
+                self.write_conflict(conflict)?;
             }
         }
 
-        try!(writeln!(self.out, "}}"));
+        writeln!(self.out, "}}")?;
         Ok(())
     }
 
@@ -159,22 +159,22 @@ where
     where
         L: Lookahead + LookaheadPrinter<W>,
     {
-        try!(writeln!(self.out, ""));
+        writeln!(self.out, "")?;
         match conflict.action {
             Action::Shift(ref terminal, state) => {
                 let max_width = max(
                     terminal.display_len(),
                     conflict.production.nonterminal.len(),
                 );
-                try!(writeln!(self.out, "{}shift/reduce conflict", INDENT_STRING));
-                try!(write!(
+                writeln!(self.out, "{}shift/reduce conflict", INDENT_STRING)?;
+                write!(
                     self.out,
                     "{}{}reduction ",
                     INDENT_STRING, INDENT_STRING
-                ));
-                try!(self.write_production(conflict.production, max_width));
+                )?;
+                self.write_production(conflict.production, max_width)?;
                 let sterminal = format!("{}", terminal);
-                try!(writeln!(
+                writeln!(
                     self.out,
                     "{}{}shift     {:width$}    shift and goto {}",
                     INDENT_STRING,
@@ -182,33 +182,33 @@ where
                     sterminal,
                     state,
                     width = max_width
-                ));
+                )?;
             }
             Action::Reduce(other_production) => {
                 let max_width = max(
                     other_production.nonterminal.len(),
                     conflict.production.nonterminal.len(),
                 );
-                try!(writeln!(
+                writeln!(
                     self.out,
                     "{}reduce/reduce conflict",
                     INDENT_STRING
-                ));
-                try!(write!(
+                )?;
+                write!(
                     self.out,
                     "{}{}reduction ",
                     INDENT_STRING, INDENT_STRING
-                ));
-                try!(self.write_production(conflict.production, max_width));
-                try!(write!(
+                )?;
+                self.write_production(conflict.production, max_width)?;
+                write!(
                     self.out,
                     "{}{}reduction ",
                     INDENT_STRING, INDENT_STRING
-                ));
-                try!(self.write_production(other_production, max_width));
+                )?;
+                self.write_production(other_production, max_width)?;
             }
         }
-        try!(self.write_lookahead(&conflict.lookahead));
+        self.write_lookahead(&conflict.lookahead)?;
         Ok(())
     }
 
@@ -219,8 +219,8 @@ where
         let max_width = get_max_length(items.vec.iter().map(|item| &item.production.nonterminal));
 
         for item in items.vec.iter() {
-            try!(writeln!(self.out, ""));
-            try!(self.write_item(item, max_width));
+            writeln!(self.out, "")?;
+            self.write_item(item, max_width)?;
         }
         Ok(())
     }
@@ -233,19 +233,19 @@ where
     where
         L: Lookahead + LookaheadPrinter<W>,
     {
-        try!(write!(self.out, "{}", INDENT_STRING));
+        write!(self.out, "{}", INDENT_STRING)?;
         // stringize it first to allow handle :width by Display for string
         let s = format!("{}", item.production.nonterminal);
-        try!(write!(self.out, "{:width$} ->", s, width = max_width));
+        write!(self.out, "{:width$} ->", s, width = max_width)?;
         for i in 0..item.index {
-            try!(write!(self.out, " {}", item.production.symbols[i]));
+            write!(self.out, " {}", item.production.symbols[i])?;
         }
-        try!(write!(self.out, " ."));
+        write!(self.out, " .")?;
         for i in item.index..item.production.symbols.len() {
-            try!(write!(self.out, " {}", item.production.symbols[i]));
+            write!(self.out, " {}", item.production.symbols[i])?;
         }
-        try!(writeln!(self.out, ""));
-        try!(self.write_lookahead(&item.lookahead));
+        writeln!(self.out, "")?;
+        self.write_lookahead(&item.lookahead)?;
         Ok(())
     }
 
@@ -255,16 +255,16 @@ where
         max_width: usize,
     ) -> io::Result<()> {
         for entry in shifts {
-            try!(write!(self.out, "{}", INDENT_STRING));
+            write!(self.out, "{}", INDENT_STRING)?;
             // stringize it first to allow handle :width by Display for string
             let s = format!("{}", entry.0);
-            try!(writeln!(
+            writeln!(
                 self.out,
                 "{:width$} shift and goto {}",
                 s,
                 entry.1,
                 width = max_width
-            ));
+            )?;
         }
         Ok(())
     }
@@ -278,8 +278,8 @@ where
     {
         let max_width = get_max_length(reductions.into_iter().map(|p| &p.1.nonterminal));
         for reduction in reductions.iter() {
-            try!(writeln!(self.out, ""));
-            try!(self.write_reduction(reduction, max_width));
+            writeln!(self.out, "")?;
+            self.write_reduction(reduction, max_width)?;
         }
         Ok(())
     }
@@ -289,16 +289,16 @@ where
         production: &'grammar Production,
         max_width: usize,
     ) -> io::Result<()> {
-        try!(write!(
+        write!(
             self.out,
             "{:width$} ->",
             production.nonterminal,
             width = max_width
-        ));
+        )?;
         for symbol in production.symbols.iter() {
-            try!(write!(self.out, " {}", symbol));
+            write!(self.out, " {}", symbol)?;
         }
-        try!(writeln!(self.out, ""));
+        writeln!(self.out, "")?;
         Ok(())
     }
 
@@ -311,9 +311,9 @@ where
         L: Lookahead + LookaheadPrinter<W>,
     {
         let ref production = reduction.1;
-        try!(write!(self.out, "{}reduction ", INDENT_STRING));
-        try!(self.write_production(production, max_width));
-        try!(self.write_lookahead(&reduction.0));
+        write!(self.out, "{}reduction ", INDENT_STRING)?;
+        self.write_production(production, max_width)?;
+        self.write_lookahead(&reduction.0)?;
         Ok(())
     }
 
@@ -322,13 +322,13 @@ where
         L: Lookahead + LookaheadPrinter<W>,
     {
         if (lookahead.has_anything_to_print()) {
-            try!(write!(
+            write!(
                 self.out,
                 "{}{}lookahead",
                 INDENT_STRING, INDENT_STRING
-            ));
-            try!(lookahead.print(self.out));
-            try!(writeln!(self.out, ""));
+            )?;
+            lookahead.print(self.out)?;
+            writeln!(self.out, "")?;
         }
         Ok(())
     }
@@ -339,35 +339,35 @@ where
         max_width: usize,
     ) -> io::Result<()> {
         for entry in gotos {
-            try!(write!(self.out, "{}", INDENT_STRING));
+            write!(self.out, "{}", INDENT_STRING)?;
             // stringize it first to allow handle :width by Display for string
             let s = format!("{}", entry.0);
-            try!(writeln!(
+            writeln!(
                 self.out,
                 "{:width$} goto {}",
                 s,
                 entry.1,
                 width = max_width
-            ));
+            )?;
         }
         Ok(())
     }
 
     fn write_section_header(&mut self, title: &str) -> io::Result<()> {
-        try!(writeln!(self.out, "\n{}", title));
-        try!(writeln!(
+        writeln!(self.out, "\n{}", title)?;
+        writeln!(
             self.out,
             "----------------------------------------"
-        ));
+        )?;
         Ok(())
     }
 
     fn write_header(&mut self) -> io::Result<()> {
-        try!(writeln!(self.out, "Lalrpop Report File"));
-        try!(writeln!(
+        writeln!(self.out, "Lalrpop Report File")?;
+        writeln!(
             self.out,
             "========================================"
-        ));
+        )?;
         Ok(())
     }
 }
@@ -402,7 +402,7 @@ where
 {
     fn print<'report, 'grammar>(self: &Self, out: &'report mut W) -> io::Result<()> {
         for i in self.iter() {
-            try!(write!(out, " {}", i))
+            write!(out, " {}", i)?
         }
         Ok(())
     }

--- a/lalrpop/src/main.rs
+++ b/lalrpop/src/main.rs
@@ -26,7 +26,7 @@ fn main1() -> io::Result<()> {
         .unwrap_or_else(|e| e.exit());
 
     if args.flag_version {
-        try!(writeln!(stdout, "{}", VERSION));
+        writeln!(stdout, "{}", VERSION)?;
         process::exit(0);
     }
 
@@ -60,10 +60,10 @@ fn main1() -> io::Result<()> {
     }
 
     if args.arg_inputs.len() == 0 {
-        try!(writeln!(
+        writeln!(
             stderr,
             "Error: no input files specified! Try --help for help."
-        ));
+        )?;
         process::exit(1);
     }
 
@@ -79,11 +79,11 @@ fn main1() -> io::Result<()> {
         match config.process_file(&arg) {
             Ok(()) => {}
             Err(err) => {
-                try!(writeln!(
+                writeln!(
                     stderr,
                     "Error encountered processing `{}`: {}",
                     arg, err
-                ));
+                )?;
                 process::exit(1);
             }
         }

--- a/lalrpop/src/normalize/inline/graph/mod.rs
+++ b/lalrpop/src/normalize/inline/graph/mod.rs
@@ -84,7 +84,7 @@ impl<'grammar> NonterminalGraph<'grammar> {
         let mut states = vec![WalkState::NotVisited; self.graph.node_count()];
         let mut result = vec![];
         for node in self.nonterminal_map.values().cloned() {
-            try!(self.walk(&mut states, &mut result, node));
+            self.walk(&mut states, &mut result, node)?;
         }
         Ok(result)
     }
@@ -101,7 +101,7 @@ impl<'grammar> NonterminalGraph<'grammar> {
             WalkState::NotVisited => {
                 states[source.index()] = WalkState::Visiting;
                 for target in self.graph.neighbors(source) {
-                    try!(self.walk(states, result, target));
+                    self.walk(states, result, target)?;
                 }
                 states[source.index()] = WalkState::Visited;
                 result.push(nt.clone());

--- a/lalrpop/src/normalize/inline/mod.rs
+++ b/lalrpop/src/normalize/inline/mod.rs
@@ -11,7 +11,7 @@ mod graph;
 mod test;
 
 pub fn inline(mut grammar: Grammar) -> NormResult<Grammar> {
-    let order = try!(graph::inline_order(&grammar));
+    let order = graph::inline_order(&grammar)?;
     for nt in order {
         inline_nt(&mut grammar, &nt);
     }

--- a/lalrpop/src/normalize/mod.rs
+++ b/lalrpop/src/normalize/mod.rs
@@ -40,8 +40,8 @@ fn normalize_helper(
     grammar: pt::Grammar,
     validate: bool,
 ) -> NormResult<r::Grammar> {
-    let grammar = try!(lower_helper(session, grammar, validate));
-    let grammar = profile!(session, "Inlining", try!(inline::inline(grammar)));
+    let grammar = lower_helper(session, grammar, validate)?;
+    let grammar = profile!(session, "Inlining", inline::inline(grammar)?);
     Ok(grammar)
 }
 
@@ -50,25 +50,25 @@ fn lower_helper(session: &Session, grammar: pt::Grammar, validate: bool) -> Norm
         session,
         "Grammar validation",
         if validate {
-            try!(prevalidate::validate(&grammar));
+            prevalidate::validate(&grammar)?;
         }
     );
     let grammar = profile!(
         session,
         "Grammar resolution",
-        try!(resolve::resolve(grammar))
+        resolve::resolve(grammar)?
     );
     let grammar = profile!(
         session,
         "Macro expansion",
-        try!(macro_expand::expand_macros(grammar))
+        macro_expand::expand_macros(grammar)?
     );
-    let grammar = profile!(session, "Token check", try!(token_check::validate(grammar)));
-    let types = profile!(session, "Infer types", try!(tyinfer::infer_types(&grammar)));
+    let grammar = profile!(session, "Token check", token_check::validate(grammar)?);
+    let types = profile!(session, "Infer types", tyinfer::infer_types(&grammar)?);
     let grammar = profile!(
         session,
         "Lowering",
-        try!(lower::lower(session, grammar, types))
+        lower::lower(session, grammar, types)?
     );
     Ok(grammar)
 }

--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -169,7 +169,7 @@ impl<'grammar> Validator<'grammar> {
                     }
 
                     for alternative in &data.alternatives {
-                        try!(self.validate_alternative(alternative));
+                        self.validate_alternative(alternative)?;
                     }
                 }
                 GrammarItem::InternToken(..) => {}
@@ -179,7 +179,7 @@ impl<'grammar> Validator<'grammar> {
     }
 
     fn validate_alternative(&self, alternative: &Alternative) -> NormResult<()> {
-        try!(self.validate_expr(&alternative.expr));
+        self.validate_expr(&alternative.expr)?;
 
         match norm_util::analyze_expr(&alternative.expr) {
             Symbols::Named(syms) => {
@@ -214,7 +214,7 @@ impl<'grammar> Validator<'grammar> {
 
     fn validate_expr(&self, expr: &ExprSymbol) -> NormResult<()> {
         for symbol in &expr.symbols {
-            try!(self.validate_symbol(symbol));
+            self.validate_symbol(symbol)?;
         }
 
         let chosen: Vec<&Symbol> = expr
@@ -260,7 +260,7 @@ impl<'grammar> Validator<'grammar> {
     fn validate_symbol(&self, symbol: &Symbol) -> NormResult<()> {
         match symbol.kind {
             SymbolKind::Expr(ref expr) => {
-                try!(self.validate_expr(expr));
+                self.validate_expr(expr)?;
             }
             SymbolKind::AmbiguousId(_) => { /* see resolve */ }
             SymbolKind::Terminal(_) => { /* see postvalidate! */ }
@@ -278,14 +278,14 @@ impl<'grammar> Validator<'grammar> {
             SymbolKind::Macro(ref msym) => {
                 debug_assert!(msym.args.len() > 0);
                 for arg in &msym.args {
-                    try!(self.validate_symbol(arg));
+                    self.validate_symbol(arg)?;
                 }
             }
             SymbolKind::Repeat(ref repeat) => {
-                try!(self.validate_symbol(&repeat.symbol));
+                self.validate_symbol(&repeat.symbol)?;
             }
             SymbolKind::Choose(ref sym) | SymbolKind::Name(_, ref sym) => {
-                try!(self.validate_symbol(sym));
+                self.validate_symbol(sym)?;
             }
             SymbolKind::Lookahead | SymbolKind::Lookbehind => {
                 // if using an internal tokenizer, lookahead/lookbehind are ok.

--- a/lalrpop/src/normalize/token_check/mod.rs
+++ b/lalrpop/src/normalize/token_check/mod.rs
@@ -216,7 +216,7 @@ impl<'grammar> Validator<'grammar> {
                 GrammarItem::InternToken(_) => {}
                 GrammarItem::Nonterminal(ref data) => {
                     for alternative in &data.alternatives {
-                        try!(self.validate_alternative(alternative));
+                        self.validate_alternative(alternative)?;
                     }
                 }
             }
@@ -226,13 +226,13 @@ impl<'grammar> Validator<'grammar> {
 
     fn validate_alternative(&mut self, alternative: &Alternative) -> NormResult<()> {
         assert!(alternative.condition.is_none()); // macro expansion should have removed these
-        try!(self.validate_expr(&alternative.expr));
+        self.validate_expr(&alternative.expr)?;
         Ok(())
     }
 
     fn validate_expr(&mut self, expr: &ExprSymbol) -> NormResult<()> {
         for symbol in &expr.symbols {
-            try!(self.validate_symbol(symbol));
+            self.validate_symbol(symbol)?;
         }
         Ok(())
     }
@@ -240,17 +240,17 @@ impl<'grammar> Validator<'grammar> {
     fn validate_symbol(&mut self, symbol: &Symbol) -> NormResult<()> {
         match symbol.kind {
             SymbolKind::Expr(ref expr) => {
-                try!(self.validate_expr(expr));
+                self.validate_expr(expr)?;
             }
             SymbolKind::Terminal(ref term) => {
-                try!(self.validate_terminal(symbol.span, term));
+                self.validate_terminal(symbol.span, term)?;
             }
             SymbolKind::Nonterminal(_) => {}
             SymbolKind::Repeat(ref repeat) => {
-                try!(self.validate_symbol(&repeat.symbol));
+                self.validate_symbol(&repeat.symbol)?;
             }
             SymbolKind::Choose(ref sym) | SymbolKind::Name(_, ref sym) => {
-                try!(self.validate_symbol(sym));
+                self.validate_symbol(sym)?;
             }
             SymbolKind::Lookahead | SymbolKind::Lookbehind | SymbolKind::Error => {}
             SymbolKind::AmbiguousId(ref id) => {
@@ -322,7 +322,7 @@ fn construct(grammar: &mut Grammar, match_block: MatchBlock) -> NormResult<()> {
     // one of precedences, that are parallel with `literals`.
     let mut regexs = Vec::with_capacity(match_entries.len());
     let mut precedences = Vec::with_capacity(match_entries.len());
-    try!({
+    {
         for match_entry in &match_entries {
             precedences.push(Precedence(match_entry.precedence));
             match match_entry.match_literal {
@@ -344,7 +344,7 @@ fn construct(grammar: &mut Grammar, match_block: MatchBlock) -> NormResult<()> {
             }
         }
         Ok(())
-    });
+    }?;
 
     let dfa = match dfa::build_dfa(&regexs, &precedences) {
         Ok(dfa) => dfa,

--- a/lalrpop/src/parser/lrgrammar.lalrpop
+++ b/lalrpop/src/parser/lrgrammar.lalrpop
@@ -304,7 +304,7 @@ MatchItem: MatchItem = {
     <lo:@L> "_" <hi:@R>             => MatchItem::CatchAll(Span(lo, hi)),
     <lo:@L> <s:MatchSymbol> <hi:@R> => MatchItem::Unmapped(s, Span(lo, hi)),
     <lo:@L> <from:MatchSymbol> <start:@L> <p:"=>"> <hi:@R> =>? {
-        let to = try!(super::parse_match_mapping(p, start + 2));
+        let to = super::parse_match_mapping(p, start + 2)?;
         Ok(MatchItem::Mapped(from, to, Span(lo, hi)))
     }
 };
@@ -333,7 +333,7 @@ AssociatedType: AssociatedType =
 
 Conversion: Conversion =
     <lo:@L> <from:Terminal> <start:@L> <p:"=>"> <hi:@R> =>? {
-        let pattern = try!(super::parse_pattern(p, start + 2));
+        let pattern = super::parse_pattern(p, start + 2)?;
         Ok(Conversion { span: Span(lo, hi),
                         from: from,
                         to: pattern })

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.16.3"
-// sha256: d181ef6d5f346eae4de31122598bf5282a38e6325323c525c3928fce87a77
+// sha256: 15347ed421d52ddfdd1bff0e3465696cebfbe4df0dbb1298081a6ebacb3318e
 use string_cache::DefaultAtom as Atom;
 use grammar::parse_tree::*;
 use grammar::pattern::*;
@@ -20609,7 +20609,7 @@ text: &'input str,
 ) -> Result<MatchItem,___lalrpop_util::ParseError<usize,Tok<'input>,tok::Error>>
 {
 {
-        let to = try!(super::parse_match_mapping(p, start + 2));
+        let to = super::parse_match_mapping(p, start + 2)?;
         Ok(MatchItem::Mapped(from, to, Span(lo, hi)))
     }
 }
@@ -20693,7 +20693,7 @@ text: &'input str,
 ) -> Result<Conversion,___lalrpop_util::ParseError<usize,Tok<'input>,tok::Error>>
 {
 {
-        let pattern = try!(super::parse_pattern(p, start + 2));
+        let pattern = super::parse_pattern(p, start + 2)?;
         Ok(Conversion { span: Span(lo, hi),
                         from: from,
                         to: pattern })

--- a/lalrpop/src/parser/mod.rs
+++ b/lalrpop/src/parser/mod.rs
@@ -44,7 +44,7 @@ macro_rules! parser {
 }
 
 pub fn parse_grammar<'input>(input: &'input str) -> Result<Grammar, ParseError<'input>> {
-    let mut grammar = try!(parser!(input, 0, Grammar, StartGrammar));
+    let mut grammar = parser!(input, 0, Grammar, StartGrammar)?;
 
     // find a unique prefix that does not appear anywhere in the input
     while input.contains(&grammar.prefix) {

--- a/lalrpop/src/rust/mod.rs
+++ b/lalrpop/src/rust/mod.rs
@@ -9,7 +9,7 @@ use tls::Tls;
 
 macro_rules! rust {
     ($w:expr, $($args:tt)*) => {
-        try!(($w).writeln(&::std::fmt::format(format_args!($($args)*))))
+        ($w).writeln(&::std::fmt::format(format_args!($($args)*)))?
     }
 }
 
@@ -72,17 +72,17 @@ impl<'me, W: Write> RustWrite<W> {
         let session = Tls::session();
         if session.emit_comments {
             for (i, comment) in iterable {
-                try!(self.write_indentation());
-                try!(writeln!(self.write, "{}, {}", i, comment));
+                self.write_indentation()?;
+                writeln!(self.write, "{}, {}", i, comment)?;
             }
         } else {
-            try!(self.write_indentation());
+            self.write_indentation()?;
             let mut first = true;
             for (i, _comment) in iterable {
                 if !first && session.emit_whitespace {
-                    try!(write!(self.write, " "));
+                    write!(self.write, " ")?;
                 }
-                try!(write!(self.write, "{},", i));
+                write!(self.write, "{},", i)?;
                 first = false;
             }
         }
@@ -104,7 +104,7 @@ impl<'me, W: Write> RustWrite<W> {
             self.indent -= TAB;
         }
 
-        try!(self.write_indented(out));
+        self.write_indented(out)?;
 
         // Detect a line that ends in a `{` or `(` and increase indentation for future lines.
         if buf[n] == ('{' as u8) || buf[n] == ('[' as u8) || buf[n] == ('(' as u8) {

--- a/lalrpop/src/test_util.rs
+++ b/lalrpop/src/test_util.rs
@@ -14,7 +14,10 @@ struct ExpectedDebug<'a>(&'a str);
 
 impl<'a> Debug for ExpectedDebug<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        write!(fmt, "{}", self.0)
+        // Ignore trailing commas in multiline Debug representation.
+        // Needed to work around rust-lang/rust#59076.
+        let s = self.0.replace(",\n", "\n");
+        write!(fmt, "{}", s)
     }
 }
 

--- a/lalrpop/src/tok/mod.rs
+++ b/lalrpop/src/tok/mod.rs
@@ -204,7 +204,7 @@ impl<'input> Tokenizer<'input> {
                 }
                 '"' => {
                     self.bump();
-                    let _ = try!(self.string_literal(idx1));
+                    let _ = self.string_literal(idx1)?;
                 }
                 '\n' => return error(UnrecognizedToken, idx0),
                 _ => {
@@ -415,13 +415,13 @@ impl<'input> Tokenizer<'input> {
 
             Some((idx1, '?')) => {
                 self.bump();
-                let idx2 = try!(self.code(idx0, "([{", "}])"));
+                let idx2 = self.code(idx0, "([{", "}])")?;
                 let code = &self.text[idx1 + 1..idx2];
                 Ok((idx0, EqualsGreaterThanQuestionCode(code), idx2))
             }
 
             Some((idx1, _)) => {
-                let idx2 = try!(self.code(idx0, "([{", "}])"));
+                let idx2 = self.code(idx0, "([{", "}])")?;
                 let code = &self.text[idx1..idx2];
                 Ok((idx0, EqualsGreaterThanCode(code), idx2))
             }
@@ -441,7 +441,7 @@ impl<'input> Tokenizer<'input> {
             if let Some((idx, c)) = self.lookahead {
                 if c == '"' {
                     self.bump();
-                    try!(self.string_literal(idx)); // discard the produced token
+                    self.string_literal(idx)?; // discard the produced token
                     continue;
                 } else if c == '\'' {
                     self.bump();
@@ -452,7 +452,7 @@ impl<'input> Tokenizer<'input> {
                 } else if c == 'r' {
                     self.bump();
                     if let Some((idx, '#')) = self.lookahead {
-                        try!(self.regex_literal(idx));
+                        self.regex_literal(idx)?;
                     }
                     continue;
                 } else if c == '/' {
@@ -639,7 +639,7 @@ impl<'input> Tokenizer<'input> {
         }
 
         if word == "use" {
-            let code_end = try!(self.code(idx0, "([{", "}])"));
+            let code_end = self.code(idx0, "([{", "}])")?;
             let code = &self.text[end..code_end];
             return Ok((start, Tok::Use(code), code_end));
         }

--- a/lalrpop/src/util.rs
+++ b/lalrpop/src/util.rs
@@ -8,9 +8,9 @@ impl<'a, S: Display> Display for Sep<&'a Vec<S>> {
         let &Sep(sep, vec) = self;
         let mut elems = vec.iter();
         if let Some(elem) = elems.next() {
-            try!(write!(fmt, "{}", elem));
+            write!(fmt, "{}", elem)?;
             while let Some(elem) = elems.next() {
-                try!(write!(fmt, "{}{}", sep, elem));
+                write!(fmt, "{}{}", sep, elem)?;
             }
         }
         Ok(())
@@ -24,9 +24,9 @@ impl<S: Display> Display for Escape<S> {
         let tmp = format!("{}", self.0);
         for c in tmp.chars() {
             match c {
-                'a'...'z' | '0'...'9' | 'A'...'Z' => try!(write!(fmt, "{}", c)),
-                '_' => try!(write!(fmt, "__")),
-                _ => try!(write!(fmt, "_{:x}", c as usize)),
+                'a'...'z' | '0'...'9' | 'A'...'Z' => write!(fmt, "{}", c)?,
+                '_' => write!(fmt, "__")?,
+                _ => write!(fmt, "_{:x}", c as usize)?,
             }
         }
         Ok(())
@@ -40,7 +40,7 @@ impl<'a, S: Display> Display for Prefix<&'a [S]> {
         let &Prefix(prefix, vec) = self;
         let mut elems = vec.iter();
         while let Some(elem) = elems.next() {
-            try!(write!(fmt, "{}{}", prefix, elem));
+            write!(fmt, "{}{}", prefix, elem)?;
         }
         Ok(())
     }


### PR DESCRIPTION
This PR replaces all uses of the `try!` macro with the `?` operator.

The `?` operator was added to replace the `try!` macro and should be
used in modern Rust code. `try` is also a reserved keyword in Rust 2018,
so this change prepares for a possible edition switch too.