### PR TITLE
refactor: Move the generated lexer into lalrpop-util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,9 @@ dependencies = [
 [[package]]
 name = "lalrpop-util"
 version = "0.17.2"
+dependencies = [
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "lazy_static"

--- a/lalrpop-util/Cargo.toml
+++ b/lalrpop-util/Cargo.toml
@@ -6,3 +6,12 @@ license = "Apache-2.0/MIT"
 version = "0.17.2" # LALRPOP
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 workspace = ".."
+
+[dependencies]
+regex = { version = "1", optional = true }
+
+[features]
+lexer = ["regex"]
+
+[package.metadata.docs.rs]
+features = ["lexer"]

--- a/lalrpop-util/src/lexer.rs
+++ b/lalrpop-util/src/lexer.rs
@@ -1,0 +1,106 @@
+use std::{fmt, marker::PhantomData};
+
+use ParseError;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Token<'input>(pub usize, pub &'input str);
+impl<'a> fmt::Display for Token<'a> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        fmt::Display::fmt(self.1, formatter)
+    }
+}
+
+pub struct MatcherBuilder {
+    regex_set: regex::RegexSet,
+    regex_vec: Vec<regex::Regex>,
+}
+
+impl MatcherBuilder {
+    pub fn new<S>(exprs: impl IntoIterator<Item = S>) -> Result<MatcherBuilder, regex::Error>
+    where
+        S: AsRef<str>,
+    {
+        let exprs = exprs.into_iter();
+        let mut regex_vec = Vec::with_capacity(exprs.size_hint().0);
+        let mut first_error = None;
+        let regex_set_result = regex::RegexSet::new(exprs.scan((), |_, s| {
+            regex_vec.push(match regex::Regex::new(s.as_ref()) {
+                Ok(regex) => regex,
+                Err(err) => {
+                    first_error = Some(err);
+                    return None;
+                }
+            });
+            Some(s)
+        }));
+
+        if let Some(err) = first_error {
+            return Err(err);
+        }
+        let regex_set = regex_set_result?;
+
+        Ok(MatcherBuilder {
+            regex_set,
+            regex_vec,
+        })
+    }
+    pub fn matcher<'input, 'builder, E>(
+        &'builder self,
+        s: &'input str,
+    ) -> Matcher<'input, 'builder, E> {
+        Matcher {
+            text: s,
+            consumed: 0,
+            regex_set: &self.regex_set,
+            regex_vec: &self.regex_vec,
+            _marker: PhantomData,
+        }
+    }
+}
+
+pub struct Matcher<'input, 'builder, E> {
+    text: &'input str,
+    consumed: usize,
+    regex_set: &'builder regex::RegexSet,
+    regex_vec: &'builder Vec<regex::Regex>,
+    _marker: PhantomData<fn() -> E>,
+}
+
+impl<'input, 'builder, E> Iterator for Matcher<'input, 'builder, E> {
+    type Item = Result<(usize, Token<'input>, usize), ParseError<usize, Token<'input>, E>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let text = self.text.trim_start();
+        let whitespace = self.text.len() - text.len();
+        let start_offset = self.consumed + whitespace;
+        if text.is_empty() {
+            self.text = text;
+            self.consumed = start_offset;
+            None
+        } else {
+            let matches = self.regex_set.matches(text);
+            if !matches.matched_any() {
+                Some(Err(ParseError::InvalidToken {
+                    location: start_offset,
+                }))
+            } else {
+                let mut longest_match = 0;
+                let mut index = 0;
+                for i in matches.iter() {
+                    let match_ = self.regex_vec[i].find(text).unwrap();
+                    let len = match_.end();
+                    if len >= longest_match {
+                        longest_match = len;
+                        index = i;
+                    }
+                }
+                let result = &text[..longest_match];
+                let remaining = &text[longest_match..];
+                let end_offset = start_offset + longest_match;
+                self.text = remaining;
+                self.consumed = end_offset;
+                Some(Ok((start_offset, Token(index, result), end_offset)))
+            }
+        }
+    }
+}

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -1,6 +1,8 @@
 use std::error::Error;
 use std::fmt;
 
+#[cfg(feature = "lexer")]
+pub mod lexer;
 pub mod state_machine;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -44,3 +44,8 @@ version = "0.17.2" # LALRPOP
 # Feature used when developing LALRPOP. Tells the build script to use an existing lalrpop binary to
 # generate LALRPOPs own parser instead of using the saved parser.
 test = []
+
+lexer = ["lalrpop-util/lexer"]
+
+[package.metadata.docs.rs]
+features = ["lexer"]

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -424,7 +424,11 @@ fn emit_recursive_ascent(
 
     if let Some(ref intern_token) = grammar.intern_token {
         intern_token::compile(&grammar, intern_token, &mut rust)?;
-        rust!(rust, "pub use self::{}intern_token::Token;", grammar.prefix);
+        rust!(
+            rust,
+            "pub use self::{}lalrpop_util::lexer::Token;",
+            grammar.prefix
+        );
     }
 
     action::emit_action_code(grammar, &mut rust)?;

--- a/lalrpop/src/grammar/parse_tree.rs
+++ b/lalrpop/src/grammar/parse_tree.rs
@@ -25,7 +25,7 @@ pub struct Grammar {
     pub module_attributes: Vec<String>,
 }
 
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Span(pub usize, pub usize);
 
 impl Into<Box<dyn Content>> for Span {

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -1,46 +1,4 @@
 //! Generates an iterator type `Matcher` that looks roughly like
-//!
-//! ```ignore
-//! mod intern_token {
-//!     extern crate regex as regex;
-//!
-//!     #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-//!     pub struct Token<'input>(pub usize, pub &'input str);
-//!     //                           ~~~~~~     ~~~~~~~~~~~
-//!     //                           token      token
-//!     //                           index      text
-//!     //                           (type)
-//!
-//!     impl<'a> fmt::Display for Token<'a> { ... }
-//!
-//!     pub struct MatcherBuilder {
-//!         regex_set: regex::RegexSet,
-//!         regex_vec: Vec<regex::Regex>,
-//!     }
-//!
-//!     impl MatcherBuilder {
-//!         fn new() -> MatchBuilder { ... }
-//!         fn matcher<'input, 'builder>(&'builder self, s: &'input str) -> Matcher<'input, 'builder> { ... }
-//!     }
-//!
-//!     pub struct Matcher<'input, 'builder> {
-//!         text: &'input str,
-//!         consumed: usize,
-//!         regex_set: &'builder regex::RegexSet,
-//!         regex_vec: &'builder Vec<regex::Regex>,
-//!     }
-//!
-//!     impl Matcher<'input> {
-//!         fn tokenize(&self, text: &str) -> Option<(usize, usize)> { ... }
-//!     }
-//!
-//!     impl<'input> Iterator for Matcher<'input> {
-//!         type Item = Result<(usize, Token<'input>, usize), ParseError>;
-//!         //                  ~~~~~  ~~~~~~~~~~~~~  ~~~~~
-//!         //                  start  token          end
-//!     }
-//! }
-//! ```
 
 use grammar::parse_tree::InternToken;
 use grammar::repr::{Grammar, TerminalLiteral};
@@ -59,32 +17,11 @@ pub fn compile<W: Write>(
     rust!(out, "mod {}intern_token {{", prefix);
     rust!(out, "#![allow(unused_imports)]");
     out.write_uses("", &grammar)?;
-    rust!(out, "extern crate regex as {}regex;", prefix);
-    rust!(out, "use std::fmt as {}fmt;", prefix);
-    rust!(out, "");
     rust!(
         out,
-        "#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]"
-    );
-    rust!(out, "pub struct Token<'input>(pub usize, pub &'input str);");
-    rust!(out, "impl<'a> {}fmt::Display for Token<'a> {{", prefix);
-    rust!(
-        out,
-        "fn fmt<'f>(&self, formatter: &mut {}fmt::Formatter<'f>) -> Result<(), {}fmt::Error> {{",
-        prefix,
+        "pub fn new_builder() -> {}lalrpop_util::lexer::MatcherBuilder {{",
         prefix
     );
-    rust!(out, "{}fmt::Display::fmt(self.1, formatter)", prefix);
-    rust!(out, "}}");
-    rust!(out, "}}");
-    rust!(out, "");
-    rust!(out, "pub struct {}MatcherBuilder {{", prefix);
-    rust!(out, "regex_set: {}regex::RegexSet,", prefix);
-    rust!(out, "regex_vec: Vec<{}regex::Regex>,", prefix);
-    rust!(out, "}}");
-    rust!(out, "");
-    rust!(out, "impl {}MatcherBuilder {{", prefix);
-    rust!(out, "pub fn new() -> {}MatcherBuilder {{", prefix);
 
     // create a vector of rust string literals with the text of each
     // regular expression
@@ -113,177 +50,14 @@ pub fn compile<W: Write>(
         rust!(out, "{},", literal);
     }
     rust!(out, "];");
-    rust!(
-        out,
-        "let {}regex_set = {}regex::RegexSet::new({}strs).unwrap();",
-        prefix,
-        prefix,
-        prefix
-    );
-
-    rust!(out, "let {}regex_vec = vec![", prefix);
-    for literal in &regex_strings {
-        rust!(out, "{}regex::Regex::new({}).unwrap(),", prefix, literal);
-    }
-    rust!(out, "];");
 
     rust!(
         out,
-        "{0}MatcherBuilder {{ regex_set: {0}regex_set, regex_vec: {0}regex_vec }}",
-        prefix
-    );
-    rust!(out, "}}"); // fn new()
-    rust!(
-        out,
-        "pub fn matcher<'input, 'builder>(&'builder self, s: &'input str) \
-         -> {}Matcher<'input, 'builder> {{",
-        prefix
-    );
-    rust!(out, "{}Matcher {{", prefix);
-    rust!(out, "text: s,");
-    rust!(out, "consumed: 0,");
-    rust!(out, "regex_set: &self.regex_set,");
-    rust!(out, "regex_vec: &self.regex_vec,");
-    rust!(out, "}}"); // struct literal
-    rust!(out, "}}"); // fn matcher()
-    rust!(out, "}}"); // impl MatcherBuilder
-    rust!(out, "");
-    rust!(out, "pub struct {}Matcher<'input, 'builder> {{", prefix);
-    rust!(out, "text: &'input str,"); // remaining input
-    rust!(out, "consumed: usize,"); // number of chars consumed thus far
-    rust!(out, "regex_set: &'builder {}regex::RegexSet,", prefix);
-    rust!(out, "regex_vec: &'builder Vec<{}regex::Regex>,", prefix);
-    rust!(out, "}}");
-    rust!(out, "");
-    rust!(
-        out,
-        "impl<'input, 'builder> Iterator for {}Matcher<'input, 'builder> {{",
-        prefix
-    );
-    rust!(
-        out,
-        "type Item = Result<(usize, Token<'input>, usize), \
-         {}lalrpop_util::ParseError<usize,Token<'input>,{}>>;",
-        prefix,
-        grammar.types.error_type()
-    );
-    rust!(out, "");
-    rust!(out, "fn next(&mut self) -> Option<Self::Item> {{");
-
-    // start by trimming whitespace from left
-    rust!(out, "let {}text = self.text.trim_start();", prefix);
-    rust!(
-        out,
-        "let {}whitespace = self.text.len() - {}text.len();",
-        prefix,
-        prefix
-    );
-    rust!(
-        out,
-        "let {}start_offset = self.consumed + {}whitespace;",
-        prefix,
-        prefix
+        "{p}lalrpop_util::lexer::MatcherBuilder::new({p}strs).unwrap()",
+        p = prefix
     );
 
-    // if nothing left, return None
-    rust!(out, "if {}text.is_empty() {{", prefix);
-    rust!(out, "self.text = {}text;", prefix);
-    rust!(out, "self.consumed = {}start_offset;", prefix);
-    rust!(out, "None");
-    rust!(out, "}} else {{");
-
-    // otherwise, use regex-set to find list of matching tokens
-    rust!(
-        out,
-        "let {}matches = self.regex_set.matches({}text);",
-        prefix,
-        prefix
-    );
-
-    // if nothing matched, return an error
-    rust!(out, "if !{}matches.matched_any() {{", prefix);
-    rust!(
-        out,
-        "Some(Err({}lalrpop_util::ParseError::InvalidToken {{",
-        prefix
-    );
-    rust!(out, "location: {}start_offset,", prefix);
-    rust!(out, "}}))");
-    rust!(out, "}} else {{");
-
-    // otherwise, have to find longest, highest-priority match. We have the literals
-    // sorted in order of increasing precedence, so we'll iterate over them one by one,
-    // checking if each one matches, and remembering the longest one.
-    rust!(out, "let mut {}longest_match = 0;", prefix); // length of longest match
-    rust!(out, "let mut {}index = 0;", prefix); // index of longest match
-    rust!(
-        out,
-        "for {}i in 0 .. {} {{",
-        prefix,
-        intern_token.match_entries.len()
-    );
-    rust!(out, "if {}matches.matched({}i) {{", prefix, prefix);
-
-    // re-run the regex to find out how long this particular match
-    // was, then compare that against the longest-match so far. Note
-    // that the order of the tuple is carefully constructed to ensure
-    // that (a) we get the longest-match but (b) if two matches are
-    // equal, we get the largest index. This is because the indices
-    // are sorted in order of increasing priority, and because we know
-    // that indices of equal priority cannot both match (because of
-    // the DFA check).
-    rust!(
-        out,
-        "let {}match = self.regex_vec[{}i].find({}text).unwrap();",
-        prefix,
-        prefix,
-        prefix
-    );
-    rust!(out, "let {}len = {}match.end();", prefix, prefix);
-    rust!(out, "if {}len >= {}longest_match {{", prefix, prefix);
-    rust!(out, "{}longest_match = {}len;", prefix, prefix);
-    rust!(out, "{}index = {}i;", prefix, prefix);
-    rust!(out, "}}"); // if is longest match
-    rust!(out, "}}"); // if matches.matched(i)
-    rust!(out, "}}"); // for loop
-
-    // transform the result into the expected return value
-    rust!(
-        out,
-        "let {}result = &{}text[..{}longest_match];",
-        prefix,
-        prefix,
-        prefix
-    );
-    rust!(
-        out,
-        "let {}remaining = &{}text[{}longest_match..];",
-        prefix,
-        prefix,
-        prefix
-    );
-    rust!(
-        out,
-        "let {}end_offset = {}start_offset + {}longest_match;",
-        prefix,
-        prefix,
-        prefix
-    );
-    rust!(out, "self.text = {}remaining;", prefix);
-    rust!(out, "self.consumed = {}end_offset;", prefix);
-    rust!(
-        out,
-        "Some(Ok(({}start_offset, Token({}index, {}result), {}end_offset)))",
-        prefix,
-        prefix,
-        prefix,
-        prefix
-    );
-
-    rust!(out, "}}"); // else
-    rust!(out, "}}"); // else
     rust!(out, "}}"); // fn
-    rust!(out, "}}"); // impl
     rust!(out, "}}"); // mod
     Ok(())
 }

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -184,8 +184,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         if self.grammar.intern_token.is_some() {
             rust!(
                 self.out,
-                "use {}::{}intern_token::Token;",
-                self.action_module,
+                "use self::{}lalrpop_util::lexer::Token;",
                 self.prefix
             );
         } else {
@@ -246,9 +245,8 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         if intern_token {
             rust!(
                 self.out,
-                "builder: {1}::{0}intern_token::{0}MatcherBuilder,",
+                "builder: {}lalrpop_util::lexer::MatcherBuilder,",
                 self.prefix,
-                self.action_module
             );
         }
         rust!(self.out, "_priv: (),");
@@ -265,7 +263,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         if intern_token {
             rust!(
                 self.out,
-                "let {0}builder = {1}::{0}intern_token::{0}MatcherBuilder::new();",
+                "let {0}builder = {1}::{0}intern_token::new_builder();",
                 self.prefix,
                 self.action_module
             );

--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -153,12 +153,12 @@ impl<'grammar> Validator<'grammar> {
                         } else if annotation.id == cfg_annotation {
                             if data.visibility.is_pub() {
                                 match annotation.arg {
-                                Some((ref name, _)) if name == "feature" => (),
-                                _ => return_err!(
-                                    annotation.id_span,
-                                    r#"`cfg` annotations must have a `feature = "my_feature" argument"#
-                                ),
-                            }
+                                    Some((ref name, _)) if name == "feature" => (),
+                                    _ => return_err!(
+                                        annotation.id_span,
+                                        r#"`cfg` annotations must have a `feature = "my_feature" argument"#
+                                    ),
+                                }
                             } else {
                                 return_err!(
                                     annotation.id_span,

--- a/lalrpop/src/normalize/token_check/mod.rs
+++ b/lalrpop/src/normalize/token_check/mod.rs
@@ -34,6 +34,12 @@ pub fn validate(mut grammar: Grammar) -> NormResult<Grammar> {
                     .collect(),
             }
         } else {
+            if cfg!(not(feature = "lexer")) {
+                return_err!(
+                    Span::default(),
+                    "The `lexer` feature must be specified unless an `extern` lexer is defined"
+                );
+            }
             TokenMode::Internal {
                 match_block: MatchBlock::new(grammar.match_token())?,
             }


### PR DESCRIPTION
Also puts generating a lexer under the `lexer` feature with a helpful
error message instead of implicitly requiring `regex` to be in
`Cargo.toml`

BREAKING CHANGE

Add the `lexer` feature to `lalrpop` if the generated lexer is used

Closes #373