### PR TITLE
Require bit-set 0.5.2 or greater

### DIFF
--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 [dependencies]
 ascii-canvas = { version = "2.0", default_features = false }
 atty = { version = "0.2", default_features = false }
-bit-set = { version = "0.5", default_features = false }
+bit-set = { version = "0.5.2", default_features = false }
 diff = { version = "0.1.12", default_features = false }
 ena = { version = "0.14", default_features = false }
 itertools = { version = "0.9", default_features = false, features = ["use_std"] }


### PR DESCRIPTION
0.5.1 seems to not build on Rust stable,
via its transitive bit-vec 0.5.1 dependency.

I upgraded lalrpop recently and bit-set resolved to 0.5.1 for whatever reason, and the build was broken. Updating bit-set to 0.5.2 fixed the problem in my project. This patch should prevent others from running into the same problem.