### PR TITLE
Spanned precedence annotations

### DIFF
--- a/lalrpop/src/normalize/precedence/mod.rs
+++ b/lalrpop/src/normalize/precedence/mod.rs
@@ -128,7 +128,7 @@ impl FromStr for Assoc {
     }
 }
 
-/// Perform precedence expansion. Rewrite rules where at least one alternative have a precedence
+/// Perform precedence expansion. Rewrite rules where at least one alternative has a precedence
 /// annotation, and generate derived rules for each level of precedence.
 pub fn expand_precedence(input: Grammar) -> NormResult<Grammar> {
     let input = resolve::resolve(input)?;
@@ -328,7 +328,7 @@ fn replace_symbols<'a>(
     }
 }
 
-/// Perform substitution of on an non-terminal in a symbol.
+/// Perform substitution of a non-terminal in a symbol.
 fn replace_symbol<'a>(
     symbol: &mut Symbol,
     target: &NonterminalString,

--- a/lalrpop/src/normalize/precedence/mod.rs
+++ b/lalrpop/src/normalize/precedence/mod.rs
@@ -65,16 +65,23 @@ pub const SIDE_ARG: &str = "side";
 /// <left: Expression2> "?" <middle: Expression2> : <right: Expression3> => ..
 /// ```
 ///
-/// ## Default
+/// ## Associative (all)
 ///
-/// By default, if no associativity is provided, all recursive occurrences are replaced with the
-/// current level, which is different from non-associativity. This can be useful for unary
-/// operators that may be iterated, such as `-` or `!`.
+/// An associative rule means that all recursive occurrences are replaced with the current level,
+/// which is different from non-associativity. This can be useful for unary operators that may be
+/// iterated, such as `-` or `!`, or non ambiguous operators. This is the default associativity.
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub enum Assoc {
     Left,
     Right,
     NonAssoc,
+    FullyAssoc,
+}
+
+impl Default for Assoc {
+    fn default() -> Self {
+        Assoc::FullyAssoc
+    }
 }
 
 /// Substitution plan.
@@ -115,6 +122,7 @@ impl FromStr for Assoc {
             "left" => Ok(Assoc::Left),
             "right" => Ok(Assoc::Right),
             "none" => Ok(Assoc::NonAssoc),
+            "all" => Ok(Assoc::FullyAssoc),
             _ => Err(ParseAssocError { _priv: () }),
         }
     }
@@ -139,10 +147,10 @@ pub fn expand_precedence(input: Grammar) -> NormResult<Grammar> {
     })
 }
 
-/// Determine if an alternative has a precedence annotation.
+/// Determine if a rule has at least one precedence annotation.
 pub fn has_prec_annot(non_term: &NonterminalData) -> bool {
-    // After prevalidation, either each or none of the alternative of a nonterminal have precedence
-    // annotations, so we just have to check the first one.
+    // After prevalidation, either at least the first alternative of a nonterminal have a
+    // precedence annotations, or none have, so we just have to check the first one.
     non_term
         .alternatives
         .first()
@@ -157,39 +165,45 @@ pub fn has_prec_annot(non_term: &NonterminalData) -> bool {
 /// Expand a rule with precedence annotations. As it implies to generate new rules, return a vector
 /// of grammar items.
 fn expand_nonterm(mut nonterm: NonterminalData) -> NormResult<Vec<GrammarItem>> {
-    let alt_with_ann = Vec::with_capacity(nonterm.alternatives.len());
-
-    let (mut lvls, alts_with_ann) = nonterm.alternatives.drain(..).fold(
-        (vec![], alt_with_ann),
-        |(mut lvls, mut acc): (Vec<u32>, Vec<(u32, Option<Assoc>, Alternative)>), mut alt| {
+    let mut lvls: Vec<u32> = Vec::new();
+    let mut alts_with_ann: Vec<(u32, Assoc, Alternative)> =
+        Vec::with_capacity(nonterm.alternatives.len());
+    let _ = nonterm.alternatives.drain(..).fold(
+        (None, Assoc::default()),
+        |(last_lvl, last_assoc): (Option<u32>, Assoc), mut alt| {
             // All the following unsafe `unwrap()`, `panic!()`, etc. should never panic thanks to
-            // prevalidation. Prevalidation must ensure that each alternative is annotated with at
-            // least a precedence level, each precedence annotation must have an argument which
+            // prevalidation. Prevalidation must ensure that at least the first alternative is annotated with at
+            // a precedence level, that each precedence annotation must have an argument which
             // is parsable as an integer, and each optional assoc annotation must have an argument
             // that is either "right", "left" or "none".
 
-            // Extract and remove precedence and associativity annotations
-            let lvl: u32 = {
-                let index = alt
-                    .annotations
-                    .iter()
-                    .position(|ann| ann.id == Atom::from(PREC_ANNOT))
-                    .unwrap();
-                let (_, val) = alt.annotations.remove(index).arg.unwrap();
-                val.parse().unwrap()
-            };
-            let assoc: Option<Assoc> = alt
+            // Extract precedence and associativity annotations
+            let lvl = alt
+                .annotations
+                .iter()
+                .position(|ann| ann.id == Atom::from(PREC_ANNOT))
+                .map(|index| {
+                    let (_, val) = alt.annotations.remove(index).arg.unwrap();
+                    val.parse().unwrap()
+                })
+                .or(last_lvl)
+                .unwrap();
+            let last_lvl = Some(lvl);
+
+            let assoc = alt
                 .annotations
                 .iter()
                 .position(|ann| ann.id == Atom::from(ASSOC_ANNOT))
                 .map(|index| {
                     let (_, val) = alt.annotations.remove(index).arg.unwrap();
                     val.parse().unwrap()
-                });
+                })
+                .unwrap_or(last_assoc);
+            let last_assoc = assoc;
 
-            acc.push((lvl, assoc, alt));
+            alts_with_ann.push((lvl, assoc, alt));
             lvls.push(lvl);
-            (lvls, acc)
+            (last_lvl, last_assoc)
         },
     );
 
@@ -234,19 +248,19 @@ fn expand_nonterm(mut nonterm: NonterminalData) -> NormResult<Vec<GrammarItem>> 
             for (assoc, alt) in &mut alts_with_assoc {
                 let err_msg = "unexpected associativity annotation on the first precedence level";
                 let (subst, dir) = match assoc {
-                    Some(Assoc::Left) => (
+                    Assoc::Left => (
                         Substitution::OneThen(symbol_kind, &nonterm_prev.as_ref().expect(err_msg)),
                         Direction::Forward,
                     ),
-                    Some(Assoc::Right) => (
+                    Assoc::Right => (
                         Substitution::OneThen(symbol_kind, &nonterm_prev.as_ref().expect(err_msg)),
                         Direction::Backward,
                     ),
-                    Some(Assoc::NonAssoc) => (
+                    Assoc::NonAssoc => (
                         Substitution::Every(&nonterm_prev.as_ref().expect(err_msg)),
                         Direction::Forward,
                     ),
-                    None => (Substitution::Every(symbol_kind), Direction::Forward),
+                    Assoc::FullyAssoc => (Substitution::Every(symbol_kind), Direction::Forward),
                 };
                 replace_nonterm(alt, &nonterm.name, subst, dir)
             }

--- a/lalrpop/src/normalize/precedence/test.rs
+++ b/lalrpop/src/normalize/precedence/test.rs
@@ -62,32 +62,30 @@ grammar;
     Expr: u32 = {
        #[precedence(level="1")]
        "const" => 0,
-
-       #[precedence(level="1")]
        "!" <Expr> => 0,
 
        #[precedence(level="2")] #[assoc(side="none")]
        "!!" <Expr> => 0,
 
-       #[precedence(level="2")] #[assoc(side="left")]
+       #[assoc(side="left")]
        "const2" => 0,
 
-       #[precedence(level="2")]
+       #[precedence(level="2")] #[assoc(side="left")]
        <left:Expr> "*" <right:Expr> => 0,
 
-       #[precedence(level="2")] #[assoc(side="right")]
+       #[assoc(side="right")]
        <left:Expr> "/" <right:Expr> => 0,
 
        #[precedence(level="3")] #[assoc(side="left")]
        <left:Expr> "?" <middle:Expr> ":" <right:Expr> => 0,
 
-       #[precedence(level="3")] #[assoc(side="right")]
+       #[assoc(side="right")]
        <left:Expr> "|" <middle:Expr> "-" <right:Expr> => 0,
 
-       #[precedence(level="3")] #[assoc(side="none")]
+       #[assoc(side="none")]
        <left:Expr> "^" <middle:Expr> "$" <right:Expr> => 0,
 
-       #[precedence(level="3")] #[assoc(side="all")]
+       #[assoc(side="all")]
        <left:Expr> "[" <middle:Expr> ";" <right:Expr> => 0,
    }
 "#,
@@ -133,32 +131,28 @@ grammar;
        #[precedence(level="5")] #[assoc(side="left")]
        <left:Expr> "?" <middle:Expr> ":" <right:Expr> => 0,
 
-       #[precedence(level="5")] #[assoc(side="right")]
+       #[assoc(side="right")]
        <left:Expr> "|" <middle:Expr> "-" <right:Expr> => 0,
 
-       #[precedence(level="5")] #[assoc(side="none")]
+       #[assoc(side="none")]
        <left:Expr> "^" <middle:Expr> "$" <right:Expr> => 0,
 
-       #[precedence(level="5")] #[assoc(side="all")]
+       #[assoc(side="all")]
        <left:Expr> "[" <middle:Expr> ";" <right:Expr> => 0,
 
        #[precedence(level="0")]
        "const" => 0,
-
-       #[precedence(level="0")]
        "!" <Expr> => 0,
 
        #[precedence(level="3")]
        #[assoc(side="none")]
        "!!" <Expr> => 0,
 
-       #[precedence(level="3")] #[assoc(side="left")]
+       #[assoc(side="left")]
        "const2" => 0,
-
-       #[precedence(level="3")]
        <left:Expr> "*" <right:Expr> => 0,
 
-       #[precedence(level="3")] #[assoc(side="right")]
+       #[assoc(side="right")]
        <left:Expr> "/" <right:Expr> => 0,
 
           }
@@ -267,7 +261,7 @@ Expr: i32 = {
     <l:Expr> "*" <r:Expr> => l * r,
     <l:Expr> "/" <r:Expr> => l / r,
 
-    #[precedence(lvl="2")]
+    #[precedence(lvl="2")] #[assoc(side="left")]
     <l:Expr> "+" <r:Expr> => l + r,
     <l:Expr> "-" <r:Expr> => l - r,
 };

--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -209,7 +209,7 @@ impl<'grammar> Validator<'grammar> {
                 if ann_prec_opt.is_none() {
                     return_err!(
                         first.span,
-                        "missing precedence annotation on the first element"
+                        "missing precedence annotation on the first alternative"
                     );
                 } else {
                     Ok(())

--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -197,7 +197,27 @@ impl<'grammar> Validator<'grammar> {
         let mut min_lvl = u32::MAX;
         let mut min_prec_ann: Option<&Annotation> = None;
 
-        // Check that all alternatives have a precedence annotation
+        // Check that at least the first alternative has a precedence annotation
+        alternatives
+            .first()
+            .map(|first| {
+                let ann_prec_opt = first
+                    .annotations
+                    .iter()
+                    .find(|ann| ann.id == Atom::from(precedence::PREC_ANNOT));
+
+                if ann_prec_opt.is_none() {
+                    return_err!(
+                        first.span,
+                        "missing precedence annotation on the first element"
+                    );
+                } else {
+                    Ok(())
+                }
+            })
+            .transpose()?;
+
+        // Check that annotations are well-formed
         alternatives.iter().try_for_each(|alt| {
             let ann_prec_opt = alt.annotations.iter().find(|ann| ann.id == Atom::from(precedence::PREC_ANNOT));
             let ann_assoc_opt = alt.annotations.iter().find(|ann| ann.id == Atom::from(precedence::ASSOC_ANNOT));
@@ -222,15 +242,12 @@ impl<'grammar> Validator<'grammar> {
                     None => return_err!(ann_prec.id_span, "missing argument for precedence annotation, expected `{}`", precedence::LVL_ARG),
                 }
             }
-            else {
-                return_err!(alt.span, "missing precedence annotation");
-            }
 
             if let Some(ann_assoc) = ann_assoc_opt {
                 match &ann_assoc.arg {
                     Some((name, value)) if *name == Atom::from(precedence::SIDE_ARG) => {
                         if value.parse::<precedence::Assoc>().is_err() {
-                            return_err!(ann_assoc.id_span, "could not parse the associativity `{}`, expected `left`, `right` or `none`", value);
+                            return_err!(ann_assoc.id_span, "could not parse the associativity `{}`, expected `left`, `right`, `none` or `all`", value);
                         }
                     }
                     Some((name, _)) => return_err!(ann_assoc.id_span, "invalid argument `{}` for associativity annotation, expected `{}`", name, precedence::SIDE_ARG),

--- a/lalrpop/src/normalize/prevalidate/test.rs
+++ b/lalrpop/src/normalize/prevalidate/test.rs
@@ -199,7 +199,7 @@ fn missing_arg_precedence() {
 #[test]
 fn cannot_parse_assoc() {
     check_err(
-        r#"could not parse the associativity `foo`, expected `left`, `right` or `none`"#,
+        r#"could not parse the associativity `foo`, expected `left`, `right`, `none` or `all`"#,
         r#"grammar; Term = { #[precedence(level="1")] #[assoc(side="foo")] "a" => ()};"#,
         r#"                                             ~~~~~~~~~~~~~~~~~             "#,
     );

--- a/lalrpop/src/normalize/prevalidate/test.rs
+++ b/lalrpop/src/normalize/prevalidate/test.rs
@@ -163,9 +163,9 @@ fn alternative_unrecognized_annotation() {
 #[test]
 fn missing_precedence() {
     check_err(
-        r#"missing precedence annotation"#,
-        r#"grammar; Term = { #[precedence(level="1")] "a" => (), "b" => () };"#,
-        r#"                                                      ~~~~~~~~~~   "#,
+        r#"missing precedence annotation on the first alternative"#,
+        r#"grammar; Term = { "a" => (), #[precedence(level="1")] "b" => () };"#,
+        r#"                  ~~~~~~~~~                                       "#,
     );
 }
 


### PR DESCRIPTION
#555 introduced precedence annotations. However, one practical quirk is that one needs to re-specify the precedence on each alternative. Usually, alternatives are grouped by precedence in a grammar, and we could use one annotation for a whole block.

To illustrate the point, here is the calc example of the LALRPOP book with current precedence annotations:

 ```
Expr: i32 = {
    #[precedence(lvl="0")]
    Num,
    #[precedence(lvl="0")]
    "(" <Expr> ")",

    #[precedence(lvl="1")] #[assoc(side="left")]
    <l:Expr> "*" <r:Expr> => l * r,
    #[precedence(lvl="1")] #[assoc(side="left")]
    <l:Expr> "/" <r:Expr> => l / r,

    #[precedence(lvl="2")] #[assoc(side="left")]
    <l:Expr> "+" <r:Expr> => l + r,
    #[precedence(lvl="2")] #[assoc(side="left")]
    <l:Expr> "-" <r:Expr> => l - r,
};
```

Which is a bit verbose. Here is how we can write the same example after this PR:
```
Expr: i32 = {
    #[precedence(lvl="0")]
    Num,
    "(" <Expr> ")",

    #[precedence(lvl="1")] #[assoc(side="left")]
    <l:Expr> "*" <r:Expr> => l * r,
    <l:Expr> "/" <r:Expr> => l / r,

    #[precedence(lvl="2")] #[assoc(side="left")]
    <l:Expr> "+" <r:Expr> => l + r,
    <l:Expr> "-" <r:Expr> => l - r,
};
```

## Rules
- if any alternative has a precedence annotation, the first alternative MUST have a precedence annotation (otherwise, we can't know which level it is)
- a precedence annotation affects all subsequent alternatives, until the next precedence annotation, or the end of the rule
- an associativity annotation affects all subsequent alternatives, until the next associativity annotation OR the next precedence annotation. The rationale is that somehow precedence annotations define blocks in the grammar, and that associativity should be re-specified at the end of such block (or be set to default if not precised), but this design can of course be discussed.

## Default associativity
The default associativity is full associativity. This makes sense because when one write:
```
Expr: ... {
  #[precedence(lvl="0")]
  <Expr> + <Expr> => ...
}
```
Full associativity entails that the alternative has the same semantics as if there were no associativity annotation at all: all `Expr` occurrence refers to the current level.

With this PR, associativity can now be inherited from the last annotation, so it may be useful to have an explicit way of going back to the default associativity. This PR adds a `side="all"` annotation to indicate the default, full associativity.

## Backward compatibility
This change is backward compatible. Since currently all alternatives need to be annotated, our rule on resetting associativity on new precedence annotations enforces that associativity is reset to default (unless specified explicitly) each time, having thus the same semantics as before.