### PR TITLE
Seems like Gleam doesn't use lalrpop anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ to! Here are some tips:
 
 - [LALRPOP] is itself implemented in LALRPOP.
 - [Gluon] is a statically typed functional programming language.
-- [Gleam](https://github.com/gleam-lang/gleam/blob/master/src/grammar.lalrpop) is a statically typed functional programming language for the Erlang VM.
 - [RustPython] is Python 3.5+ rewritten in Rust
 - [Solang] is Ethereum Solidity rewritten in Rust
 


### PR DESCRIPTION
According to: https://github.com/gleam-lang/gleam/commit/4fe17ae84159ec01d43e895291e085d5eba3ca6c