### PR TITLE
depend on a more recent version of the unicode-xid crate

### DIFF
--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -30,7 +30,7 @@ serde = "1.0"
 serde_derive = "1.0"
 string_cache = "0.7.1"
 term = "0.5"
-unicode-xid = "0.1"
+unicode-xid = "0.2"
 sha2 = "0.8.0"
 
 [dev-dependencies]


### PR DESCRIPTION
unicode-xid is at version 0.2.0 in debian unstable.  I want to make sure lalrpop can work with it!

This is an aspirational PR -- i want to see what the CI does with it, and i would love to hear feedback from the lalrpop devs about any concerns that they have about this change.