### PR TITLE
Option for the lexer not to skip the whitespace

### DIFF
--- a/lalrpop/src/grammar/consts.rs
+++ b/lalrpop/src/grammar/consts.rs
@@ -19,6 +19,9 @@ pub const CFG: &str = "cfg";
 /// Annotation to request LALR.
 pub const LALR: &str = "LALR";
 
+/// Annotation to request NO_SKIP_WHITESPACE.
+pub const NO_SKIP_WHITESPACE: &str = "no_skip_whitespace";
+
 /// Annotation to request recursive-ascent-style code generation.
 pub const TABLE_DRIVEN: &str = "table_driven";
 

--- a/lalrpop/src/grammar/parse_tree.rs
+++ b/lalrpop/src/grammar/parse_tree.rs
@@ -1,7 +1,7 @@
 //! The "parse-tree" is what is produced by the parser. We use it do
 //! some pre-expansion and so forth before creating the proper AST.
 
-use grammar::consts::{INPUT_LIFETIME, LALR, RECURSIVE_ASCENT, TABLE_DRIVEN, TEST_ALL};
+use grammar::consts::{INPUT_LIFETIME, LALR, NO_SKIP_WHITESPACE, RECURSIVE_ASCENT, TABLE_DRIVEN, TEST_ALL};
 use grammar::pattern::Pattern;
 use grammar::repr::{self as r, NominalTypeRepr, TypeRepr};
 use lexer::dfa::DFA;
@@ -1173,6 +1173,9 @@ pub fn read_algorithm(annotations: &[Annotation], algorithm: &mut r::Algorithm) 
     for annotation in annotations {
         if annotation.id == Atom::from(LALR) {
             algorithm.lalr = true;
+        }
+        else if annotation.id == Atom::from(NO_SKIP_WHITESPACE) {
+            algorithm.skip_whitespace = false;
         } else if annotation.id == Atom::from(TABLE_DRIVEN) {
             algorithm.codegen = r::LrCodeGeneration::TableDriven;
         } else if annotation.id == Atom::from(RECURSIVE_ASCENT) {

--- a/lalrpop/src/grammar/repr.rs
+++ b/lalrpop/src/grammar/repr.rs
@@ -96,6 +96,7 @@ pub struct NonterminalData {
 pub struct Algorithm {
     pub lalr: bool,
     pub codegen: LrCodeGeneration,
+    pub skip_whitespace: bool
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -740,6 +741,7 @@ impl Default for Algorithm {
         Algorithm {
             lalr: false,
             codegen: LrCodeGeneration::TableDriven,
+            skip_whitespace: true
         }
     }
 }

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -170,20 +170,31 @@ pub fn compile<W: Write>(
     rust!(out, "");
     rust!(out, "fn next(&mut self) -> Option<Self::Item> {{");
 
-    // start by trimming whitespace from left
-    rust!(out, "let {}text = self.text.trim_start();", prefix);
-    rust!(
-        out,
-        "let {}whitespace = self.text.len() - {}text.len();",
-        prefix,
-        prefix
-    );
-    rust!(
-        out,
-        "let {}start_offset = self.consumed + {}whitespace;",
-        prefix,
-        prefix
-    );
+    if grammar.algorithm.skip_whitespace {
+        // start by trimming whitespace from left
+        rust!(out, "let {}text = self.text.trim_start();", prefix);
+        rust!(
+            out,
+            "let {}whitespace = self.text.len() - {}text.len();",
+            prefix,
+            prefix
+        );
+        rust!(
+            out,
+            "let {}start_offset = self.consumed + {}whitespace;",
+            prefix,
+            prefix
+        );
+    }
+    else
+    {
+        rust!(out, "let {}text = &self.text[..];", prefix);
+        rust!(
+            out,
+            "let {}start_offset = self.consumed;",
+            prefix
+        );
+    }
 
     // if nothing left, return None
     rust!(out, "if {}text.is_empty() {{", prefix);

--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -45,6 +45,7 @@ impl<'grammar> Validator<'grammar> {
     fn validate(&self) -> NormResult<()> {
         let allowed_names = vec![
             Atom::from(LALR),
+            Atom::from(NO_SKIP_WHITESPACE),
             Atom::from(TABLE_DRIVEN),
             Atom::from(RECURSIVE_ASCENT),
             Atom::from(TEST_ALL),


### PR DESCRIPTION
Added an annotation not to skip the whitespace.
An example would be:

````rust
use std::str::FromStr;

#[LALR]
#[no_skip_whitespace]
grammar;

match {
    r"[[:alpha:]_[:digit:]]+" => WORD,
    "=" => EQUAL,
    "$" => EXPAND,
    "|" => PIPE
} else {
    r"[[:digit:]]+" => NUMBER,
    r"\s+" => WS
}

pub Command: String = {
    <s1:SimpleCommand> PIPE <s2:SimpleCommand>=> format! ("(command1 {}) |(command2 {})", s1, s2),
    <s:SimpleCommand> => format! ("{}", s)
};

SimpleCommand: String = {
    <e:SimpleCommandElement> => format! ("(command {}) (parameters)", e),
    <e:SimpleCommandElement> WS <p:Params> => format! ("(command {}) (parameters {})", e, p)
};

SimpleCommandElement: String = {
    <w:Words> => w,
    <a:Assignment> WS <s:SimpleCommandElement> => format! ("(assign {}) {}", a, s)
}

Params: String = {
    <w:Words> => {
        println! ("(parameter {})", w);
        format! ("(parameter {})", w)
    },
    <w:Words> WS <p:Params> => {
        println! ("(parameter {}) {}", w, p);
        format! ("(parameter {}) {}", w, p)
    }
}

Assignment: String = {
    <w1:WORD> EQUAL <w2:Words> => format! ("{} := {}", w1, w2),
    <w:WORD> EQUAL => format! ("{} := ()", w)
};

Words: String = {
    <w:Word> => w,
    <w:Word><e:Words> => 
    {
        println! ("(words (word {}) {})", w, e);
        format! ("(word {}) {}", w, e)
    }
}

Word: String = {
    <w:WORD> => {
        println! ("{}", w);
        w.to_string()
    },
    <e:Expand> => e
};

Expand: String = {
    EXPAND <w:WORD> => {
        println! ("(expand {})", w);
        format! ("(expand {})", w)
    }
};
````
