### PR TITLE
Fix /* */ multiline comment lexer example

### DIFF
--- a/doc/src/lexer_tutorial/001_lexer_gen.md
+++ b/doc/src/lexer_tutorial/001_lexer_gen.md
@@ -330,7 +330,7 @@ To this end `ignore patterns` can be specified.
 match {
     r"\s*" => { }, // The default whitespace skipping is disabled an `ignore pattern` is specified
     r"//[^\n\r]*[\n\r]*" => { }, // Skip `// comments`
-    r"/\*([^\*]*\*+[^\*/])*([^\*]*\*+|[^\*])*\*/" => { },  // Skip `/* comments */`
+    r"/\*[^*]*\*+(?:[^/*][^*]*\*+)*/" => { },  // Skip `/* comments */`
 }
 ```
 


### PR DESCRIPTION
The previous multiline comments example captures everything between the first `/*` and the last `*/` unless I'm mistaken.

See for example below grammar: It parses `/* */ poc1 /* */ poc2` into `poc2`, but it should be `poc1`. This is fixed with the updated regex (from here: https://stackoverflow.com/a/36328890)

```
grammar();

match {
    r"\s*" => { }, // The default whitespace skipping is disabled an `ignore pattern` is specified
    r"//[^\n\r]*[\n\r]*" => { }, // Skip `// comments`
    r"/\*([^\*]*\*+[^\*/])*([^\*]*\*+|[^\*])*\*/" => { },  // Skip `/* comments */`
    _
}

pub Poc: String = {
    <Name> => <>,
    <Name> Poc => <>,
}

Name: String = r"[A-Za-z_][A-Za-z0-9_]*!?" => (<>).to_owned();
```