### PR TITLE
Ship calculator .lalrpop files to rust 2018

### DIFF
--- a/doc/calculator/src/calculator4.lalrpop
+++ b/doc/calculator/src/calculator4.lalrpop
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use ast::{Expr, Opcode};
+use crate::ast::{Expr, Opcode};
 
 grammar;
 

--- a/doc/calculator/src/calculator5.lalrpop
+++ b/doc/calculator/src/calculator5.lalrpop
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use ast::{Expr, Opcode};
+use crate::ast::{Expr, Opcode};
 
 grammar;
 

--- a/doc/calculator/src/calculator6.lalrpop
+++ b/doc/calculator/src/calculator6.lalrpop
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use ast::{Expr, Opcode};
+use crate::ast::{Expr, Opcode};
 
 use lalrpop_util::ParseError;
 

--- a/doc/calculator/src/calculator6b.lalrpop
+++ b/doc/calculator/src/calculator6b.lalrpop
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use ast::{Expr, Opcode};
+use crate::ast::{Expr, Opcode};
 
 use super::Calculator6Error;
 

--- a/doc/calculator/src/calculator7.lalrpop
+++ b/doc/calculator/src/calculator7.lalrpop
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use ast::{Expr, Opcode};
+use crate::ast::{Expr, Opcode};
 use lalrpop_util::ErrorRecovery;
 
 grammar<'err>(errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, &'static str>>);

--- a/doc/calculator/src/calculator8.lalrpop
+++ b/doc/calculator/src/calculator8.lalrpop
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use ast::{Expr, Opcode};
+use crate::ast::{Expr, Opcode};
 
 grammar(scale: i32);
 

--- a/doc/calculator/src/calculator9.lalrpop
+++ b/doc/calculator/src/calculator9.lalrpop
@@ -1,5 +1,5 @@
-use ast::{ExprSymbol, Opcode};
-use tok9::Tok;
+use crate::ast::{ExprSymbol, Opcode};
+use crate::tok9::Tok;
 
 grammar<'input>(input: &'input str);
 


### PR DESCRIPTION
Refer to https://doc.rust-lang.org/reference/items/use-declarations.html.
In 2018 edition, "crate::" is needed for in-scope items.

I  ran "cargo build" & "cargo test" with 'edition="2018"' in Cargo.toml, build and tests pass.