### PR TITLE
Update solang grammar location

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ to! Here are some tips:
 [LALRPOP]: https://github.com/lalrpop/lalrpop/blob/8034f3dacc4b20581bd10c5cb0b4f9faae778bb5/lalrpop/src/parser/lrgrammar.lalrpop
 [Gluon]: https://github.com/gluon-lang/gluon/blob/d7ce3e81c1fcfdf25cdd6d1abde2b6e376b4bf50/parser/src/grammar.lalrpop
 [RustPython]: https://github.com/RustPython/RustPython/blob/master/parser/src/python.lalrpop
-[Solang]: https://github.com/hyperledger-labs/solang/blob/master/src/parser/solidity.lalrpop
+[Solang]: https://github.com/hyperledger-labs/solang/blob/main/solang-parser/src/solidity.lalrpop
 [gitter lobby]: https://gitter.im/lalrpop/Lobby
 
 ### Contributing


### PR DESCRIPTION
The location of the Solidity grammar has changed after a refactor. 
The link to said grammar in the README has been updated.