### PR TITLE
Fix typos

### DIFF
--- a/doc/calculator/src/calculator2b.lalrpop
+++ b/doc/calculator/src/calculator2b.lalrpop
@@ -18,7 +18,7 @@ match {
     r"[0-9]+",
 
     // Within a match level, fixed strings like `"22"` get
-    // precedence over regular expresions.
+    // precedence over regular expressions.
     "22"
 } else {
     // These items have next highest precedence.
@@ -32,7 +32,7 @@ match {
     r"\w+" => ID,
 
     // This `_` means "add in all the other strings and
-    // regular expressions in the grammer here" (e.g.,
+    // regular expressions in the grammar here" (e.g.,
     // `"("`).
     _
 } // you can have more `else` sections if you like

--- a/doc/pascal/yacc/pascal.l
+++ b/doc/pascal/yacc/pascal.l
@@ -136,7 +136,7 @@ NQUOTE [^']
 \n    line_no++;
 
 .    { fprintf (stderr,
-    "'%c' (0%o): illegal charcter at line %d\n",
+    "'%c' (0%o): illegal character at line %d\n",
      yytext[0], yytext[0], line_no);
     }
 

--- a/doc/src/lexer_tutorial/index.md
+++ b/doc/src/lexer_tutorial/index.md
@@ -1,6 +1,6 @@
 # Fine control over the lexer
 
-This part is about controling the inner workings of LALRPOP's built-in lexer generator and using your own hand written parser.
+This part is about controlling the inner workings of LALRPOP's built-in lexer generator and using your own hand written parser.
 
 - [LALRPOP's lexer generator](001_lexer_gen.md)
 - [Writing a custom lexer](002_writing_custom_lexer.md)

--- a/doc/src/tutorial/008_error_recovery.md
+++ b/doc/src/tutorial/008_error_recovery.md
@@ -49,7 +49,7 @@ Term: Box<Expr> = {
 
 Now we can add a test that includes various errors (e.g., missing 
 operands). Note that now the `parse` method takes two arguments 
-instead of one, which is caused by that we rewrote the "grammer" line 
+instead of one, which is caused by that we rewrote the "grammar" line 
 in the LALRPOP file. You can see that the parser recovered from missing 
 operands by inserting this `!` token where necessary.
 

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -1,4 +1,4 @@
-//! Utilies for running in a build script.
+//! Utilities for running in a build script.
 
 use crate::file_text::FileText;
 use crate::grammar::parse_tree as pt;

--- a/lalrpop/src/lr1/build/test.rs
+++ b/lalrpop/src/lr1/build/test.rs
@@ -247,7 +247,7 @@ T: () = {
     assert_eq!(states.len(), 10);
 }
 
-/// Without the artifical '$', grammar is not LR(0).
+/// Without the artificial '$', grammar is not LR(0).
 #[test]
 fn lr0_expr_grammar_with_implicit_eof() {
     let _tls = Tls::test();

--- a/lalrpop/src/lr1/codegen/ascent.rs
+++ b/lalrpop/src/lr1/codegen/ascent.rs
@@ -94,7 +94,7 @@ impl<'grammar> StackSuffix<'grammar> {
     }
 
     /// returns the (optional, fixed) -- number of optional
-    /// items in stack prefix and numer of fixed
+    /// items in stack prefix and number of fixed
     fn optional_fixed_lens(&self) -> (usize, usize) {
         (self.len_optional, self.len() - self.len_optional)
     }
@@ -602,7 +602,7 @@ impl<'ascent, 'grammar, W: Write>
     //
     // Returns a list of argument names and a flag if this fn resulted
     // from pushing a terminal (in which case the lookahead must be
-    // computed interally).
+    // computed internally).
     fn fn_args(
         &mut self,
         optional_prefix: &[Symbol],
@@ -890,10 +890,10 @@ impl<'ascent, 'grammar, W: Write>
             rust!(self.out, "let {p}end = {p}start;", p = self.prefix);
         }
 
-        let transfered_syms = transfer_syms.len();
+        let transferred_syms = transfer_syms.len();
 
         let mut args = transfer_syms;
-        if transfered_syms == 0 {
+        if transferred_syms == 0 {
             args.push(format!("&{}start", self.prefix));
             args.push(format!("&{}end", self.prefix));
         }

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -1084,10 +1084,10 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
             rust!(self.out, "let {p}end = {p}start.clone();", p = self.prefix,);
         }
 
-        let transfered_syms = transfer_syms.len();
+        let transferred_syms = transfer_syms.len();
 
         let mut args = transfer_syms;
-        if transfered_syms == 0 {
+        if transferred_syms == 0 {
             args.push(format!("&{}start", self.prefix));
             args.push(format!("&{}end", self.prefix));
         }
@@ -1527,7 +1527,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
 
         rust!(self.out, "const {}TERMINAL: &[&str] = &[", self.prefix);
         let all_terminals = if self.grammar.uses_error_recovery {
-            // Subtract one to exlude the error terminal
+            // Subtract one to exclude the error terminal
             &self.grammar.terminals.all[..self.grammar.terminals.all.len() - 1]
         } else {
             &self.grammar.terminals.all

--- a/lalrpop/src/lr1/interpret.rs
+++ b/lalrpop/src/lr1/interpret.rs
@@ -1,4 +1,4 @@
-//! LR(1) interpeter. Just builds up parse trees. Intended for testing.
+//! LR(1) interpreter. Just builds up parse trees. Intended for testing.
 
 use crate::generate::ParseTree;
 use crate::grammar::repr::*;

--- a/lalrpop/src/lr1/lane_table/README.md
+++ b/lalrpop/src/lr1/lane_table/README.md
@@ -409,7 +409,7 @@ can merge the conflicts. We find one in S3', and hence we redirect the
 S3 edge to S3' and we are done. (I think the actual search we want is
 to make first look for a clone of S3 that is using literally the same
 context as us (i.e., same root node), as in this case. If that is not
-found, *then* we search for one with a mergable context. If *that*
+found, *then* we search for one with a mergeable context. If *that*
 fails, then we clone a new state.)
 
 The final state thus has two copies of S3, one for the path from S1,

--- a/lalrpop/src/lr1/lane_table/construct/mod.rs
+++ b/lalrpop/src/lr1/lane_table/construct/mod.rs
@@ -172,7 +172,7 @@ impl<'grammar> LaneTableConstruct<'grammar> {
 
         // Construct the initial states; each state will map to a
         // context-set derived from its row in the lane-table. This is
-        // fallible, because a state may be internally inconstent.
+        // fallible, because a state may be internally inconsistent.
         //
         // (To handle unification, we also map each state to a
         // `StateSet` that is its entry in the `ena` table.)

--- a/lalrpop/src/message/test.rs
+++ b/lalrpop/src/message/test.rs
@@ -106,7 +106,7 @@ fn paragraphs() {
         .begin_wrap()
         .text(
             "This is the final paragraph. The reader won't even spare this one \
-             a second glance, despite it containing just waht they need to know \
+             a second glance, despite it containing just what they need to know \
              to solve their problem and to derive greater pleasure from life. \
              The secret: All you need is love! Dum da da dum.",
         )
@@ -139,7 +139,7 @@ fn paragraphs() {
     "  The reader won't even spare",
     "  this one a second glance,",
     "  despite it containing just",
-    "  waht they need to know to",
+    "  what they need to know to",
     "  solve their problem and to",
     "  derive greater pleasure from",
     "  life. The secret: All you",

--- a/lalrpop/src/tok/mod.rs
+++ b/lalrpop/src/tok/mod.rs
@@ -436,7 +436,7 @@ impl<'input> Tokenizer<'input> {
         // This is the interesting case. To find the end of the code,
         // we have to scan ahead, matching (), [], and {}, and looking
         // for a suitable terminator: `,`, `;`, `]`, `}`, or `)`.
-        // Additionaly we had to take into account that we can encounter an character literal
+        // Additionally we had to take into account that we can encounter an character literal
         // equal to one of delimiters.
         let mut balance = 0; // number of unclosed `(` etc
         loop {


### PR DESCRIPTION
Found via `codespell -S target -L crate,dum,numer,atleast`