### PR TITLE
Fixed inability to process symlinks to lalrpop files

### DIFF
--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -191,7 +191,16 @@ fn lalrpop_files<P: AsRef<Path>>(root_dir: P) -> io::Result<Vec<PathBuf>> {
             result.extend(lalrpop_files(&path)?);
         }
 
-        if file_type.is_file()
+        let is_symlink_file = || -> io::Result<bool> {
+            if !file_type.is_symlink() {
+                Ok(false)
+            } else {
+                // Ensure all symlinks are resolved
+                Ok(fs::metadata(&path)?.is_file())
+            }
+        };
+
+        if (file_type.is_file() || is_symlink_file()?)
             && path.extension().is_some()
             && path.extension().unwrap() == "lalrpop"
         {


### PR DESCRIPTION
I'm attempting to build the [basic-cookies](https://github.com/drjokepu/basic-cookies) crate using the [Bazel](https://bazel.build/) build system and I ran into an issue where the `.lalrpop` files were not being processed leading to the following error:
```output
error: couldn't read /private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/sandbox/darwin-sandbox/1299/execroot/cargo_raze/bazel-out/darwin-fastbuild/bin/external/cargo_raze__basic_cookies__0_1_4/basic_cookies_build_script.out_dir/cookie_grammar.rs: No such file or directory (os error 2)
 --> external/cargo_raze__basic_cookies__0_1_4/src/cookie.rs:9:1
  |
9 | lalrpop_mod!(cookie_grammar);
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to previous error
```

Almost every Bazel subcommand/action is done on symlinks to source files, not the source files directly. When the `build.rs` of `basic-cookies` is run, it's run in the following sandboxed workspace where all files are symlinks:
```command
% tree /private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/sandbox/darwin-sandbox/1299/execroot/cargo_raze/bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/cargo_raze__basic_cookies__0_1_4/basic_cookies_build_script_script_.runfiles/cargo_raze__basic_cookies__0_1_4/
```
```output
/private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/sandbox/darwin-sandbox/1299/execroot/cargo_raze/bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/cargo_raze__basic_cookies__0_1_4/basic_cookies_build_script_script_.runfiles/cargo_raze__basic_cookies__0_1_4/
├── BUILD.bazel -> /private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/execroot/cargo_raze/external/cargo_raze__basic_cookies__0_1_4/BUILD.bazel
├── Cargo.lock -> /private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/execroot/cargo_raze/external/cargo_raze__basic_cookies__0_1_4/Cargo.lock
├── Cargo.toml -> /private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/execroot/cargo_raze/external/cargo_raze__basic_cookies__0_1_4/Cargo.toml
├── LICENSE.md -> /private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/execroot/cargo_raze/external/cargo_raze__basic_cookies__0_1_4/LICENSE.md
├── README.md -> /private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/execroot/cargo_raze/external/cargo_raze__basic_cookies__0_1_4/README.md
├── WORKSPACE.bazel -> /private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/execroot/cargo_raze/external/cargo_raze__basic_cookies__0_1_4/WORKSPACE.bazel
├── basic_cookies_build_script_script_ -> /private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/execroot/cargo_raze/bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/cargo_raze__basic_cookies__0_1_4/basic_cookies_build_script_script_
├── build.rs -> /private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/execroot/cargo_raze/external/cargo_raze__basic_cookies__0_1_4/build.rs
└── src
    ├── cookie.rs -> /private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/execroot/cargo_raze/external/cargo_raze__basic_cookies__0_1_4/src/cookie.rs
    ├── cookie_grammar.lalrpop -> /private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/execroot/cargo_raze/external/cargo_raze__basic_cookies__0_1_4/src/cookie_grammar.lalrpop
    ├── cookie_lexer.rs -> /private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/execroot/cargo_raze/external/cargo_raze__basic_cookies__0_1_4/src/cookie_lexer.rs
    ├── lib.rs -> /private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/execroot/cargo_raze/external/cargo_raze__basic_cookies__0_1_4/src/lib.rs
    └── linked_list.rs -> /private/var/tmp/_bazel_user/32618c3132899251ff30687e197d6243/execroot/cargo_raze/external/cargo_raze__basic_cookies__0_1_4/src/linked_list.rs

1 directory, 13 files
```

The root cause of the build failure above is because the `lalrpop_files` function does not handle symlinks. 
https://github.com/lalrpop/lalrpop/blob/6fd067fb4a14243b2dc396c6d4487958460e01e4/lalrpop/src/build/mod.rs#L182-L202

With the changes in this pull request, I was able to successfully build `basic-cookies`.
