### PR TITLE
Fix LALRPOP book site-url option

### DIFF
--- a/doc/book.toml
+++ b/doc/book.toml
@@ -5,6 +5,7 @@ authors = ["LALRPOP Developers"]
 
 [output.html]
 mathjax-support = true
+site-url = "/lalrpop/"
 
 [output.html.playpen]
 editable = true


### PR DESCRIPTION
Fixes #617 

With this fix, mdBook will generate the line `<base href="/lalrpop/">` instead of `<base href="/">` in the 404.html file.