### PR TITLE
document lalr mode in the advanced settings

### DIFF
--- a/doc/src/advanced_setup.md
+++ b/doc/src/advanced_setup.md
@@ -1,3 +1,5 @@
+### Customizing the Build Process
+
 When you setup LALRPOP, you create a `build.rs` file that looks something
 like this:
 
@@ -29,3 +31,16 @@ fn main() {
         .process_current_dir();
 }
 ```
+
+### Using the Legacy LALR Parser
+
+By default, LALRPOP uses the
+[lane table](../../lalrpop/src/lr1/lane_table/README.md)
+algorithm which is LR(1) but creates much smaller tables. There is no longer
+any clear benefit to using the previous LALR implementation but it is still
+available.
+
+To enable it, build with the `LALRPOP_LANE_TABLE=disabled` environment
+variable by setting `std::env::set_var` in your `build.rs` and add the
+`#[lalr]` attribute above the `grammar;` declaration in your lalrpop grammar
+file.


### PR DESCRIPTION
This fulfills issue #586 and adds a link to the lane table README
for users who are interested in how LALRPOP works.