### PR TITLE
CI fixed. Clippy warnings fixed.

### DIFF
--- a/doc/pascal/lalrpop/src/main.rs
+++ b/doc/pascal/lalrpop/src/main.rs
@@ -12,7 +12,7 @@ use pico_args::Arguments;
 
 lalrpop_mod!(pascal);
 
-const USAGE: &'static str = "
+const USAGE: &str = "
 Usage: pascal <inputs>...
 
 Parses each input file.
@@ -52,7 +52,7 @@ fn main() {
         let time_stamp = Instant::now();
         let result = pascal::fileParser::new().parse(&s);
         let elapsed = time_stamp.elapsed();
-        let elapsed = elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1000_000_000.0;
+        let elapsed = elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1_000_000_000.0;
 
         match result {
             Ok(()) => println!("Input `{}` ({}s): OK", input.display(), elapsed),

--- a/doc/whitespace/src/ast.rs
+++ b/doc/whitespace/src/ast.rs
@@ -114,7 +114,7 @@ impl<'program> Interpreter<'program> {
     fn pop(&mut self) -> Result<Int, String> {
         match self.stack.pop() {
             Some(n) => Ok(n),
-            None => Err(format!("Stack underflow")),
+            None => Err("Stack underflow".to_string()),
         }
     }
 }

--- a/doc/whitespace/src/main.rs
+++ b/doc/whitespace/src/main.rs
@@ -9,9 +9,9 @@ fn main() {
             use std::fs::File;
 
             File::open(&filename)
-                .expect(&format!("Can't open {}", &filename))
+                .unwrap_or_else(|_| panic!("Can't open {}", &filename))
                 .read_to_string(&mut source)
-                .expect(&format!("Can't read contents of {}", &filename));
+                .unwrap_or_else(|_| panic!("Can't read contents of {}", &filename));
         }
 
         None => {

--- a/lalrpop/src/api/mod.rs
+++ b/lalrpop/src/api/mod.rs
@@ -222,7 +222,7 @@ impl Configuration {
                         if feature_var.starts_with(prefix) {
                             Some(
                                 feature_var[prefix.len()..]
-                                    .replace("_", "-")
+                                    .replace('_', "-")
                                     .to_ascii_lowercase(),
                             )
                         } else {

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -108,7 +108,7 @@ fn process_file_into(
     report_file: &Path,
 ) -> io::Result<()> {
     session.emit_rerun_directive(lalrpop_file);
-    if session.force_build || needs_rebuild(&lalrpop_file, &rs_file)? {
+    if session.force_build || needs_rebuild(lalrpop_file, rs_file)? {
         log!(
             session,
             Informative,
@@ -118,7 +118,7 @@ fn process_file_into(
         if let Some(parent) = rs_file.parent() {
             fs::create_dir_all(parent)?;
         }
-        remove_old_file(&rs_file)?;
+        remove_old_file(rs_file)?;
 
         // Load the LALRPOP source text for this file:
         let file_text = Rc::new(FileText::from_path(lalrpop_file.to_path_buf())?);
@@ -136,10 +136,10 @@ fn process_file_into(
         // file behind.
         {
             let grammar = parse_and_normalize_grammar(&session, &file_text)?;
-            let buffer = emit_recursive_ascent(&session, &grammar, &report_file)?;
+            let buffer = emit_recursive_ascent(&session, &grammar, report_file)?;
             let mut output_file = fs::File::create(&rs_file)?;
             writeln!(output_file, "{}", LALRPOP_VERSION_HEADER)?;
-            writeln!(output_file, "{}", hash_file(&lalrpop_file)?)?;
+            writeln!(output_file, "{}", hash_file(lalrpop_file)?)?;
             output_file.write_all(&buffer)?;
         }
     }
@@ -170,7 +170,7 @@ fn needs_rebuild(lalrpop_file: &Path, rs_file: &Path) -> io::Result<bool> {
             f.read_line(&mut version_str)?;
             f.read_line(&mut hash_str)?;
 
-            Ok(hash_str.trim() != hash_file(&lalrpop_file)?
+            Ok(hash_str.trim() != hash_file(lalrpop_file)?
                 || version_str.trim() != LALRPOP_VERSION_HEADER)
         }
         Err(e) => match e.kind() {
@@ -218,7 +218,7 @@ fn parse_and_normalize_grammar(session: &Session, file_text: &FileText) -> io::R
         Err(ParseError::InvalidToken { location }) => {
             let ch = file_text.text()[location..].chars().next().unwrap();
             report_error(
-                &file_text,
+                file_text,
                 pt::Span(location, location),
                 &format!("invalid character `{}`", ch),
             );
@@ -226,7 +226,7 @@ fn parse_and_normalize_grammar(session: &Session, file_text: &FileText) -> io::R
 
         Err(ParseError::UnrecognizedEOF { location, .. }) => {
             report_error(
-                &file_text,
+                file_text,
                 pt::Span(location, location),
                 "unexpected end of file",
             );
@@ -239,7 +239,7 @@ fn parse_and_normalize_grammar(session: &Session, file_text: &FileText) -> io::R
             let _ = expected; // didn't implement this yet :)
             let text = &file_text.text()[lo..hi];
             report_error(
-                &file_text,
+                file_text,
                 pt::Span(lo, hi),
                 &format!("unexpected token: `{}`", text),
             );
@@ -248,7 +248,7 @@ fn parse_and_normalize_grammar(session: &Session, file_text: &FileText) -> io::R
         Err(ParseError::ExtraToken { token: (lo, _, hi) }) => {
             let text = &file_text.text()[lo..hi];
             report_error(
-                &file_text,
+                file_text,
                 pt::Span(lo, hi),
                 &format!("extra token at end of input: `{}`", text),
             );
@@ -275,7 +275,7 @@ fn parse_and_normalize_grammar(session: &Session, file_text: &FileText) -> io::R
             };
 
             report_error(
-                &file_text,
+                file_text,
                 pt::Span(error.location, error.location + 1),
                 string,
             )
@@ -284,7 +284,7 @@ fn parse_and_normalize_grammar(session: &Session, file_text: &FileText) -> io::R
 
     match normalize::normalize(session, grammar) {
         Ok(grammar) => Ok(grammar),
-        Err(error) => report_error(&file_text, error.span, &error.message),
+        Err(error) => report_error(file_text, error.span, &error.message),
     }
 }
 
@@ -388,7 +388,7 @@ fn emit_recursive_ascent(
 
         let _lr1_tls = lr1::Lr1Tls::install(grammar.terminals.clone());
 
-        let lr1result = lr1::build_states(&grammar, start_nt.clone());
+        let lr1result = lr1::build_states(grammar, start_nt.clone());
         if session.emit_report {
             let mut output_report_file = fs::File::create(&report_file)?;
             lr1::generate_report(&mut output_report_file, &lr1result)?;
@@ -397,7 +397,7 @@ fn emit_recursive_ascent(
         let states = match lr1result {
             Ok(states) => states,
             Err(error) => {
-                let messages = lr1::report_error(&grammar, &error);
+                let messages = lr1::report_error(grammar, &error);
                 let _ = report_messages(messages);
                 exit(1) // FIXME -- propagate up instead of calling `exit`
             }
@@ -405,7 +405,7 @@ fn emit_recursive_ascent(
 
         match grammar.algorithm.codegen {
             r::LrCodeGeneration::RecursiveAscent => lr1::codegen::ascent::compile(
-                &grammar,
+                grammar,
                 user_nt.clone(),
                 start_nt.clone(),
                 &states,
@@ -413,7 +413,7 @@ fn emit_recursive_ascent(
                 &mut rust,
             )?,
             r::LrCodeGeneration::TableDriven => lr1::codegen::parse_table::compile(
-                &grammar,
+                grammar,
                 user_nt.clone(),
                 start_nt.clone(),
                 &states,
@@ -422,7 +422,7 @@ fn emit_recursive_ascent(
             )?,
 
             r::LrCodeGeneration::TestAll => lr1::codegen::test_all::compile(
-                &grammar,
+                grammar,
                 user_nt.clone(),
                 start_nt.clone(),
                 &states,
@@ -433,7 +433,7 @@ fn emit_recursive_ascent(
         rust!(
             rust,
             "{}use self::{}parse{}::{}Parser;",
-            grammar.nonterminals[&user_nt].visibility,
+            grammar.nonterminals[user_nt].visibility,
             grammar.prefix,
             start_nt,
             user_nt
@@ -441,7 +441,7 @@ fn emit_recursive_ascent(
     }
 
     if let Some(ref intern_token) = grammar.intern_token {
-        intern_token::compile(&grammar, intern_token, &mut rust)?;
+        intern_token::compile(grammar, intern_token, &mut rust)?;
         rust!(
             rust,
             "pub(crate) use self::{}lalrpop_util::lexer::Token;",

--- a/lalrpop/src/grammar/parse_tree.rs
+++ b/lalrpop/src/grammar/parse_tree.rs
@@ -1203,13 +1203,13 @@ impl Path {
 
 pub fn read_algorithm(annotations: &[Annotation], algorithm: &mut r::Algorithm) {
     for annotation in annotations {
-        if annotation.id == Atom::from(LALR) {
+        if annotation.id == *LALR {
             algorithm.lalr = true;
-        } else if annotation.id == Atom::from(TABLE_DRIVEN) {
+        } else if annotation.id == *TABLE_DRIVEN {
             algorithm.codegen = r::LrCodeGeneration::TableDriven;
-        } else if annotation.id == Atom::from(RECURSIVE_ASCENT) {
+        } else if annotation.id == *RECURSIVE_ASCENT {
             algorithm.codegen = r::LrCodeGeneration::RecursiveAscent;
-        } else if annotation.id == Atom::from(TEST_ALL) {
+        } else if annotation.id == *TEST_ALL {
             algorithm.codegen = r::LrCodeGeneration::TestAll;
         } else {
             panic!(

--- a/lalrpop/src/grammar/repr.rs
+++ b/lalrpop/src/grammar/repr.rs
@@ -388,7 +388,7 @@ impl Types {
         };
 
         let args = vec![
-            types.terminal_loc_type().clone(),
+            types.terminal_loc_type(),
             types.terminal_token_type().clone(),
             types.error_type(),
         ];
@@ -450,7 +450,7 @@ impl Types {
 
     pub fn terminal_type(&self, id: &TerminalString) -> &TypeRepr {
         self.terminal_types
-            .get(&id)
+            .get(id)
             .unwrap_or(&self.terminal_token_type)
     }
 
@@ -459,11 +459,11 @@ impl Types {
     }
 
     pub fn lookup_nonterminal_type(&self, id: &NonterminalString) -> Option<&TypeRepr> {
-        self.nonterminal_types.get(&id)
+        self.nonterminal_types.get(id)
     }
 
     pub fn nonterminal_type(&self, id: &NonterminalString) -> &TypeRepr {
-        &self.nonterminal_types[&id]
+        &self.nonterminal_types[id]
     }
 
     pub fn nonterminal_types(&self) -> Vec<TypeRepr> {

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -16,7 +16,7 @@ pub fn compile<W: Write>(
     rust!(out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
     rust!(out, "mod {}intern_token {{", prefix);
     rust!(out, "#![allow(unused_imports)]");
-    out.write_uses("super::", &grammar)?;
+    out.write_uses("super::", grammar)?;
     rust!(
         out,
         "pub fn new_builder() -> {}lalrpop_util::lexer::MatcherBuilder {{",
@@ -31,8 +31,8 @@ pub fn compile<W: Write>(
         .map(|match_entry| {
             (
                 match match_entry.match_literal {
-                    TerminalLiteral::Quoted(ref s) => re::parse_literal(&s),
-                    TerminalLiteral::Regex(ref s) => re::parse_regex(&s).unwrap(),
+                    TerminalLiteral::Quoted(ref s) => re::parse_literal(s),
+                    TerminalLiteral::Regex(ref s) => re::parse_regex(s).unwrap(),
                 },
                 match match_entry.user_name {
                     MatchMapping::Terminal(_) => false,

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -335,7 +335,7 @@ impl LookaheadBuild for Nil {
         _remainder: &[Symbol],
         lookahead: &Nil,
     ) -> Vec<LR0Item<'grammar>> {
-        lr.items(nt, 0, &lookahead)
+        lr.items(nt, 0, lookahead)
     }
 }
 

--- a/lalrpop/src/lr1/build/test.rs
+++ b/lalrpop/src/lr1/build/test.rs
@@ -21,7 +21,7 @@ const ITERATIONS: usize = 22;
 fn random_test<'g>(grammar: &Grammar, states: &'g [LR1State<'g>], start_symbol: NonterminalString) {
     for i in 0..ITERATIONS {
         let input_tree = generate::random_parse_tree(grammar, start_symbol.clone());
-        let output_tree = interpret(&states, input_tree.terminals()).unwrap();
+        let output_tree = interpret(states, input_tree.terminals()).unwrap();
 
         println!("test {}", i);
         println!("input_tree = {}", input_tree);
@@ -39,7 +39,7 @@ macro_rules! tokens {
 
 fn items<'g>(grammar: &'g Grammar, nonterminal: &str, index: usize, la: Token) -> LR1Items<'g> {
     let set = TokenSet::from(la);
-    let lr1: LR<TokenSet> = LR::new(&grammar, nt(nonterminal), set.clone());
+    let lr1: LR<TokenSet> = LR::new(grammar, nt(nonterminal), set.clone());
     let items = lr1.transitive_closure(lr1.items(&nt(nonterminal), index, &set));
     items
 }

--- a/lalrpop/src/lr1/build_lalr/mod.rs
+++ b/lalrpop/src/lr1/build_lalr/mod.rs
@@ -7,7 +7,7 @@ use crate::lr1::core::*;
 use crate::lr1::lookahead::*;
 use crate::tls::Tls;
 use itertools::Itertools;
-use std::mem;
+
 
 #[cfg(test)]
 mod test;
@@ -93,7 +93,7 @@ pub fn collapse_to_lalr_states<'grammar>(lr_states: &[LR1State<'grammar>]) -> LR
     //
     //     X = "(" (*) ")" ["Foo", "Bar"]
     for lalr1_state in &mut lalr1_states {
-        let items = mem::replace(&mut lalr1_state.items, vec![]);
+        let items = std::mem::take(&mut lalr1_state.items);
 
         let items: Multimap<LR0Item<'grammar>, TokenSet> = items
             .into_iter()
@@ -148,7 +148,7 @@ pub fn collapse_to_lalr_states<'grammar>(lr_states: &[LR1State<'grammar>]) -> LR
 
     let conflicts: Vec<_> = lr1_states
         .iter()
-        .flat_map(|s| TokenSet::conflicts(s))
+        .flat_map(TokenSet::conflicts)
         .collect();
 
     if !conflicts.is_empty() {

--- a/lalrpop/src/lr1/codegen/ascent.rs
+++ b/lalrpop/src/lr1/codegen/ascent.rs
@@ -25,7 +25,7 @@ pub fn compile<'grammar, W: Write>(
     action_module: &str,
     out: &mut RustWrite<W>,
 ) -> io::Result<()> {
-    let graph = StateGraph::new(&states);
+    let graph = StateGraph::new(states);
     let mut ascent = CodeGenerator::new_ascent(
         grammar,
         user_start_symbol,
@@ -641,7 +641,7 @@ impl<'ascent, 'grammar, W: Write>
                 self.prefix,
                 i,
                 self.types
-                    .spanned_type(optional_prefix[i].ty(&self.types).clone()),
+                    .spanned_type(optional_prefix[i].ty(self.types).clone()),
             )
         });
 
@@ -652,7 +652,7 @@ impl<'ascent, 'grammar, W: Write>
                 self.prefix,
                 optional_prefix.len() + i,
                 self.types
-                    .spanned_type(fixed_prefix[i].ty(&self.types).clone())
+                    .spanned_type(fixed_prefix[i].ty(self.types).clone())
             )
         });
 

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -179,7 +179,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
 
     pub fn write_uses(&mut self) -> io::Result<()> {
         self.out
-            .write_uses(&format!("{}::", self.action_module), &self.grammar)?;
+            .write_uses(&format!("{}::", self.action_module), self.grammar)?;
 
         if self.grammar.intern_token.is_some() {
             rust!(

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -485,7 +485,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
             // Write an action for each terminal (either shift, reduce, or error).
             let custom = &self.custom;
             let iterator = self.grammar.terminals.all.iter().map(|terminal| {
-                if let Some(new_state) = state.shifts.get(&terminal) {
+                if let Some(new_state) = state.shifts.get(terminal) {
                     (
                         new_state.0 as i32 + 1,
                         Comment::Goto(Token::Terminal(terminal.clone()), new_state.0),

--- a/lalrpop/src/lr1/codegen/test_all.rs
+++ b/lalrpop/src/lr1/codegen/test_all.rs
@@ -123,12 +123,10 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TestAll> {
             .collect();
         let parameters = if non_lifetimes.is_empty() {
             String::new()
+        } else if self.grammar.intern_token.is_some() {
+            format!("::<{}>", Sep(", ", &non_lifetimes))
         } else {
-            if self.grammar.intern_token.is_some() {
-                format!("::<{}>", Sep(", ", &non_lifetimes))
-            } else {
-                format!("::<{}, _, _>", Sep(", ", &non_lifetimes))
-            }
+            format!("::<{}, _, _>", Sep(", ", &non_lifetimes))
         };
         rust!(
             self.out,

--- a/lalrpop/src/lr1/example/mod.rs
+++ b/lalrpop/src/lr1/example/mod.rs
@@ -304,7 +304,7 @@ impl Example {
 
         // Write the labels on top:
         //    A1   B2  C3  D4 E5 F6
-        self.paint_symbols_on(&self.symbols, &positions, styles, view);
+        self.paint_symbols_on(&self.symbols, positions, styles, view);
     }
 
     fn paint_symbols_on(

--- a/lalrpop/src/lr1/first/mod.rs
+++ b/lalrpop/src/lr1/first/mod.rs
@@ -89,7 +89,7 @@ impl FirstSets {
         let epsilon = set.take_eof();
 
         if epsilon {
-            set.union_with(&lookahead);
+            set.union_with(lookahead);
         }
 
         set

--- a/lalrpop/src/lr1/lane_table/construct/merge.rs
+++ b/lalrpop/src/lr1/lane_table/construct/merge.rs
@@ -101,7 +101,7 @@ impl<'m, 'grammar> Merge<'m, 'grammar> {
                     self.clones
                         .get(&successor)
                         .into_iter()
-                        .flat_map(|clones| clones) // get() returns an Option<Set>
+                        .flatten() // get() returns an Option<Set>
                         .cloned()
                         .find(|&successor1| context_sets.union(state, successor1))
                 };

--- a/lalrpop/src/lr1/lane_table/construct/mod.rs
+++ b/lalrpop/src/lr1/lane_table/construct/mod.rs
@@ -84,7 +84,7 @@ impl<'grammar> LaneTableConstruct<'grammar> {
                     );
                     let conflicts: Vec<Conflict<'grammar, TokenSet>> = states
                         .iter()
-                        .flat_map(|s| Lookahead::conflicts(&s))
+                        .flat_map(Lookahead::conflicts)
                         .collect();
                     return Err(TableConstructionError { states, conflicts });
                 }

--- a/lalrpop/src/lr1/lane_table/table/context_set/mod.rs
+++ b/lalrpop/src/lr1/lane_table/table/context_set/mod.rs
@@ -75,12 +75,12 @@ impl ContextSet {
         set: &TokenSet,
     ) -> Result<bool, OverlappingLookahead> {
         for (value, index) in self.values.iter().zip((0..).map(ConflictIndex::new)) {
-            if index != conflict && value.is_intersecting(&set) {
+            if index != conflict && value.is_intersecting(set) {
                 return Err(OverlappingLookahead);
             }
         }
 
-        Ok(self.values[conflict.index].union_with(&set))
+        Ok(self.values[conflict.index].union_with(set))
     }
 
     pub fn apply<'grammar>(&self, state: &mut LR1State<'grammar>, actions: &Set<Action<'grammar>>) {

--- a/lalrpop/src/lr1/lane_table/table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/table/mod.rs
@@ -56,7 +56,7 @@ impl<'grammar> LaneTable<'grammar> {
         self.lookaheads
             .entry((state, conflict))
             .or_insert_with(TokenSet::new)
-            .union_with(&tokens);
+            .union_with(tokens);
     }
 
     pub fn add_successor(&mut self, state: StateIndex, succ: StateIndex) {

--- a/lalrpop/src/lr1/lane_table/test.rs
+++ b/lalrpop/src/lr1/lane_table/test.rs
@@ -108,7 +108,7 @@ fn build_table<'grammar>(
     goal: &str,
     tokens: &[&str],
 ) -> LaneTable<'grammar> {
-    let lr0_err = build::build_lr0_states(&grammar, nt(goal)).unwrap_err();
+    let lr0_err = build::build_lr0_states(grammar, nt(goal)).unwrap_err();
 
     // Push the `tokens` to find the index of the inconsistent state
     let inconsistent_state_index = traverse(&lr0_err.states, tokens);
@@ -122,10 +122,10 @@ fn build_table<'grammar>(
     // Extract conflicting items and trace the lanes, constructing a table
     let conflicting_items = super::conflicting_actions(inconsistent_state);
     println!("conflicting_items={:#?}", conflicting_items);
-    let first_sets = FirstSets::new(&grammar);
+    let first_sets = FirstSets::new(grammar);
     let state_graph = StateGraph::new(&lr0_err.states);
     let mut tracer = LaneTracer::new(
-        &grammar,
+        grammar,
         nt("G"),
         &lr0_err.states,
         &first_sets,

--- a/lalrpop/src/lr1/mod.rs
+++ b/lalrpop/src/lr1/mod.rs
@@ -55,7 +55,7 @@ fn rewrite_state_indices(grammar: &Grammar, states: &mut [core::LR1State]) {
         if grammar
             .nonterminals
             .keys()
-            .any(|nonterminal| state.gotos.get(&nonterminal).is_some())
+            .any(|nonterminal| state.gotos.get(nonterminal).is_some())
         {
             start_states[index] = true;
         }

--- a/lalrpop/src/lr1/report/mod.rs
+++ b/lalrpop/src/lr1/report/mod.rs
@@ -14,7 +14,7 @@ pub fn generate_report<'grammar, W: Write + 'grammar>(
     generator.report_lr_table_construction(lr1result)
 }
 
-static INDENT_STRING: &'static str = "    ";
+static INDENT_STRING: &str = "    ";
 
 struct ReportGenerator<'report, W>
 where
@@ -46,7 +46,7 @@ where
         match lr1result {
             Ok(ref states) => {
                 writeln!(self.out, "Constructed {} states", states.len())?;
-                self.report_states(&states, &Map::new())?;
+                self.report_states(states, &Map::new())?;
             }
             Err(ref table_construction_error) => {
                 writeln!(self.out, "Failure")?;
@@ -113,7 +113,7 @@ where
         self.write_section_header("State Table")?;
         for state in states {
             writeln!(self.out)?;
-            self.report_state(&state, conflict_map.get(&state.index))?;
+            self.report_state(state, conflict_map.get(&state.index))?;
         }
         Ok(())
     }
@@ -346,20 +346,20 @@ trait LookaheadPrinter<W>
 where
     W: Write,
 {
-    fn print<'report>(self: &Self, out: &'report mut W) -> io::Result<()>;
+    fn print<'report>(&self, out: &'report mut W) -> io::Result<()>;
 
-    fn has_anything_to_print(self: &Self) -> bool;
+    fn has_anything_to_print(&self) -> bool;
 }
 
 impl<W> LookaheadPrinter<W> for Nil
 where
     W: Write,
 {
-    fn print<'report>(self: &Self, _: &'report mut W) -> io::Result<()> {
+    fn print<'report>(&self, _: &'report mut W) -> io::Result<()> {
         Ok(())
     }
 
-    fn has_anything_to_print(self: &Self) -> bool {
+    fn has_anything_to_print(&self) -> bool {
         false
     }
 }
@@ -368,14 +368,14 @@ impl<W> LookaheadPrinter<W> for TokenSet
 where
     W: Write,
 {
-    fn print<'report>(self: &Self, out: &'report mut W) -> io::Result<()> {
+    fn print<'report>(&self, out: &'report mut W) -> io::Result<()> {
         for i in self.iter() {
             write!(out, " {}", i)?
         }
         Ok(())
     }
 
-    fn has_anything_to_print(self: &Self) -> bool {
+    fn has_anything_to_print(&self) -> bool {
         self.len() > 0
     }
 }

--- a/lalrpop/src/lr1/trace/reduce/test.rs
+++ b/lalrpop/src/lr1/trace/reduce/test.rs
@@ -73,9 +73,7 @@ fn backtrace1() {
     let semi_item = states[top_state.0]
         .items
         .vec
-        .iter()
-        .filter(|item| item.lookahead.contains(&semi))
-        .next()
+        .iter().find(|item| item.lookahead.contains(&semi))
         .unwrap();
 
     let backtrace = tracer.backtrace_reduce(top_state, semi_item.to_lr0());
@@ -294,9 +292,7 @@ fn backtrace_filter() {
     let lr1_item = states[top_state.0]
         .items
         .vec
-        .iter()
-        .filter(|item| item.lookahead.contains(&semi))
-        .next()
+        .iter().find(|item| item.lookahead.contains(&semi))
         .unwrap();
 
     let backtrace = tracer.backtrace_reduce(top_state, lr1_item.to_lr0());

--- a/lalrpop/src/main.rs
+++ b/lalrpop/src/main.rs
@@ -11,7 +11,7 @@ use pico_args::Arguments;
 
 use lalrpop::Configuration;
 
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+static VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const USAGE: &str = "
 Usage: lalrpop [options] <inputs>...
@@ -180,7 +180,7 @@ mod test {
     }
 
     fn parse_args_vec(args: &Vec<&str>) -> Args {
-        parse_args(Arguments::from_vec(os_vec(&args))).unwrap()
+        parse_args(Arguments::from_vec(os_vec(args))).unwrap()
     }
 
     #[test]

--- a/lalrpop/src/normalize/inline/graph/mod.rs
+++ b/lalrpop/src/normalize/inline/graph/mod.rs
@@ -110,7 +110,7 @@ impl<'grammar> NonterminalGraph<'grammar> {
             WalkState::Visited => Ok(()),
             WalkState::Visiting => {
                 return_err!(
-                    self.grammar.nonterminals[&nt].span,
+                    self.grammar.nonterminals[nt].span,
                     "cyclic inline directive: `{}` would have to be inlined into itself",
                     nt
                 );

--- a/lalrpop/src/normalize/lower/mod.rs
+++ b/lalrpop/src/normalize/lower/mod.rs
@@ -306,12 +306,12 @@ impl<'s> LowerState<'s> {
             Some(pt::ActionKind::Lookahead) => self.lookahead_action_fn(),
             Some(pt::ActionKind::Lookbehind) => self.lookbehind_action_fn(),
             Some(pt::ActionKind::User(string)) => {
-                self.action_fn(nt_type, false, &expr, &symbols, Some(string))
+                self.action_fn(nt_type, false, expr, symbols, Some(string))
             }
             Some(pt::ActionKind::Fallible(string)) => {
-                self.action_fn(nt_type, true, &expr, &symbols, Some(string))
+                self.action_fn(nt_type, true, expr, symbols, Some(string))
             }
-            None => self.action_fn(nt_type, false, &expr, &symbols, None),
+            None => self.action_fn(nt_type, false, expr, symbols, None),
         }
     }
 

--- a/lalrpop/src/normalize/macro_expand/mod.rs
+++ b/lalrpop/src/normalize/macro_expand/mod.rs
@@ -315,11 +315,11 @@ impl MacroExpander {
     }
 
     fn re_match(&self, span: Span, lhs: &Atom, regex: &Atom) -> NormResult<bool> {
-        let re = match Regex::new(&regex) {
+        let re = match Regex::new(regex) {
             Ok(re) => re,
             Err(err) => return_err!(span, "invalid regular expression `{}`: {}", regex, err),
         };
-        Ok(re.is_match(&lhs))
+        Ok(re.is_match(lhs))
     }
 
     fn macro_expand_symbols(
@@ -455,7 +455,7 @@ impl MacroExpander {
 
                 let plus_repeat = Box::new(RepeatSymbol {
                     op: RepeatOp::Plus,
-                    symbol: repeat.symbol.clone(),
+                    symbol: repeat.symbol,
                 });
 
                 Ok(GrammarItem::Nonterminal(NonterminalData {
@@ -541,7 +541,7 @@ impl MacroExpander {
                                         span,
                                         SymbolKind::Name(
                                             Name::immut(e),
-                                            Box::new(repeat.symbol.clone()),
+                                            Box::new(repeat.symbol),
                                         ),
                                     ),
                                 ],
@@ -573,7 +573,7 @@ impl MacroExpander {
                         Alternative {
                             span,
                             expr: ExprSymbol {
-                                symbols: vec![repeat.symbol.clone()],
+                                symbols: vec![repeat.symbol],
                             },
                             condition: None,
                             action: action("Some(<>)"),

--- a/lalrpop/src/normalize/mod.rs
+++ b/lalrpop/src/normalize/mod.rs
@@ -19,7 +19,7 @@ macro_rules! return_err {
         return Err(NormError {
             message: format!($($args),+),
             span: $span
-        });
+        })
     }
 }
 

--- a/lalrpop/src/normalize/precedence/mod.rs
+++ b/lalrpop/src/normalize/precedence/mod.rs
@@ -157,7 +157,7 @@ pub fn has_prec_annot(non_term: &NonterminalData) -> bool {
         .map(|alt| {
             alt.annotations
                 .iter()
-                .any(|ann| ann.id == Atom::from(PREC_ANNOT) || ann.id == Atom::from(ASSOC_ANNOT))
+                .any(|ann| ann.id == *PREC_ANNOT || ann.id == *ASSOC_ANNOT)
         })
         .unwrap_or(false)
 }
@@ -186,7 +186,7 @@ fn expand_nonterm(mut nonterm: NonterminalData) -> NormResult<Vec<GrammarItem>> 
             let (lvl, last_assoc) = alt
                 .annotations
                 .iter()
-                .position(|ann| ann.id == Atom::from(PREC_ANNOT))
+                .position(|ann| ann.id == *PREC_ANNOT)
                 .map(|index| {
                     let (_, val) = alt.annotations.remove(index).arg.unwrap();
                     (val.parse().unwrap(), Assoc::default())
@@ -196,7 +196,7 @@ fn expand_nonterm(mut nonterm: NonterminalData) -> NormResult<Vec<GrammarItem>> 
             let assoc = alt
                 .annotations
                 .iter()
-                .position(|ann| ann.id == Atom::from(ASSOC_ANNOT))
+                .position(|ann| ann.id == *ASSOC_ANNOT)
                 .map(|index| {
                     let (_, val) = alt.annotations.remove(index).arg.unwrap();
                     val.parse().unwrap()
@@ -209,7 +209,7 @@ fn expand_nonterm(mut nonterm: NonterminalData) -> NormResult<Vec<GrammarItem>> 
         },
     );
 
-    lvls.sort();
+    lvls.sort_unstable();
     lvls.dedup();
 
     let rest = &mut alts_with_ann.into_iter();
@@ -251,15 +251,15 @@ fn expand_nonterm(mut nonterm: NonterminalData) -> NormResult<Vec<GrammarItem>> 
                 let err_msg = "unexpected associativity annotation on the first precedence level";
                 let (subst, dir) = match assoc {
                     Assoc::Left => (
-                        Substitution::OneThen(symbol_kind, &nonterm_prev.as_ref().expect(err_msg)),
+                        Substitution::OneThen(symbol_kind, nonterm_prev.as_ref().expect(err_msg)),
                         Direction::Forward,
                     ),
                     Assoc::Right => (
-                        Substitution::OneThen(symbol_kind, &nonterm_prev.as_ref().expect(err_msg)),
+                        Substitution::OneThen(symbol_kind, nonterm_prev.as_ref().expect(err_msg)),
                         Direction::Backward,
                     ),
                     Assoc::NonAssoc => (
-                        Substitution::Every(&nonterm_prev.as_ref().expect(err_msg)),
+                        Substitution::Every(nonterm_prev.as_ref().expect(err_msg)),
                         Direction::Forward,
                     ),
                     Assoc::FullyAssoc => (Substitution::Every(symbol_kind), Direction::Forward),

--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -184,8 +184,8 @@ impl<'grammar> Validator<'grammar> {
     fn validate_precedence(&self, alternatives: &Vec<Alternative>) -> NormResult<()> {
         let with_precedence = alternatives.iter().any(|alt| {
             alt.annotations.iter().any(|ann| {
-                ann.id == Atom::from(precedence::PREC_ANNOT)
-                    || ann.id == Atom::from(precedence::ASSOC_ANNOT)
+                ann.id == *precedence::PREC_ANNOT
+                    || ann.id == *precedence::ASSOC_ANNOT
             })
         });
 
@@ -204,7 +204,7 @@ impl<'grammar> Validator<'grammar> {
                 let ann_prec_opt = first
                     .annotations
                     .iter()
-                    .find(|ann| ann.id == Atom::from(precedence::PREC_ANNOT));
+                    .find(|ann| ann.id == *precedence::PREC_ANNOT);
 
                 if ann_prec_opt.is_none() {
                     return_err!(
@@ -219,8 +219,8 @@ impl<'grammar> Validator<'grammar> {
 
         // Check that annotations are well-formed
         alternatives.iter().try_for_each(|alt| {
-            let ann_prec_opt = alt.annotations.iter().find(|ann| ann.id == Atom::from(precedence::PREC_ANNOT));
-            let ann_assoc_opt = alt.annotations.iter().find(|ann| ann.id == Atom::from(precedence::ASSOC_ANNOT));
+            let ann_prec_opt = alt.annotations.iter().find(|ann| ann.id == *precedence::PREC_ANNOT);
+            let ann_assoc_opt = alt.annotations.iter().find(|ann| ann.id == *precedence::ASSOC_ANNOT);
 
             if let Some(ann_prec) = ann_prec_opt {
                 match &ann_prec.arg {
@@ -228,10 +228,10 @@ impl<'grammar> Validator<'grammar> {
                         if let Ok(lvl) = value.parse::<u32>() {
                             if lvl < min_lvl {
                                 min_lvl = lvl;
-                                min_prec_ann = ann_assoc_opt.clone();
+                                min_prec_ann = ann_assoc_opt;
                             }
                             else if lvl == min_lvl && min_prec_ann.is_none() && ann_assoc_opt.is_some() {
-                                min_prec_ann = ann_assoc_opt.clone();
+                                min_prec_ann = ann_assoc_opt;
                             }
                         }
                         else {

--- a/lalrpop/src/normalize/prevalidate/test.rs
+++ b/lalrpop/src/normalize/prevalidate/test.rs
@@ -2,7 +2,7 @@ use crate::parser;
 use crate::test_util;
 
 fn check_err(expected_err: &str, grammar: &str, span: &str) {
-    let parsed_grammar = parser::parse_grammar(&grammar).unwrap();
+    let parsed_grammar = parser::parse_grammar(grammar).unwrap();
     let err = super::validate(&parsed_grammar).unwrap_err();
     test_util::check_norm_err(expected_err, span, err);
 }

--- a/lalrpop/src/normalize/resolve/mod.rs
+++ b/lalrpop/src/normalize/resolve/mod.rs
@@ -146,7 +146,7 @@ impl Validator {
         args: &[NonterminalString],
     ) -> NormResult<Map<Atom, Def>> {
         for (index, arg) in args.iter().enumerate() {
-            if args[..index].contains(&arg) {
+            if args[..index].contains(arg) {
                 return_err!(
                     span,
                     "multiple macro arguments declared with the name `{}`",

--- a/lalrpop/src/normalize/token_check/mod.rs
+++ b/lalrpop/src/normalize/token_check/mod.rs
@@ -334,10 +334,10 @@ fn construct(grammar: &mut Grammar, match_block: MatchBlock) -> NormResult<()> {
         precedences.push(Precedence(match_entry.precedence));
         match match_entry.match_literal {
             TerminalLiteral::Quoted(ref s) => {
-                regexs.push(re::parse_literal(&s));
+                regexs.push(re::parse_literal(s));
             }
             TerminalLiteral::Regex(ref s) => {
-                match re::parse_regex(&s) {
+                match re::parse_regex(s) {
                     Ok(regex) => regexs.push(regex),
                     Err(error) => {
                         let literal_span = spans[&match_entry.match_literal];

--- a/lalrpop/src/normalize/token_check/test.rs
+++ b/lalrpop/src/normalize/token_check/test.rs
@@ -6,18 +6,18 @@ use crate::parser;
 use crate::test_util;
 
 fn validate_grammar(grammar: &str) -> NormResult<Grammar> {
-    let parsed_grammar = parser::parse_grammar(&grammar).expect("parse grammar");
+    let parsed_grammar = parser::parse_grammar(grammar).expect("parse grammar");
     let parsed_grammar = resolve(parsed_grammar).expect("resolve");
     super::validate(parsed_grammar)
 }
 
 fn check_err(expected_err: &str, grammar: &str, span: &str) {
-    let err = validate_grammar(&grammar).unwrap_err();
+    let err = validate_grammar(grammar).unwrap_err();
     test_util::check_norm_err(expected_err, span, err);
 }
 
 fn check_intern_token(grammar: &str, expected_tokens: Vec<(&'static str, &'static str)>) {
-    let parsed_grammar = validate_grammar(&grammar).expect("validate");
+    let parsed_grammar = validate_grammar(grammar).expect("validate");
     let intern_token = parsed_grammar.intern_token().expect("intern_token");
     println!("intern_token: {:?}", intern_token);
     for (input, expected_user_name) in expected_tokens {
@@ -160,7 +160,7 @@ fn invalid_match_regex_literal() {
 #[test]
 fn match_catch_all() {
     let grammar = r#"grammar; match { r"(?i)begin" => "BEGIN", _ } X = { "foo", r"foo" };"#;
-    assert!(validate_grammar(&grammar).is_ok())
+    assert!(validate_grammar(grammar).is_ok())
 }
 
 #[test]
@@ -176,7 +176,7 @@ fn complex_match() {
             "ABC" BEGIN => String::from("Success")
         };
 "##;
-    assert!(validate_grammar(&grammar).is_ok())
+    assert!(validate_grammar(grammar).is_ok())
 }
 
 /// Test that overlapping regular expressions are still forbidden within one level

--- a/lalrpop/src/normalize/tyinfer/mod.rs
+++ b/lalrpop/src/normalize/tyinfer/mod.rs
@@ -14,7 +14,7 @@ use string_cache::DefaultAtom as Atom;
 mod test;
 
 pub fn infer_types(grammar: &Grammar) -> NormResult<Types> {
-    let inferencer = TypeInferencer::new(&grammar)?;
+    let inferencer = TypeInferencer::new(grammar)?;
     inferencer.infer_types()
 }
 
@@ -161,8 +161,8 @@ impl<'grammar> TypeInferencer<'grammar> {
             return Ok(repr.clone());
         }
 
-        let nt = self.nonterminals[&id];
-        if self.stack.contains(&id) {
+        let nt = self.nonterminals[id];
+        if self.stack.contains(id) {
             return_err!(
                 nt.span,
                 "cannot infer type of `{}` because it references itself",

--- a/lalrpop/src/normalize/tyinfer/test.rs
+++ b/lalrpop/src/normalize/tyinfer/test.rs
@@ -8,7 +8,7 @@ use string_cache::DefaultAtom as Atom;
 
 fn type_repr(s: &str) -> TypeRepr {
     let type_ref = parser::parse_type_ref(s).unwrap();
-    return type_ref.type_repr();
+    type_ref.type_repr()
 }
 
 fn compare(g1: &str, expected: Vec<(&'static str, &'static str)>) {

--- a/lalrpop/src/parser/test.rs
+++ b/lalrpop/src/parser/test.rs
@@ -15,8 +15,8 @@ fn match_block() {
     ];
 
     for block in blocks {
-        let parsed = parser::parse_grammar(&block)
-            .expect(format!("Invalid grammar; grammar={}", block).as_str());
+        let parsed = parser::parse_grammar(block)
+            .unwrap_or_else(|_| panic!("Invalid grammar; grammar={}", block));
         let first_item = parsed.items.first().expect("has item");
         match *first_item {
             GrammarItem::MatchToken(_) => (), // OK

--- a/lalrpop/src/test_util.rs
+++ b/lalrpop/src/test_util.rs
@@ -51,7 +51,7 @@ pub fn compare<D: Debug, E: Debug>(actual: D, expected: E) {
     /// dummy text.
     fn normalize<'t>(with_spans: &'t str) -> std::borrow::Cow<'t, str> {
         SPAN.with(|span| {
-            span.replace_all(&with_spans, "Span(..)")
+            span.replace_all(with_spans, "Span(..)")
         })
     }
 }
@@ -62,8 +62,8 @@ pub fn normalized_grammar(s: &str) -> r::Grammar {
 
 pub fn check_norm_err(expected_err: &str, span: &str, err: NormError) {
     let expected_err = Regex::new(expected_err).unwrap();
-    let start_index = span.find("~").unwrap();
-    let end_index = span.rfind("~").unwrap() + 1;
+    let start_index = span.find('~').unwrap();
+    let end_index = span.rfind('~').unwrap() + 1;
     assert!(start_index <= end_index);
     assert_eq!(err.span, pt::Span(start_index, end_index));
     assert!(

--- a/lalrpop/src/tok/mod.rs
+++ b/lalrpop/src/tok/mod.rs
@@ -652,7 +652,7 @@ impl<'input> Tokenizer<'input> {
                     .filter(|&&(w, _)| w == word)
                     .map(|&(_, ref t)| t.clone())
                     .next()
-                    .unwrap_or_else(|| {
+                    .unwrap_or({
                         match self.lookahead {
                             Some((_, '<')) => MacroId(word),
                             _ => Id(word),

--- a/lalrpop/src/tok/test.rs
+++ b/lalrpop/src/tok/test.rs
@@ -11,13 +11,13 @@ use self::Expectation::*;
 fn gen_test(input: &str, expected: Vec<(&str, Expectation)>) {
     // use $ to signal EOL because it can be replaced with a single space
     // for spans, and because it applies also to r#XXX# style strings:
-    let input = input.replace("$", "\n");
+    let input = input.replace('$', "\n");
 
     let tokenizer = Tokenizer::new(&input, 0);
     let len = expected.len();
     for (token, (expected_span, expectation)) in tokenizer.zip(expected.into_iter()) {
-        let expected_start = expected_span.find("~").unwrap();
-        let expected_end = expected_span.rfind("~").unwrap() + 1;
+        let expected_start = expected_span.find('~').unwrap();
+        let expected_end = expected_span.rfind('~').unwrap() + 1;
         println!("token: {:?}", token);
         match expectation {
             ExpectTok(expected_tok) => {


### PR DESCRIPTION
## Cargo check (a170459c0692a47d7dc1a0df44e9ec1fbb9efd50)
- Trailing semicolon removed

## Cargo clippy (93ea60027606382ec4d9977b59e13842de1ea0e1)
- Extra referencing removed.
- Extra type annotations removed.
- Extra lifetime annotations removed.
- Extra `clone` removed.

## Motivation

Cargo check failed with `rustc 1.60.0 (7737e0b5c 2022-04-04)`:

```text
warning: trailing semicolon in macro used in expression position
   --> lalrpop/src/normalize/mod.rs:22:11
    |
22  |           });
    |             ^
    |
   ::: lalrpop/src/normalize/token_check/mod.rs:376:13
    |
376 | /             return_err!(
377 | |                 spans[literal0],
378 | |                 "ambiguity detected between the terminal `{}` and the terminal `{}`",
379 | |                 literal0,
380 | |                 literal1
381 | |             )
    | |_____________- in this macro invocation
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `return_err`
    = note: this warning originates in the macro `return_err` (in Nightly builds, run with -Z macro-backtrace for more info)
```