### PR TITLE
doc(api) Fix `intern_token` example

### DIFF
--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -28,7 +28,7 @@
 //!         consumed: usize,
 //!         regex_set: &'builder regex::RegexSet,
 //!         regex_vec: &'builder Vec<regex::Regex>,
-//! }
+//!     }
 //!
 //!     impl Matcher<'input> {
 //!         fn tokenize(&self, text: &str) -> Option<(usize, usize)> { ... }


### PR DESCRIPTION
A very small fix. Thanks for the documentation!