### PR TITLE
Fix book links (issue #546)

### DIFF
--- a/doc/src/lexer_tutorial/001_lexer_gen.md
+++ b/doc/src/lexer_tutorial/001_lexer_gen.md
@@ -8,7 +8,7 @@ breaking up the input using regular expressions is often called
 **lexing** or **tokenizing**.
 
 If you're comfortable with the idea of a lexer or tokenizer, you may
-wish to skip ahead to the [calculator3](#calculator3) example, which covers
+wish to skip ahead to the [calculator3][calculator3] example, which covers
 parsing bigger expressions, and come back here only when you find you
 want more control. You may also be interested in the
 [tutorial on writing a custom lexer][lexer tutorial].
@@ -336,5 +336,5 @@ match {
 
 
 [lexer tutorial]: index.md
-[calculator2b]: ../../calculator/src/calculator2b.lalrpop
-[calculator3]: ../../calculator/src/calculator3.lalrpop
+[calculator2b]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/calculator2b.lalrpop
+[calculator3]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/calculator3.lalrpop

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -21,7 +21,7 @@ We now have to edit the generated [`calculator/Cargo.toml`][calculator-Cargo.tom
 file to invoke the LALRPOP preprocessor. The resulting file should
 look something like:
 
-[calculator-Cargo.toml]: ../../calculator/Cargo.toml
+[calculator-Cargo.toml]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/Cargo.toml
 
 ```
 [package]

--- a/doc/src/tutorial/002_paren_numbers.md
+++ b/doc/src/tutorial/002_paren_numbers.md
@@ -129,5 +129,5 @@ fn parse<'input>(&self, input: &'input str)
 }
 ```
 
-[calculator1]: ../../calculator/src/calculator1.lalrpop
-[main]: ../../calculator/src/main.rs
+[calculator1]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/calculator1.lalrpop
+[main]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/main.rs

--- a/doc/src/tutorial/003_type_inference.md
+++ b/doc/src/tutorial/003_type_inference.md
@@ -86,5 +86,5 @@ The `<>` expressions also works with struct constructors (like `Foo
 {...}` in examples above). This works out well if the names of your
 parsed values match the names of your struct fields.
 
-[calculator1]: ../../calculator/src/calculator1.lalrpop
-[calculator2]: ../../calculator/src/calculator2.lalrpop
+[calculator1]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/calculator1.lalrpop
+[calculator2]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/calculator2.lalrpop

--- a/doc/src/tutorial/004_full_expressions.md
+++ b/doc/src/tutorial/004_full_expressions.md
@@ -77,4 +77,4 @@ access the parser from other modules. If you get a warning about an
 unused `new()` method on `FooParser`, drop the `pub` from nonterminal
 `Foo`.
 
-[calculator3]: ../../calculator/src/calculator3.lalrpop
+[calculator3]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/calculator3.lalrpop

--- a/doc/src/tutorial/005_building_asts.md
+++ b/doc/src/tutorial/005_building_asts.md
@@ -100,6 +100,6 @@ fn calculator4() {
 }
 ```
 
-[main]: ../../calculator/src/main.rs
-[calculator4]: ../../calculator/src/calculator4.lalrpop
-[astrs]: ../../calculator/src/ast.rs
+[main]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/main.rs
+[calculator4]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/calculator4.lalrpop
+[astrs]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/ast.rs

--- a/doc/src/tutorial/006_macros.md
+++ b/doc/src/tutorial/006_macros.md
@@ -134,6 +134,6 @@ fn calculator5() {
 }
 ```
 
-[main]: ../../calculator/src/main.rs
-[calculator4]: ../../calculator/src/calculator4.lalrpop
-[calculator5]: ../../calculator/src/calculator5.lalrpop
+[main]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/main.rs
+[calculator4]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/calculator4.lalrpop
+[calculator5]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/calculator5.lalrpop

--- a/doc/src/tutorial/007_fallible_actions.md
+++ b/doc/src/tutorial/007_fallible_actions.md
@@ -129,5 +129,5 @@ fn calculator6b() {
 
 There we go! You can find the full grammar in [`calculator6b.lalrpop`][calculator6b].
 
-[calculator6]: ../../calculator/src/calculator6.lalrpop
-[calculator6b]: ../../calculator/src/calculator6b.lalrpop
+[calculator6]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/calculator6.lalrpop
+[calculator6b]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/calculator6b.lalrpop

--- a/doc/src/tutorial/009_state_parameter.md
+++ b/doc/src/tutorial/009_state_parameter.md
@@ -31,6 +31,8 @@ fn calculator8() {
 }
 ```
 
-For a more practical example with a custom tree structure, check out [this parser](https://github.com/lalrpop/lalrpop/blob/master/lalrpop-test/src/expr_arena.lalrpop) using [this structure](https://github.com/lalrpop/lalrpop/blob/master/lalrpop-test/src/expr_arena_ast.rs) to build the AST.
+For a more practical example with a custom tree structure, check out [this parser][expr_arena] using [this structure][expr_arena_ast] to build the AST.
 
 
+[expr_arena]: https://github.com/lalrpop/lalrpop/blob/master/lalrpop-test/src/expr_arena.lalrpop
+[expr_arena_ast]: https://github.com/lalrpop/lalrpop/blob/master/lalrpop-test/src/expr_arena_ast.rs

--- a/doc/src/tutorial/index.md
+++ b/doc/src/tutorial/index.md
@@ -26,4 +26,4 @@ cover when I get time to write about them:
 - Plans for future features
 
 [Crash course on parsers]: ../crash_course.md
-[from here]: https://github.com/lalrpop/lalrpop/blob/master/lalrpop-test/src/main.rs
+[from here]: https://github.com/lalrpop/lalrpop/blob/master/lalrpop-test/src/lib.rs


### PR DESCRIPTION
Fix [books](http://lalrpop.github.io/lalrpop/index.html) link.

https://github.com/lalrpop/lalrpop/issues/546
This issue caused by relative path in markdown. Then I changed relative path to absolute path.

And in [tutorial first page](http://lalrpop.github.io/lalrpop/tutorial/index.html), path is changed main.rs → lib.rs.

I would appreciate it is checked.

Fixes #598 #546