### PR TITLE
Clarify meaning/purpose of `pub` annotations on nonterminals

### DIFF
--- a/doc/src/tutorial/004_full_expressions.md
+++ b/doc/src/tutorial/004_full_expressions.md
@@ -65,7 +65,7 @@ something like `2+3*4`:
 
 In the first one, we give multiplication higher precedence, and in the
 second one, we (incorrectly) give addition higher precedence. If you
-look at the grammar now, you can see that the second one is 
+look at the grammar now, you can see that the second one is
 impossible: a `Factor` cannot have an `Expr` as its left-hand side.
 This is the purpose of the tiers: to force the parser into the
 precedence you want.

--- a/doc/src/tutorial/004_full_expressions.md
+++ b/doc/src/tutorial/004_full_expressions.md
@@ -65,9 +65,16 @@ something like `2+3*4`:
 
 In the first one, we give multiplication higher precedence, and in the
 second one, we (incorrectly) give addition higher precedence. If you
-look at the grammar now, you can see that the second one is
+look at the grammar now, you can see that the second one is 
 impossible: a `Factor` cannot have an `Expr` as its left-hand side.
 This is the purpose of the tiers: to force the parser into the
 precedence you want.
+
+Finally, note that we only write `pub` before the nonterminal we're 
+interested in parsing (`Expr`) and not any of the helpers. Nonterminals
+marked `pub` have extra code generated, like the `new()` method used to
+access the parser from other modules. If you get a warning about an 
+unused `new()` method on `FooParser`, drop the `pub` from nonterminal
+`Foo`.
 
 [calculator3]: ../../calculator/src/calculator3.lalrpop


### PR DESCRIPTION
I was getting some dead code warnings I couldn't turn off. @segeljakt pointed out on Gitter that it might be the `pub` annotations. I didn't see anything in the docs that clarified that, so I add some text as early as seemed reasonable.