### PR TITLE
Fix #573

### DIFF
--- a/lalrpop-test/src/lexer_generic.lalrpop
+++ b/lalrpop-test/src/lexer_generic.lalrpop
@@ -1,0 +1,17 @@
+use crate::lexer_generic_lib::{LexerTrait, Token};
+
+grammar<'i, L>(text: &'i str) where L: LexerTrait;
+
+pub Addition: u32 = {
+    <l:num> "+" <r:num> => u32::from(l) + u32::from(r)
+};
+
+extern {
+    type Location = usize;
+    type Error = L::Error;
+
+    enum Token {
+        "+" => Token::Plus,
+        num => Token::Num(_),
+    }
+}

--- a/lalrpop-test/src/lexer_generic_lib.rs
+++ b/lalrpop-test/src/lexer_generic_lib.rs
@@ -1,0 +1,103 @@
+/// Token returned by the lexers
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Token {
+    Num(u32),
+    Plus,
+}
+
+impl From<Token> for u32 {
+    fn from(value: Token) -> Self {
+        match value {
+            Token::Num(num) => num,
+            _ => u32::MAX,
+        }
+    }
+}
+
+/// Generic trait for lexing
+pub trait LexerTrait {
+    /// Type of error returned by the lexer
+    type Error: std::fmt::Debug + std::cmp::PartialEq;
+}
+
+/// A concrete lexer
+#[derive(Clone)]
+pub struct Lexer<'i> {
+    source: &'i str,
+    input: std::iter::Peekable<std::str::CharIndices<'i>>,
+}
+
+impl<'i> Lexer<'i> {
+    pub fn new(source: &'i str) -> Self {
+        Self {
+            source,
+            input: source.char_indices().peekable(),
+        }
+    }
+}
+
+/// Concrete lexer error
+#[derive(Debug, PartialEq)]
+pub struct Error(String);
+
+impl<'i> Iterator for Lexer<'i> {
+    type Item = Result<(usize, Token, usize), Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Try to parse a token
+        loop {
+            if let Some((pos, ch)) = self.input.next() {
+                // Skip over whitespace
+                if ch.is_ascii_whitespace() {
+                    continue;
+                }
+
+                // Scan until next boundary
+                let start = pos;
+                let mut end;
+                loop {
+                    match self.input.peek() {
+                        Some((pos, ch)) => {
+                            end = *pos;
+
+                            if ch.is_ascii_whitespace() {
+                                break;
+                            } else {
+                                self.input.next();
+                            }
+                        }
+                        None => {
+                            end = self.source.len();
+                            break;
+                        }
+                    }
+                }
+
+                // Get slice
+                // SAFETY: the indices where returned by char_indices
+                let slice = unsafe { self.source.get_unchecked(start..end) };
+
+                eprintln!("{:?}", slice);
+
+                return if slice == "+" {
+                    Some(Ok((start, Token::Plus, end)))
+                } else if slice.is_empty() {
+                    return None;
+                } else {
+                    match slice.parse::<u32>() {
+                        Ok(num) => Some(Ok((start, Token::Num(num), end))),
+                        Err(_) => Some(Err(Error(slice.to_owned()))),
+                    }
+                };
+            } else {
+                // End of input
+                return None;
+            }
+        }
+    }
+}
+
+/// Implement LexerTrait
+impl<'i> LexerTrait for Lexer<'i> {
+    type Error = Error;
+}

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -113,6 +113,10 @@ lalrpop_mod!(
 /// test for inlining expansion issue #55
 lalrpop_mod!(issue_55);
 
+/// test for issue #573
+lalrpop_mod!(lexer_generic);
+mod lexer_generic_lib;
+
 /// test for inlining of fallible NTs (issue #91)
 lalrpop_mod!(inline_fallible);
 
@@ -832,6 +836,18 @@ fn error_recovery_span_starts_just_dropped_states() {
     // Here, we drop the `+` in favor of the `-`.
     // Therefore, the span we give is the `+`.
     test_error_recovery_spans("1 + - 4", ". - . .", "1 - 4");
+}
+
+#[test]
+fn lexer_generic_test() {
+    use lexer_generic_lib::Lexer;
+
+    let input = "2 + 3";
+    let lexer = Lexer::new(input);
+    let parser = lexer_generic::AdditionParser::new();
+    let result = parser.parse::<Lexer, _, _>(input, lexer);
+
+    assert_eq!(Ok(5), result);
 }
 
 #[test]

--- a/lalrpop/src/lr1/codegen/test_all.rs
+++ b/lalrpop/src/lr1/codegen/test_all.rs
@@ -124,7 +124,11 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TestAll> {
         let parameters = if non_lifetimes.is_empty() {
             String::new()
         } else {
-            format!("::<{}>", Sep(", ", &non_lifetimes))
+            if self.grammar.intern_token.is_some() {
+                format!("::<{}>", Sep(", ", &non_lifetimes))
+            } else {
+                format!("::<{}, _, _>", Sep(", ", &non_lifetimes))
+            }
         };
         rust!(
             self.out,

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -34071,16 +34071,19 @@ ___5,
 )
 }
 
-pub trait ___ToTriple<'input, > {
+pub trait ___ToTriple<'input, >
+{
 fn to_triple(value: Self) -> Result<(usize,Tok<'input>,usize), ___lalrpop_util::ParseError<usize, Tok<'input>, tok::Error>>;
 }
 
-impl<'input, > ___ToTriple<'input, > for (usize, Tok<'input>, usize) {
+impl<'input, > ___ToTriple<'input, > for (usize, Tok<'input>, usize)
+{
 fn to_triple(value: Self) -> Result<(usize,Tok<'input>,usize), ___lalrpop_util::ParseError<usize, Tok<'input>, tok::Error>> {
 Ok(value)
 }
 }
-impl<'input, > ___ToTriple<'input, > for Result<(usize, Tok<'input>, usize), tok::Error> {
+impl<'input, > ___ToTriple<'input, > for Result<(usize, Tok<'input>, usize), tok::Error>
+{
 fn to_triple(value: Self) -> Result<(usize,Tok<'input>,usize), ___lalrpop_util::ParseError<usize, Tok<'input>, tok::Error>> {
 match value {
 Ok(v) => Ok(v),


### PR DESCRIPTION
When using an external lexer with generic type bounds, those type bounds
where not propagated to the definition of __ToTriple, which this PR
fixes.

This uncovered a bug when generating the parse module as the passed-in
types where not accounting for the 2 extra type parameters for external
token and lexer.