### PR TITLE
Update lalrpop_mod!() to match on any $vis pattern

### DIFF
--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -184,20 +184,12 @@ pub struct ErrorRecovery<L, T, E> {
 
 #[macro_export]
 macro_rules! lalrpop_mod {
-    ($(#[$attr:meta])* $modname:ident) => {
-        lalrpop_mod!($(#[$attr])* $modname, concat!("/", stringify!($modname), ".rs"));
+    ($(#[$attr:meta])* $vis:vis $modname:ident) => {
+        lalrpop_mod!($(#[$attr])* $vis $modname, concat!("/", stringify!($modname), ".rs"));
     };
 
-    ($(#[$attr:meta])* pub $modname:ident) => {
-        lalrpop_mod!($(#[$attr])* pub $modname, concat!("/", stringify!($modname), ".rs"));
-    };
-
-    ($(#[$attr:meta])* $modname:ident, $source:expr) => {
-        $(#[$attr])* mod $modname { include!(concat!(env!("OUT_DIR"), $source)); }
-    };
-
-    ($(#[$attr:meta])* pub $modname:ident, $source:expr) => {
-        $(#[$attr])* pub mod $modname { include!(concat!(env!("OUT_DIR"), $source)); }
+    ($(#[$attr:meta])* $vis:vis $modname:ident, $source:expr) => {
+        $(#[$attr])* $vis mod $modname { include!(concat!(env!("OUT_DIR"), $source)); }
     };
 }
 


### PR DESCRIPTION
I just tried to use `lalrpop_util::lalrpop_mod!(pub(crate) grammar)` and got a `no rules expected the token "("` error during macro expansion.

By the looks of it, as well as matching the normal `ident` and `expr` "metavariables", `macro_rules!` macros can use [a `vis` metavariable][1] to match a (possibly empty) visibility specifier like `pub` or `pub(crate)`.

This PR updates the macro definition to use `vis` instead of manually matching on the private and `pub` variants.

[1]: https://doc.rust-lang.org/reference/macros-by-example.html#metavariables