### PR TITLE
Fix inlining of fallible productions

### DIFF
--- a/lalrpop-test/src/inline_fallible.lalrpop
+++ b/lalrpop-test/src/inline_fallible.lalrpop
@@ -1,0 +1,29 @@
+grammar;
+
+pub Inline: i32 =
+    <i:Inlined> => i + 400;
+
+pub MultipleInline: i32 =
+    <i:Inlined> <j:Inlined> => i + j;
+
+pub InlineIntoFallible: i32 =
+    <i:Inlined> =>? Ok(i + 400);
+
+pub ADifferentProductionIsFallible: i32 = {
+    <i:Inlined> => i + 400,
+    "b" =>? Ok(0),
+};
+
+pub RecursiveInline: i32 =
+    <i:RecursivelyInlined> => i + 400;
+
+#[inline]
+Inlined: i32 = {
+    "a1" =>? Ok(10),
+    "a2" => 20,
+};
+
+// to even further obscure the fallible-ness
+#[inline]
+RecursivelyInlined: i32 =
+    "c" <i:Inlined> "d" => 2 * i;

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -110,6 +110,9 @@ lalrpop_mod!(
 /// test for inlining expansion issue #55
 lalrpop_mod!(issue_55);
 
+/// test for inlining of fallible NTs (issue #91)
+lalrpop_mod!(inline_fallible);
+
 /// test for unit action code
 lalrpop_mod!(unit);
 
@@ -839,6 +842,25 @@ fn issue_55_test1() {
     assert!(a.is_empty());
     assert_eq!(b, "Z");
     assert_eq!(c, vec!["X", "Y"]);
+}
+
+#[test]
+fn inline_fallible() {
+    assert!(inline_fallible::InlineParser::new()
+        .parse("a1")
+        .is_ok());
+    assert!(inline_fallible::MultipleInlineParser::new()
+        .parse("a2 a1")
+        .is_ok());
+    assert!(inline_fallible::InlineIntoFallibleParser::new()
+        .parse("a2")
+        .is_ok());
+    assert!(inline_fallible::ADifferentProductionIsFallibleParser::new()
+        .parse("a1")
+        .is_ok());
+    assert!(inline_fallible::RecursiveInlineParser::new()
+        .parse("c a2 d")
+        .is_ok());
 }
 
 #[test]


### PR DESCRIPTION
Fixes #91.  (both bugs mentioned in https://github.com/lalrpop/lalrpop/issues/91#issuecomment-789413948)

#Just2016Things

---

~~**Note:** I believe this may be the first time LALRPOP will ever use the `?` operator in codegen.~~

~~While this certainly is supported by LALRPOP's MSRV of 1.36, theoretically speaking it is still possible for older versions of rust to compile LALRPOP's output files (and so this may technically boost the minimum version of rust required for doing *that*).  That said, it does not change codegen for any existing code that already used to compile.~~

**Edit:** Never mind that.  Minimum required version of Rust to compile the output rust files is *also* 1.36, due to use of the `alloc` crate, so `?` should be fair game.