### PR TITLE
Add required "lexer" feature to tutorial

### DIFF
--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -30,7 +30,8 @@ version = "0.1.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 
 [build-dependencies] # <-- We added this and everything after!
-lalrpop = "0.19.0"
+# It's required to add the "lexer" feature if a custom lexer is not defined
+lalrpop = { version = "0.19.0", features = ["lexer"] }
 
 [dependencies]
 lalrpop-util = "0.19.0"


### PR DESCRIPTION
This is required to get the tutorial working (without a custom lexer) - as a first time user I guess the default would be use the builtin lexer, though I appreciate there may be a reason for this not being the default.