### PR TITLE
perf: Move the symbol mismatch panic into a colder path

### DIFF
--- a/lalrpop/src/generate.rs
+++ b/lalrpop/src/generate.rs
@@ -32,7 +32,7 @@ struct Generator<'grammar> {
     depth: u32,
 }
 
-const MAX_DEPTH: u32 = 10000;
+const MAX_DEPTH: u32 = 7000;
 
 impl<'grammar> Generator<'grammar> {
     fn nonterminal(&mut self, nt: NonterminalString) -> Option<ParseTree> {

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -1175,6 +1175,11 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
     }
 
     fn emit_downcast_fns(&mut self) -> io::Result<()> {
+        rust!(self.out, "#[inline(never)]");
+        rust!(self.out, "fn {}symbol_type_mismatch() -> ! {{", self.prefix);
+        rust!(self.out, "panic!(\"symbol type mismatch\")");
+        rust!(self.out, "}}");
+
         for (ty, name) in self.custom.variants.clone() {
             self.emit_downcast_fn(&name, ty)?;
         }
@@ -1224,7 +1229,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
             self.prefix,
             self.prefix
         );
-        rust!(self.out, "_ => panic!(\"symbol type mismatch\")");
+        rust!(self.out, "_ => {}symbol_type_mismatch()", self.prefix);
         rust!(self.out, "}}");
 
         rust!(self.out, "}}");

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -4787,6 +4787,10 @@ let ___next_state = ___goto(___state, ___nonterminal);
 ___states.push(___next_state);
 None
 }
+#[inline(never)]
+fn ___symbol_type_mismatch() -> ! {
+panic!("symbol type mismatch")
+}
 fn ___pop_Variant9<
   'input,
 >(
@@ -4795,7 +4799,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant9(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant46<
@@ -4806,7 +4810,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant46(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant78<
@@ -4817,7 +4821,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant78(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant40<
@@ -4828,7 +4832,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant40(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant10<
@@ -4839,7 +4843,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant10(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant44<
@@ -4850,7 +4854,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant44(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant48<
@@ -4861,7 +4865,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant48(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant20<
@@ -4872,7 +4876,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant20(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant7<
@@ -4883,7 +4887,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant7(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant59<
@@ -4894,7 +4898,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant59(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant12<
@@ -4905,7 +4909,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant12(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant61<
@@ -4916,7 +4920,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant61(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant62<
@@ -4927,7 +4931,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant62(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant14<
@@ -4938,7 +4942,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant14(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant65<
@@ -4949,7 +4953,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant65(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant63<
@@ -4960,7 +4964,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant63(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant22<
@@ -4971,7 +4975,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant22(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant73<
@@ -4982,7 +4986,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant73(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant24<
@@ -4993,7 +4997,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant24(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant75<
@@ -5004,7 +5008,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant75(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant77<
@@ -5015,7 +5019,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant77(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant26<
@@ -5026,7 +5030,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant26(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant16<
@@ -5037,7 +5041,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant16(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant80<
@@ -5048,7 +5052,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant80(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant28<
@@ -5059,7 +5063,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant28(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant82<
@@ -5070,7 +5074,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant82(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant86<
@@ -5081,7 +5085,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant86(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant87<
@@ -5092,7 +5096,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant87(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant30<
@@ -5103,7 +5107,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant30(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant90<
@@ -5114,7 +5118,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant90(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant76<
@@ -5125,7 +5129,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant76(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant85<
@@ -5136,7 +5140,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant85(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant0<
@@ -5147,7 +5151,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant0(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant91<
@@ -5158,7 +5162,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant91(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant32<
@@ -5169,7 +5173,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant32(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant34<
@@ -5180,7 +5184,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant34(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant36<
@@ -5191,7 +5195,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant36(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant3<
@@ -5202,7 +5206,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant3(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant43<
@@ -5213,7 +5217,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant43(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant50<
@@ -5224,7 +5228,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant50(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant83<
@@ -5235,7 +5239,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant83(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant53<
@@ -5246,7 +5250,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant53(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant54<
@@ -5257,7 +5261,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant54(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant51<
@@ -5268,7 +5272,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant51(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant55<
@@ -5279,7 +5283,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant55(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant56<
@@ -5290,7 +5294,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant56(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant84<
@@ -5301,7 +5305,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant84(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant5<
@@ -5312,7 +5316,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant5(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant57<
@@ -5323,7 +5327,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant57(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant58<
@@ -5334,7 +5338,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant58(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant52<
@@ -5345,7 +5349,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant52(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant95<
@@ -5356,7 +5360,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant95(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant18<
@@ -5367,7 +5371,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant18(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant39<
@@ -5378,7 +5382,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant39(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant47<
@@ -5389,7 +5393,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant47(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant41<
@@ -5400,7 +5404,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant41(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant42<
@@ -5411,7 +5415,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant42(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant8<
@@ -5422,7 +5426,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant8(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant60<
@@ -5433,7 +5437,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant60(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant64<
@@ -5444,7 +5448,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant64(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant72<
@@ -5455,7 +5459,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant72(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant74<
@@ -5466,7 +5470,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant74(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant79<
@@ -5477,7 +5481,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant79(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant67<
@@ -5488,7 +5492,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant67(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant81<
@@ -5499,7 +5503,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant81(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant89<
@@ -5510,7 +5514,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant89(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant2<
@@ -5521,7 +5525,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant2(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant92<
@@ -5532,7 +5536,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant92(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant93<
@@ -5543,7 +5547,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant93(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant94<
@@ -5554,7 +5558,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant94(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant4<
@@ -5565,7 +5569,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant4(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant68<
@@ -5576,7 +5580,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant68(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant6<
@@ -5587,7 +5591,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant6(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant69<
@@ -5598,7 +5602,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant69(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant71<
@@ -5609,7 +5613,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant71(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant70<
@@ -5620,7 +5624,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant70(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant11<
@@ -5631,7 +5635,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant11(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant45<
@@ -5642,7 +5646,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant45(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant49<
@@ -5653,7 +5657,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant49(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant21<
@@ -5664,7 +5668,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant21(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant13<
@@ -5675,7 +5679,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant13(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant15<
@@ -5686,7 +5690,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant15(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant66<
@@ -5697,7 +5701,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant66(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant23<
@@ -5708,7 +5712,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant23(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant25<
@@ -5719,7 +5723,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant25(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant27<
@@ -5730,7 +5734,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant27(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant17<
@@ -5741,7 +5745,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant17(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant29<
@@ -5752,7 +5756,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant29(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant88<
@@ -5763,7 +5767,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant88(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant31<
@@ -5774,7 +5778,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant31(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant33<
@@ -5785,7 +5789,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant33(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant35<
@@ -5796,7 +5800,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant35(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant37<
@@ -5807,7 +5811,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant37(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant38<
@@ -5818,7 +5822,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant38(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant19<
@@ -5829,7 +5833,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant19(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 fn ___pop_Variant1<
@@ -5840,7 +5844,7 @@ ___symbols: &mut ::std::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop().unwrap() {
 (___l, ___Symbol::Variant1(___v), ___r) => (___l, ___v, ___r),
-_ => panic!("symbol type mismatch")
+_ => ___symbol_type_mismatch()
 }
 }
 pub(crate) fn ___reduce0<


### PR DESCRIPTION
Makes it easier for llvm to inline the pop functions

