### PR TITLE
Fix #480 ('use super::' with internal lexer)

### DIFF
--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -87,6 +87,9 @@ lalrpop_mod!(mut_name);
 /// test that uses `super` in paths in various places
 lalrpop_mod!(use_super);
 
+/// regression test for #480 (`use super` with default tokenizer)
+lalrpop_mod!(use_super_internal_tok);
+
 /// Custom error type (issue #113)
 #[derive(Debug, PartialEq)]
 pub struct MyCustomError(char);
@@ -494,6 +497,14 @@ fn loc_empty() {
 #[test]
 fn use_super_test1() {
     util::test(|v| use_super::SParser::new().parse(v), "()", 0);
+}
+
+#[test]
+fn use_super_internal_tok() {
+    assert_eq!(
+        use_super_internal_tok::SParser::new().parse("b").unwrap(),
+        util::CaptureMe,
+    );
 }
 
 #[test]

--- a/lalrpop-test/src/use_super_internal_tok.lalrpop
+++ b/lalrpop-test/src/use_super_internal_tok.lalrpop
@@ -1,0 +1,5 @@
+grammar;
+
+use super::util::CaptureMe as Renamed;
+
+pub S: Renamed = "b" => Renamed;

--- a/lalrpop-test/src/util/mod.rs
+++ b/lalrpop-test/src/util/mod.rs
@@ -109,3 +109,7 @@ pub fn compare_str(actual: &str, expected: &str, msg: &str) {
         panic!("{}", msg);
     }
 }
+
+/// Something that a test can import if it's trying specifically to test imports.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub struct CaptureMe;

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -16,7 +16,7 @@ pub fn compile<W: Write>(
     rust!(out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
     rust!(out, "mod {}intern_token {{", prefix);
     rust!(out, "#![allow(unused_imports)]");
-    out.write_uses("", &grammar)?;
+    out.write_uses("super::", &grammar)?;
     rust!(
         out,
         "pub fn new_builder() -> {}lalrpop_util::lexer::MatcherBuilder {{",


### PR DESCRIPTION
A one-line change to lalrpop/src/lexer/intern_token/mod.rs.  (the rest is tests)

I was surprised to see that the infrastructure was already there, and in fact the correct function was even already in use! Just this argument was wrong.

I found it surprising that this would be the case, so I did some sleuthing into the commit history. The single line modified by this commit was written in this commit: 1b206d166572d5a76baaa2792

This line was probably copied from [this similar line](https://github.com/lalrpop/lalrpop/blob/fc9986c725d908a60b11d8480711afa33f7f3564/lalrpop/src/build/mod.rs#L338) that I believe generates the 'uses' at the very top of the generated grammar file.

You can see the test added for the aforementioned commit here:

https://github.com/lalrpop/lalrpop/pull/223/commits/4ecd594e5104f21c5758ed1266e4321063cf8927#diff-a6e59d678291fca1872fd2212d565242df94e2bf23428bc5135a3a8c7e7bc250

That test had a very simple import of the form `use super::Name;`. This worked, but for the wrong reason; it was causing the internal module to import `Name` indirectly via the `use super::Name` that was generated in the outer module.  Anything of the form `use super::module::Name` or `use super::Name as Renamed;` would fail, however, as `module` and `Name` wouldn't exist at that location.