### PR TITLE
Add From<E> for ParseError<L, T, E>

### DIFF
--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -135,6 +135,12 @@ where
     }
 }
 
+impl<L, T, E> From<E> for ParseError<L, T, E> {
+    fn from(error: E) -> Self {
+        ParseError::User { error }
+    }
+}
+
 impl<L, T, E> Error for ParseError<L, T, E>
 where
     L: fmt::Debug + fmt::Display,


### PR DESCRIPTION
Useful especially combined with the `?` syntax, as you can do `MyLocalError(...)?` and it gets transformed into a `ParseError` without having to worry about writing out the wrapper.