### PR TITLE
Ignore trailing commas in `ExpectedDebug`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-- 1.26.0
+- 1.31.0
 - beta
 - nightly
 cache:

--- a/lalrpop-test/src/util/mod.rs
+++ b/lalrpop-test/src/util/mod.rs
@@ -66,7 +66,10 @@ struct ExpectedDebug<'a>(&'a str);
 
 impl<'a> Debug for ExpectedDebug<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        write!(fmt, "{}", self.0)
+        // Ignore trailing commas in multiline Debug representation.
+        // Needed to work around rust-lang/rust#59076.
+        let s = self.0.replace(",\n", "\n");
+        write!(fmt, "{}", s)
     }
 }
 

--- a/lalrpop/src/test_util.rs
+++ b/lalrpop/src/test_util.rs
@@ -14,7 +14,10 @@ struct ExpectedDebug<'a>(&'a str);
 
 impl<'a> Debug for ExpectedDebug<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        write!(fmt, "{}", self.0)
+        // Ignore trailing commas in multiline Debug representation.
+        // Needed to work around rust-lang/rust#59076.
+        let s = self.0.replace(",\n", "\n");
+        write!(fmt, "{}", s)
     }
 }
 


### PR DESCRIPTION
rust-lang/rust/pull/59076 changed the multiline Debug representation to
always include a trailing comma. This change currently breaks our tests
on beta and nightly, since we use this Debug representation to compare
expected parsing output.

We cannot simply add the trailing commas to the expected output strings,
since that would break on older rustc versions we support. Instead, this
commit makes it so that all trailing commas are stripped before the
comparison.

This workaround can be removed once rust-lang/rust/pull/59076 reaches
our minimum supported rustc version.