### PR TITLE
Add mdbook-linkcheck to deploy mdbook

### DIFF
--- a/tools/ci-install.sh
+++ b/tools/ci-install.sh
@@ -9,3 +9,9 @@ else
     cargo install mdbook --vers "0.4.7"
 fi
 
+if command -v mdbook-linkcheck >/dev/null 2>&1; then
+    echo "mdbook-linkcheck already installed at $(command -v mdbook-linkcheck)"
+else
+    echo "installing mdbook-linkcheck"
+    cargo install mdbook-linkcheck --vers "0.7.6"
+fi


### PR DESCRIPTION
In pull request #644 the attribute `output.linkcheck` was added, but the `mdbook-linkcheck` was not installed in the shell script, so the action run [#32](https://github.com/lalrpop/lalrpop/actions/runs/1811895551) fails to deploy the version whose broken links are fixed.
Here I add the installation part of `mdbook-linkcheck` in `ci-install.sh` so the book can be deployed successfully. (It seems that the problem can be solved in another way: set `optional = true` in the `[output.linkcheck]` section, but I didn't choose it here because I thought it would be better to check it again before deployment)