### PR TITLE
Add Solang to the list of examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ to! Here are some tips:
 - [Gluon] is a statically typed functional programming language.
 - [Gleam](https://github.com/gleam-lang/gleam/blob/master/src/grammar.lalrpop) is a statically typed functional programming language for the Erlang VM.
 - [RustPython] is Python 3.5+ rewritten in Rust
+- [Solang] is Ethereum Solidity rewritten in Rust
 
 [The LALRPOP book]: http://lalrpop.github.io/lalrpop/
 [quick start guide]: http://lalrpop.github.io/lalrpop/quick_start_guide.html
@@ -52,6 +53,7 @@ to! Here are some tips:
 [LALRPOP]: https://github.com/lalrpop/lalrpop/blob/8034f3dacc4b20581bd10c5cb0b4f9faae778bb5/lalrpop/src/parser/lrgrammar.lalrpop
 [Gluon]: https://github.com/gluon-lang/gluon/blob/d7ce3e81c1fcfdf25cdd6d1abde2b6e376b4bf50/parser/src/grammar.lalrpop
 [RustPython]: https://github.com/RustPython/RustPython/blob/master/parser/src/python.lalrpop
+[Solang]: https://github.com/hyperledger-labs/solang/blob/master/src/parser/solidity.lalrpop
 [gitter lobby]: https://gitter.im/lalrpop/Lobby
 
 ### Contributing


### PR DESCRIPTION
Solang uses lalrpop for parsing Solidity.

Signed-off-by: Sean Young <sean@mess.org>