### PR TITLE
fix: Don't include whitespace in the span with empty nonterminals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -48,15 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bit-set"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-vec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -157,7 +157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -232,7 +232,7 @@ version = "0.18.1"
 dependencies = [
  "ascii-canvas 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-set 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ena 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -242,8 +242,8 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -308,8 +308,8 @@ dependencies = [
  "lalrpop 0.18.1",
  "lalrpop-util 0.18.1",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -326,7 +326,7 @@ name = "phf_shared"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "siphasher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "siphasher 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -341,7 +341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -349,10 +349,10 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -436,20 +436,20 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.106"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.106"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -477,7 +477,7 @@ dependencies = [
  "new_debug_unreachable 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_shared 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -487,11 +487,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -563,8 +563,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-"checksum bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
-"checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
+"checksum bit-set 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+"checksum bit-vec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
@@ -583,7 +583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
-"checksum hermit-abi 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8a0d737e0f947a1864e93d33fdef4af8445a00d1ed8dc0c8ddb73139ea6abf15"
+"checksum hermit-abi 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 "checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 "checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -596,8 +596,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum phf_shared 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-"checksum proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
-"checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+"checksum proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
+"checksum quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
 "checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 "checksum rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -607,13 +607,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 "checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 "checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
-"checksum serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
-"checksum serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
+"checksum serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)" = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
+"checksum serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)" = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
 "checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
-"checksum siphasher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e88f89a550c01e4cd809f3df4f52dc9e939f3273a2017eabd5c6d12fd98bb23"
+"checksum siphasher 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
 "checksum string_cache 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2940c75beb4e3bf3a494cef919a747a2cb81e52571e212bfbd185074add7208a"
 "checksum strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
-"checksum syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+"checksum syn 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "e8e5aa70697bb26ee62214ae3288465ecec0000f05182f039b477001f08f5ae7"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -145,6 +145,8 @@ lalrpop_mod!(
 
 lalrpop_mod!(comments);
 
+lalrpop_mod!(sp_from_optional);
+
 pub fn use_cfg_created_parser() {
     cfg::CreatedParser::new();
 }
@@ -1015,5 +1017,15 @@ fn comments() {
             )
             .unwrap(),
         vec!["22", "3", "5", "13"]
+    );
+}
+
+#[test]
+fn sp_from_optional() {
+    assert_eq!(
+        sp_from_optional::TestParser::new()
+            .parse("before   let")
+            .unwrap(),
+        (9, "let", 12)
     );
 }

--- a/lalrpop-test/src/loc_issue_90_lib.rs
+++ b/lalrpop-test/src/loc_issue_90_lib.rs
@@ -34,7 +34,7 @@ Ok(
         Upgrade(
             0,
             Wonky(
-                5,
+                6,
                 6
             ),
             6
@@ -125,8 +125,8 @@ Ok(
         Ref(
             0,
             Maybe(
-                1,
-                1
+                2,
+                2
             ),
             Ident(
                 2,

--- a/lalrpop-test/src/sp_from_optional.lalrpop
+++ b/lalrpop-test/src/sp_from_optional.lalrpop
@@ -1,0 +1,13 @@
+grammar;
+
+Sp<T> = @L T @R;
+
+Meta: () = {
+    "comment" => (),
+    => (),
+};
+
+// An empty `Meta` production here should not cause the span of `Let` to include the preceding whitespace
+Let: &'input str = Meta <"let">;
+
+pub Test: (usize, &'input str, usize) = "before" <Sp<Let>>;

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -5874,8 +5874,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // "::"? =  => ActionFn(135);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action135::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant2(___nt), ___end));
 (0, 0)
@@ -5907,8 +5907,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // ";"? =  => ActionFn(152);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action152::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant2(___nt), ___end));
 (0, 1)
@@ -5940,8 +5940,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // "mut"? =  => ActionFn(141);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action141::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant2(___nt), ___end));
 (0, 2)
@@ -5994,8 +5994,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // ("->" <TypeRef>)? =  => ActionFn(166);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action166::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant4(___nt), ___end));
 (0, 4)
@@ -6048,8 +6048,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (":" <TypeRef>)? =  => ActionFn(158);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action158::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant4(___nt), ___end));
 (0, 6)
@@ -6104,8 +6104,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // ("<" <Comma<TypeBoundParameter>> ">")? =  => ActionFn(162);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action162::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant6(___nt), ___end));
 (0, 8)
@@ -6158,8 +6158,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // ("if" <Cond>)? =  => ActionFn(147);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action147::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant8(___nt), ___end));
 (0, 10)
@@ -6174,8 +6174,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // () =  => ActionFn(170);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action170::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant9(___nt), ___end));
 (0, 11)
@@ -6209,8 +6209,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<Alternative> ",")* =  => ActionFn(238);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action238::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant11(___nt), ___end));
 (0, 13)
@@ -6300,8 +6300,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<Conversion> ",")* =  => ActionFn(262);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action262::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant13(___nt), ___end));
 (0, 16)
@@ -6391,8 +6391,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<FieldPattern> ",")* =  => ActionFn(123);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action123::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant15(___nt), ___end));
 (0, 19)
@@ -6482,8 +6482,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<GrammarParameter> ",")* =  => ActionFn(228);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action228::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant17(___nt), ___end));
 (0, 22)
@@ -6573,8 +6573,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<GrammarWhereClause> ",")* =  => ActionFn(205);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action205::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant19(___nt), ___end));
 (0, 25)
@@ -6664,8 +6664,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<Id> "::")* =  => ActionFn(131);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action131::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant21(___nt), ___end));
 (0, 28)
@@ -6755,8 +6755,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<Lifetime> "+")* =  => ActionFn(208);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action208::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant23(___nt), ___end));
 (0, 31)
@@ -6846,8 +6846,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<MatchItem> ",")* =  => ActionFn(257);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action257::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant25(___nt), ___end));
 (0, 34)
@@ -6937,8 +6937,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<NotMacroId> ",")* =  => ActionFn(233);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action233::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant27(___nt), ___end));
 (0, 37)
@@ -7028,8 +7028,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<Pattern> ",")* =  => ActionFn(267);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action267::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant29(___nt), ___end));
 (0, 40)
@@ -7119,8 +7119,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<Symbol> ",")* =  => ActionFn(243);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action243::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant31(___nt), ___end));
 (0, 43)
@@ -7210,8 +7210,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<TypeBound> "+")* =  => ActionFn(213);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action213::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant33(___nt), ___end));
 (0, 46)
@@ -7301,8 +7301,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<TypeBoundParameter> ",")* =  => ActionFn(223);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action223::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant35(___nt), ___end));
 (0, 49)
@@ -7392,8 +7392,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<TypeParameter> ",")* =  => ActionFn(200);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action200::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant37(___nt), ___end));
 (0, 52)
@@ -7483,8 +7483,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<TypeRef> ",")* =  => ActionFn(218);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action218::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant38(___nt), ___end));
 (0, 55)
@@ -7574,8 +7574,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<TypeRefOrLifetime> ",")* =  => ActionFn(248);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action248::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant38(___nt), ___end));
 (0, 58)
@@ -7646,8 +7646,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // @L =  => ActionFn(183);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action183::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant39(___nt), ___end));
 (0, 60)
@@ -7662,8 +7662,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // @R =  => ActionFn(182);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action182::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant39(___nt), ___end));
 (0, 61)
@@ -7763,8 +7763,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Action? =  => ActionFn(145);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action145::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant41(___nt), ___end));
 (0, 63)
@@ -7910,8 +7910,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Alternative? =  => ActionFn(237);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action237::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant42(___nt), ___end));
 (0, 65)
@@ -8029,8 +8029,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Annotation* =  => ActionFn(184);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action184::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant45(___nt), ___end));
 (0, 68)
@@ -8137,8 +8137,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // AnnotationArg? =  => ActionFn(156);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action156::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant47(___nt), ___end));
 (0, 71)
@@ -8175,8 +8175,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // AssociatedType* =  => ActionFn(129);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action129::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant49(___nt), ___end));
 (0, 73)
@@ -8261,8 +8261,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<Alternative> =  => ActionFn(449);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action449::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant43(___nt), ___end));
 (0, 75)
@@ -8330,8 +8330,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<Conversion> =  => ActionFn(467);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action467::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant50(___nt), ___end));
 (0, 76)
@@ -8399,8 +8399,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<GrammarParameter> =  => ActionFn(493);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action493::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant51(___nt), ___end));
 (0, 77)
@@ -8468,8 +8468,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<GrammarWhereClause> =  => ActionFn(521);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action521::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant52(___nt), ___end));
 (0, 78)
@@ -8537,8 +8537,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<MatchItem> =  => ActionFn(565);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action565::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant53(___nt), ___end));
 (0, 79)
@@ -8606,8 +8606,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<NotMacroId> =  => ActionFn(569);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action569::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant54(___nt), ___end));
 (0, 80)
@@ -8675,8 +8675,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<Pattern> =  => ActionFn(573);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action573::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant55(___nt), ___end));
 (0, 81)
@@ -8744,8 +8744,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<Symbol> =  => ActionFn(643);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action643::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant56(___nt), ___end));
 (0, 82)
@@ -8813,8 +8813,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<TypeBoundParameter> =  => ActionFn(651);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action651::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant5(___nt), ___end));
 (0, 83)
@@ -8882,8 +8882,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<TypeParameter> =  => ActionFn(655);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action655::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant57(___nt), ___end));
 (0, 84)
@@ -8951,8 +8951,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<TypeRef> =  => ActionFn(659);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action659::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant58(___nt), ___end));
 (0, 85)
@@ -9020,8 +9020,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<TypeRefOrLifetime> =  => ActionFn(663);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action663::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant58(___nt), ___end));
 (0, 86)
@@ -9177,8 +9177,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Conversion? =  => ActionFn(261);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action261::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant60(___nt), ___end));
 (0, 90)
@@ -9232,8 +9232,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // ExprSymbol =  => ActionFn(640);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action640::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant62(___nt), ___end));
 (0, 93)
@@ -9431,8 +9431,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // FieldPattern? =  => ActionFn(122);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action122::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant64(___nt), ___end));
 (0, 96)
@@ -9468,8 +9468,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // ForAll =  => ActionFn(324);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action324::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant57(___nt), ___end));
 (0, 97)
@@ -12432,8 +12432,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // GrammarItem* =  => ActionFn(174);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action174::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant66(___nt), ___end));
 (0, 100)
@@ -12538,8 +12538,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // GrammarParameter? =  => ActionFn(227);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action227::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant67(___nt), ___end));
 (0, 103)
@@ -12591,8 +12591,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // GrammarParameters? =  => ActionFn(179);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action179::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant68(___nt), ___end));
 (0, 105)
@@ -12644,8 +12644,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // GrammarTypeParameters? =  => ActionFn(181);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action181::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant69(___nt), ___end));
 (0, 107)
@@ -12741,8 +12741,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // GrammarWhereClause? =  => ActionFn(204);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action204::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant70(___nt), ___end));
 (0, 109)
@@ -12793,8 +12793,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // GrammarWhereClauses? =  => ActionFn(177);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action177::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant71(___nt), ___end));
 (0, 111)
@@ -12877,8 +12877,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Lifetime? =  => ActionFn(138);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action138::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant72(___nt), ___end));
 (0, 114)
@@ -12978,8 +12978,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // MatchItem? =  => ActionFn(256);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action256::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant74(___nt), ___end));
 (0, 118)
@@ -13286,8 +13286,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // NotMacroId? =  => ActionFn(232);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action232::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant79(___nt), ___end));
 (0, 126)
@@ -13411,8 +13411,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Pattern? =  => ActionFn(266);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action266::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant81(___nt), ___end));
 (0, 129)
@@ -13700,8 +13700,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Plus<Lifetime> =  => ActionFn(557);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action557::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant83(___nt), ___end));
 (0, 131)
@@ -13769,8 +13769,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Plus<TypeBound> =  => ActionFn(647);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action647::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant84(___nt), ___end));
 (0, 132)
@@ -13957,8 +13957,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // ShebangAttribute* =  => ActionFn(188);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action188::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant88(___nt), ___end));
 (0, 138)
@@ -14108,8 +14108,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Symbol* =  => ActionFn(142);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action142::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant31(___nt), ___end));
 (0, 142)
@@ -14247,8 +14247,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Symbol? =  => ActionFn(242);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action242::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant89(___nt), ___end));
 (0, 146)
@@ -14750,8 +14750,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // TypeBound? =  => ActionFn(212);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action212::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant92(___nt), ___end));
 (0, 151)
@@ -14837,8 +14837,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // TypeBoundParameter? =  => ActionFn(222);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action222::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant93(___nt), ___end));
 (0, 153)
@@ -14921,8 +14921,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // TypeParameter? =  => ActionFn(199);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action199::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant94(___nt), ___end));
 (0, 156)
@@ -15273,8 +15273,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // TypeRef? =  => ActionFn(217);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action217::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant4(___nt), ___end));
 (0, 158)
@@ -15340,8 +15340,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // TypeRefOrLifetime? =  => ActionFn(247);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action247::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant4(___nt), ___end));
 (0, 160)
@@ -15375,8 +15375,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Use* =  => ActionFn(186);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action186::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant66(___nt), ___end));
 (0, 162)
@@ -15482,8 +15482,8 @@ _: ::std::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Visibility =  => ActionFn(325);
-let ___start = ___symbols.last().map(|s| s.2.clone()).unwrap_or_default();
-let ___end = ___lookahead_start.cloned().unwrap_or_else(|| ___start.clone());
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
+let ___end = ___start.clone();
 let ___nt = super::___action325::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant95(___nt), ___end));
 (0, 164)


### PR DESCRIPTION
Empty non-terminals used to be spanned by the whitespace between the
previous and next token. If the non-terminal was the first thing in
another production this span would leak into that production, causing it
to have a to large span assigned.

This makes empty productions instead only point to the start of the
lookahead to avoid this problem.