### PR TITLE
Update book to regex v1.0

### DIFF
--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -19,7 +19,7 @@ build = "build.rs" # LALRPOP preprocessing
 # crate, you can skip this dependency.)
 [dependencies]
 lalrpop-util = "0.17.2"
-regex = "0.2.0"
+regex = "1"
 
 # Add a build-time dependency on the lalrpop library:
 [build-dependencies]

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -32,7 +32,7 @@ lalrpop = "0.17.2"
 
 [dependencies]
 lalrpop-util = "0.17.2"
-regex = "0.2.1"
+regex = "1"
 ```
 
 Cargo can run [build scripts] as a pre-processing step,


### PR DESCRIPTION
The v0.2 regex crate came out 3 years ago.

I was about to publish a crate of my own when I saw this pre-1.0 dependency in my `Cargo.toml` that I had copied from the book.