### PR TITLE
Add the lexer feature as a default for lalrpop-util.

### DIFF
--- a/lalrpop-util/Cargo.toml
+++ b/lalrpop-util/Cargo.toml
@@ -14,7 +14,7 @@ regex = { version = "1", optional = true }
 [features]
 lexer = ["regex"]
 std = []
-default = ["std"]
+default = ["std", "lexer"]
 
 [package.metadata.docs.rs]
 features = ["lexer"]


### PR DESCRIPTION
When working through the tutorial, the examples won't compile if
`edition = "2021"` is included in `calculator/Cargo.toml`.

This has been previously report in https://github.com/lalrpop/lalrpop/issues/616 and https://github.com/lalrpop/lalrpop/issues/650.

The issue appears to be related to a new dependency resolver algorithm
used by [default beginning with Rust edition 2021](https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html).

There is further background information on the new resolver algorithm:

-   [release notes for resolver 2 in build 1.51.0](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#cargos-new-feature-resolver)
-   [description of the resolver version 2](https://doc.rust-lang.org/nightly/cargo/reference/features.html#feature-resolver-version-2)

My understanding is that the previous resolver algorithm would merge
features for dependencies, so for the `Cargo.toml` demonstrated in the
tutorial:

```
[build-dependencies]
lalrpop = "0.19.7"

[dependencies]
lalrpop-util = "0.19.7"
```

`lalrpop-util` would end up with the `lexer` feature enabled, because
even though `lalrpop-util` doesn't enable the `lexer` feature by
default, `lalrpop` does enable the `lexer` feature by default.

Using the new dependency resolver algorithm which is default in Rust
2021, having `lexer` as a default feature for `lalrpop` will no longer
cause the feature to be enabled for `lalrpop-util`.

The 'lexer' feature was previously added as a default for lalrpop
(https://github.com/lalrpop/lalrpop/pull/540) so I assume adding the `lexer` as a default feature for `lalrpop-util`
is the desired behavior, rather than just updating the tutorial to add
the `lexer` feature to the `lalrpop-util` dependency.