### PR TITLE
Fix the tutorial links

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,4 +21,16 @@ jobs:
           components: rustfmt
       - name: Run tests
         run: ./ci.sh
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: rustup update nightly && rustup default nightly
+    - run: rustup component add rust-docs
+    - run: sh ./tools/ci-install.sh
+    - run: |
+        cd doc/
+        curl -sSLo linkcheck.sh \
+          https://raw.githubusercontent.com/rust-lang/rust/master/src/tools/linkchecker/linkcheck.sh
+        sh linkcheck.sh book
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ members = [
         "lalrpop-util",
         "lalrpop",
 ]
+exclude = [
+        "doc/linkchecker"
+]

--- a/doc/src/lexer_tutorial.md
+++ b/doc/src/lexer_tutorial.md
@@ -1,1 +1,0 @@
-# Lexer Tutorial

--- a/tools/ci-install.sh
+++ b/tools/ci-install.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 #
-# This script runs on travis to prep the CI as needed.
+# This script runs on Actions to prep the CI as needed.
+
+MDBOOK_VER=0.4.7
 
 if command -v mdbook >/dev/null 2>&1; then
     echo "mdbook already installed at $(command -v mdbook)"
 else
     echo "installing mdbook"
-    cargo install mdbook --vers "0.4.7"
+    mkdir mdbook
+    curl -Lf https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VER}/mdbook-v${MDBOOK_VER}-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+    echo `pwd`/mdbook >> $GITHUB_PATH
 fi
 


### PR DESCRIPTION
All the page links on this page were broken: http://lalrpop.github.io/lalrpop/tutorial/index.html

It appears that this is because of a duplicate tutorial/ component, so I deleted it and it seems right now.