### PR TITLE
Fix leading zeros in each byte of the sha3 getting dropped

### DIFF
--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -15,9 +15,10 @@ use crate::tls::Tls;
 use crate::tok;
 use crate::util::Sep;
 use atty;
+use itertools::Itertools;
 use lalrpop_util::ParseError;
-use tiny_keccak::Sha3;
 use term;
+use tiny_keccak::{Hasher, Sha3};
 
 use std::fs;
 use std::io::{self, BufRead, Read, Write};
@@ -27,8 +28,6 @@ use std::rc::Rc;
 
 mod action;
 mod fake_term;
-
-use tiny_keccak::Hasher;
 
 use self::fake_term::FakeTerminal;
 
@@ -44,18 +43,14 @@ fn hash_file(file: &Path) -> io::Result<String> {
     let mut file = fs::File::open(&file)?;
     let mut file_bytes = Vec::new();
     file.read_to_end(&mut file_bytes).unwrap();
-    
+
     let mut sha3 = Sha3::v256();
     sha3.update(&file_bytes);
-    
+
     let mut output = [0u8; 32];
     sha3.finalize(&mut output);
 
-    let mut hash_str = "// sha3: ".to_owned();
-    for byte in &output {
-        hash_str.push_str(&format!("{:x}", byte));
-    }
-    Ok(hash_str)
+    Ok(format!("// sha3: {:02x}", output.iter().format("")))
 }
 
 pub fn process_dir<P: AsRef<Path>>(session: Rc<Session>, root_dir: P) -> io::Result<()> {

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.19.7"
-// sha3: bdf56d5cb64e045081b011951e1f7e646042e24364123d199a6d09a6d88
+// sha3: bdf506d5cb64e0045081b011951e1f7e6460042e243641023d1909a6d09a6d88
 use string_cache::DefaultAtom as Atom;
 use grammar::parse_tree::*;
 use grammar::pattern::*;


### PR DESCRIPTION
Was switching from my build script building lalrpop to just verifying that the
generated file is up to date via the sha3 and noticed that the sha3 is
formatted.. very wrong.
