### PR TITLE
Allow generating no_std-compatible parsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,12 +407,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
-
-[[package]]
 name = "siphasher"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,15 +414,14 @@ checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
 
 [[package]]
 name = "string_cache"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2940c75beb4e3bf3a494cef919a747a2cb81e52571e212bfbd185074add7208a"
+checksum = "8ddb1139b5353f96e429e1a5e19fbaf663bddedaa06d1dbd49f82e352601209a"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
  "phf_shared",
  "precomputed-hash",
- "serde",
 ]
 
 [[package]]

--- a/lalrpop-util/Cargo.toml
+++ b/lalrpop-util/Cargo.toml
@@ -6,12 +6,15 @@ license = "Apache-2.0/MIT"
 version = "0.19.1" # LALRPOP
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 workspace = ".."
+edition = "2018"
 
 [dependencies]
 regex = { version = "1", optional = true }
 
 [features]
 lexer = ["regex"]
+std = []
+default = ["std"]
 
 [package.metadata.docs.rs]
 features = ["lexer"]

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -1,5 +1,11 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use alloc::{string::String, vec::Vec};
+use core::fmt;
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::fmt;
 
 #[cfg(feature = "lexer")]
 pub mod lexer;
@@ -141,6 +147,7 @@ impl<L, T, E> From<E> for ParseError<L, T, E> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<L, T, E> Error for ParseError<L, T, E>
 where
     L: fmt::Debug + fmt::Display,

--- a/lalrpop-util/src/state_machine.rs
+++ b/lalrpop-util/src/state_machine.rs
@@ -1,11 +1,13 @@
 #![allow(dead_code)]
 
-use std::fmt::Debug;
+use alloc::{string::String, vec, vec::Vec};
+use core::fmt::Debug;
 
 const DEBUG_ENABLED: bool = false;
 
 macro_rules! debug {
     ($($args:expr),* $(,)*) => {
+        #[cfg(feature = "std")]
         if DEBUG_ENABLED {
             eprintln!($($args),*);
         }

--- a/lalrpop/src/grammar/parse_tree.rs
+++ b/lalrpop/src/grammar/parse_tree.rs
@@ -7,10 +7,10 @@ use crate::grammar::repr::{self as r, NominalTypeRepr, TypeRepr};
 use crate::lexer::dfa::DFA;
 use crate::message::builder::InlineBuilder;
 use crate::message::Content;
-use std::fmt::{Debug, Display, Error, Formatter};
-use string_cache::DefaultAtom as Atom;
 use crate::tls::Tls;
 use crate::util::Sep;
+use std::fmt::{Debug, Display, Error, Formatter};
+use string_cache::DefaultAtom as Atom;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Grammar {
@@ -1171,16 +1171,16 @@ impl Path {
 
     pub fn vec() -> Path {
         Path {
-            absolute: true,
-            ids: vec![Atom::from("std"), Atom::from("vec"), Atom::from("Vec")],
+            absolute: false,
+            ids: vec![Atom::from("alloc"), Atom::from("vec"), Atom::from("Vec")],
         }
     }
 
     pub fn option() -> Path {
         Path {
-            absolute: true,
+            absolute: false,
             ids: vec![
-                Atom::from("std"),
+                Atom::from("core"),
                 Atom::from("option"),
                 Atom::from("Option"),
             ],

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -5,8 +5,8 @@ use crate::grammar::free_variables::FreeVariables;
 use crate::grammar::repr::*;
 use crate::lr1::core::*;
 use crate::rust::RustWrite;
-use std::io::{self, Write};
 use crate::util::Sep;
+use std::io::{self, Write};
 
 /// Base struct for various kinds of code generator. The flavor of
 /// code generator is customized by supplying distinct types for `C`
@@ -353,7 +353,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
                 TypeParameter::Id(ref id) => id.to_string(),
             })
             .collect();
-        format!("::std::marker::PhantomData<({})>", Sep(", ", &phantom_bits),)
+        format!("core::marker::PhantomData<({})>", Sep(", ", &phantom_bits),)
     }
 
     /// Returns expression that captures the user-declared type
@@ -371,7 +371,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
             })
             .collect();
         format!(
-            "::std::marker::PhantomData::<({})>",
+            "core::marker::PhantomData::<({})>",
             Sep(", ", &phantom_bits),
         )
     }

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -877,12 +877,12 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
             format!("{}action: {}", self.prefix, self.custom.state_type),
             format!("{}lookahead_start: Option<&{}>", self.prefix, loc_type),
             format!(
-                "{}states: &mut ::std::vec::Vec<{}>",
-                self.prefix, self.custom.state_type
+                "{}states: &mut alloc::vec::Vec<{}>",
+                self.prefix, self.custom.state_type,
             ),
             format!(
-                "{}symbols: &mut ::std::vec::Vec<{}>",
-                self.prefix, spanned_symbol_type
+                "{}symbols: &mut alloc::vec::Vec<{}>",
+                self.prefix, spanned_symbol_type,
             ),
             format!("_: {}", self.phantom_data_type()),
         ];
@@ -1009,8 +1009,8 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
         let parameters = vec![
             format!("{}lookahead_start: Option<&{}>", self.prefix, loc_type),
             format!(
-                "{}symbols: &mut ::std::vec::Vec<{}>",
-                self.prefix, spanned_symbol_type
+                "{}symbols: &mut alloc::vec::Vec<{}>",
+                self.prefix, spanned_symbol_type,
             ),
             format!("_: {}", self.phantom_data_type()),
         ];
@@ -1184,9 +1184,9 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
         rust!(self.out, ">(");
         rust!(
             self.out,
-            "{}symbols: &mut ::std::vec::Vec<{}>",
+            "{}symbols: &mut alloc::vec::Vec<{}>",
             self.prefix,
-            spanned_symbol_type
+            spanned_symbol_type,
         );
         rust!(self.out, ") -> {}", self.types.spanned_type(variant_ty));
 
@@ -1520,9 +1520,9 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
     fn emit_expected_tokens_fn(&mut self) -> io::Result<()> {
         rust!(
             self.out,
-            "fn {p}expected_tokens({p}state: {}) -> Vec<::std::string::String> {{",
+            "fn {p}expected_tokens({p}state: {}) -> alloc::vec::Vec<alloc::string::String> {{",
             self.custom.state_type,
-            p = self.prefix
+            p = self.prefix,
         );
 
         rust!(self.out, "const {}TERMINAL: &[&str] = &[", self.prefix);

--- a/lalrpop/src/rust/mod.rs
+++ b/lalrpop/src/rust/mod.rs
@@ -3,9 +3,9 @@
 
 use crate::grammar::parse_tree::Visibility;
 use crate::grammar::repr::{self, Grammar};
+use crate::tls::Tls;
 use std::fmt::{self, Display};
 use std::io::{self, Write};
-use crate::tls::Tls;
 
 macro_rules! rust {
     ($w:expr, $($args:tt)*) => {
@@ -155,6 +155,8 @@ impl<'me, W: Write> RustWrite<W> {
             "use self::{p}lalrpop_util::state_machine as {p}state_machine;",
             p = prefix,
         );
+        rust!(self, "extern crate core;");
+        rust!(self, "extern crate alloc;");
 
         Ok(())
     }


### PR DESCRIPTION
Fixes #397.

I went with an option rather than only using `core`/`alloc` because a) `alloc` still requires `extern crate alloc;` in the root of the crate, and b) `core` isn't available in Rust 2015, which `calculator`, `whitespace` etc are.

Oh, also, I turned off rustfmt since it was reformatting everything; I'm not sure what the formatting guidelines are for lalrpop, or if rustfmt just hasn't been run in a while.
