### PR TITLE
issues/480

### DIFF
--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -318,7 +318,7 @@ fn emit_module_attributes<W: Write>(
 }
 
 fn emit_uses<W: Write>(grammar: &r::Grammar, rust: &mut RustWrite<W>) -> io::Result<()> {
-    rust.write_uses("", grammar)
+    rust.write_uses(&format!("{}::", grammar.action_module), grammar)
 }
 
 fn emit_recursive_ascent(

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -58,7 +58,7 @@ pub fn compile<W: Write>(
     rust!(out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
     rust!(out, "mod {}intern_token {{", prefix);
     rust!(out, "#![allow(unused_imports)]");
-    out.write_uses("", &grammar)?;
+    out.write_uses("super::", &grammar)?;
     rust!(out, "extern crate regex as {}regex;", prefix);
     rust!(out, "use std::fmt as {}fmt;", prefix);
     rust!(out, "");


### PR DESCRIPTION
the `write_uses` call as defined within [lalrpop/src/rust/mod.rs](https://github.com/lalrpop/lalrpop/blob/c531b74798a4b2640784cb4909f32e294ba652d8/lalrpop/src/rust/mod.rs#L130-#L141) requires a prefix be passed to it to populate the output. It appears based on the decision at lines [133 & 134](https://github.com/lalrpop/lalrpop/blob/c531b74798a4b2640784cb4909f32e294ba652d8/lalrpop/src/rust/mod.rs#L133-#L134) if the prefix is an empty string, it will output nothing (even if an output is required). 

This patch aims to provide a default string which can be prefixed when required.

The goal is to address: https://github.com/lalrpop/lalrpop/issues/480