### PR TITLE
Add `#![allow(clippy::all)]` to generated files

### DIFF
--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -165,7 +165,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         rust!(
             self.out,
             "#![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, \
-             unused_imports, unused_parens)]"
+             unused_imports, unused_parens, clippy::all)]"
         );
         rust!(self.out, "");
 

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -17,7 +17,7 @@ extern crate alloc;
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 mod ___parse___Top {
-#![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens)]
+#![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::all)]
 
 use string_cache::DefaultAtom as Atom;
 use grammar::parse_tree::*;


### PR DESCRIPTION
No need to lint generated files.