### PR TITLE
Mark generated types pub(crate)

### DIFF
--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -78,7 +78,7 @@ pub fn compile<W: Write>(
     rust!(out, "}}");
     rust!(out, "}}");
     rust!(out, "");
-    rust!(out, "pub struct {}MatcherBuilder {{", prefix);
+    rust!(out, "pub(crate) struct {}MatcherBuilder {{", prefix);
     rust!(out, "regex_set: {}regex::RegexSet,", prefix);
     rust!(out, "regex_vec: Vec<{}regex::Regex>,", prefix);
     rust!(out, "}}");
@@ -148,7 +148,7 @@ pub fn compile<W: Write>(
     rust!(out, "}}"); // fn matcher()
     rust!(out, "}}"); // impl MatcherBuilder
     rust!(out, "");
-    rust!(out, "pub struct {}Matcher<'input, 'builder> {{", prefix);
+    rust!(out, "pub(crate) struct {}Matcher<'input, 'builder> {{", prefix);
     rust!(out, "text: &'input str,"); // remaining input
     rust!(out, "consumed: usize,"); // number of chars consumed thus far
     rust!(out, "regex_set: &'builder {}regex::RegexSet,", prefix);

--- a/lalrpop/src/lr1/codegen/ascent.rs
+++ b/lalrpop/src/lr1/codegen/ascent.rs
@@ -180,7 +180,7 @@ impl<'ascent, 'grammar, W: Write>
         rust!(self.out, "#[allow(dead_code)]");
         rust!(
             self.out,
-            "pub enum {}Nonterminal<{}>",
+            "pub(crate) enum {}Nonterminal<{}>",
             self.prefix,
             Sep(", ", &self.custom.nonterminal_type_params)
         );

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -172,7 +172,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
 
         rust!(
             self.out,
-            "pub struct {p}StateMachine<{mtp}>",
+            "pub(crate) struct {p}StateMachine<{mtp}>",
             p = self.prefix,
             mtp = machine_type_parameters,
         );
@@ -410,7 +410,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
         rust!(self.out, "#[allow(dead_code)]");
         rust!(
             self.out,
-            "pub enum {}Symbol<{}>",
+            "pub(crate) enum {}Symbol<{}>",
             self.prefix,
             Sep(", ", &self.custom.symbol_type_params),
         );

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -31,7 +31,7 @@ extern crate lalrpop_util as ___lalrpop_util;
 use self::___lalrpop_util::state_machine as ___state_machine;
 use super::___ToTriple;
 #[allow(dead_code)]
-pub enum ___Symbol<'input>
+pub(crate) enum ___Symbol<'input>
  {
 Variant0(Tok<'input>),
 Variant1(&'input str),
@@ -3726,7 +3726,7 @@ Some(terminal.to_string())
 }
 }).collect()
 }
-pub struct ___StateMachine<'input>
+pub(crate) struct ___StateMachine<'input>
 where 
 {
 text: &'input str,


### PR DESCRIPTION
To work around [this issue](https://github.com/rust-lang/rust/issues/65707): otherwise, all tokens referenced in grammar need to be exported from crate.