### PR TITLE
Lex raw identifiers

### DIFF
--- a/lalrpop/src/tok/mod.rs
+++ b/lalrpop/src/tok/mod.rs
@@ -600,6 +600,11 @@ impl<'input> Tokenizer<'input> {
                     None => error(UnterminatedStringLiteral, idx0),
                 }
             }
+            Some(idx1) if matches!(self.lookahead, Some((idx2, c)) if idx1 == idx2 && is_identifier_start(c)) =>
+            {
+                self.bump();
+                self.identifierish(idx0)
+            }
             Some(idx1) => error(ExpectedStringLiteral, idx1),
             None => error(UnterminatedStringLiteral, idx0),
         }
@@ -636,6 +641,10 @@ impl<'input> Tokenizer<'input> {
 
         if word == "_" {
             return Ok((idx0, Underscore, idx0 + 1));
+        }
+
+        if word == "r#_" {
+            return Ok((idx0, Underscore, idx0 + 3));
         }
 
         if word == "use" {

--- a/lalrpop/src/tok/test.rs
+++ b/lalrpop/src/tok/test.rs
@@ -521,19 +521,23 @@ fn code_forgot_comma() {
 #[test]
 fn various_kinds_of_ids() {
     test(
-        "foo<T<'a,U,`Z*{}`>>",
+        "foo<T<'a,U,`Z*{}`,r#type,r#use>>",
         vec![
-            ("~~~                ", MacroId("foo")),
-            ("   ~               ", LessThan),
-            ("    ~              ", MacroId("T")),
-            ("     ~             ", LessThan),
-            ("      ~~           ", Lifetime("'a")),
-            ("        ~          ", Comma),
-            ("         ~         ", Id("U")),
-            ("          ~        ", Comma),
-            ("           ~~~~~~  ", Escape("Z*{}")),
-            ("                 ~ ", GreaterThan),
-            ("                  ~", GreaterThan),
+            ("~~~                             ", MacroId("foo")),
+            ("   ~                            ", LessThan),
+            ("    ~                           ", MacroId("T")),
+            ("     ~                          ", LessThan),
+            ("      ~~                        ", Lifetime("'a")),
+            ("        ~                       ", Comma),
+            ("         ~                      ", Id("U")),
+            ("          ~                     ", Comma),
+            ("           ~~~~~~               ", Escape("Z*{}")),
+            ("                 ~              ", Comma),
+            ("                  ~~~~~~        ", Id("r#type")),
+            ("                        ~       ", Comma),
+            ("                         ~~~~~  ", Id("r#use")),
+            ("                              ~ ", GreaterThan),
+            ("                               ~", GreaterThan),
         ],
     );
 }


### PR DESCRIPTION
Lex raw identifiers (identifiers prefixed with `r#`). Fixes #613 