### PR TITLE
Modify Cargo.toml example to contain edition

### DIFF
--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -33,7 +33,7 @@ authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 lalrpop = "0.20.0"
 
 [dependencies]
-lalrpop-util = "0.20.0"
+lalrpop-util = { version = "0.20.0", features = ["lexer"] }
 ```
 
 Cargo can run [build scripts] as a pre-processing step,

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -28,6 +28,7 @@ look something like:
 name = "calculator"
 version = "0.1.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
+edition = "2021"
 
 [build-dependencies] # <-- We added this and everything after!
 lalrpop = "0.20.0"


### PR DESCRIPTION
## TL;DR

- When I run `cargo init` it produces a `Cargo.toml` file with `edition = "2021"` in it. 

- When I went through [Adding LALRPOP to your Cargo.toml file](https://lalrpop.github.io/lalrpop/tutorial/001_adding_lalrpop.html) in the tutorial I only updated the `[build-dependencies]` and `[dependencies]` sections not thinking about the `edition` in the `[package]` section at all.

- I got a bunch of errors shown below. 

- Three options that fixed the errors for me were:

	1: Changing the edition to "2018" in `Cargo.toml`

	2: Removing the edition from `Cargo.toml`

	3: Keeping the edition at "2021" and adding 
	`lalrpop = "0.19.8"` to the `[dependencies]`
	in the `Cargo.toml` file


I'm still new to Rust, but I don't think I've customized `cargo init` in a way that makes it add the edition. I'm assuming it does that by default now. With that in mind I'm put together this PR which adds the edition to the example and puts `lalrpop` under the dependencies.  


---


Steps to reproduce:

### Step 1 

Run:

```
cargo new --bin calculator
```

and `cd` into the directory with `cd calculator`


### Step 2

Update the `build-dependencies` and `dependencies` 
sections of the `Cargo.toml` file by modifying this
default file that was created:

```toml
[package]
name = "calculator"
version = "0.1.0"
edition = "2021"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

[dependencies]
```

To:

```toml
[package]
name = "calculator"
version = "0.1.0"
edition = "2021"

[build-dependencies] # <-- We added this and everything after!
lalrpop = "0.19.8"

[dependencies]
lalrpop-util = "0.19.8"
regex = "1"
```

### Step 3

Create `build.rs` with

```rust
extern crate lalrpop;

fn main() {
    lalrpop::process_root().unwrap();
}
```

### Step 4

Create `src/calculator1.lalrpop` with:

```rust
use std::str::FromStr;

grammar;

pub Term: i32 = {
    <n:Num> => n,
    "(" <t:Term> ")" => t,
};

Num: i32 = <s:r"[0-9]+"> => i32::from_str(s).unwrap();
```

### Step 5

Change the main.rs file to:

```
#[macro_use]
extern crate lalrpop_util;

fn main() {
    println!("Run `cargo test` to use this file");
}

lalrpop_mod!(pub calculator1); // synthesized by LALRPOP

#[test]
fn calculator1() {
    assert!(calculator1::TermParser::new()
        .parse("22")
        .is_ok());
    assert!(calculator1::TermParser::new()
        .parse("(22)")
        .is_ok());
    assert!(calculator1::TermParser::new()
        .parse("((((22))))")
        .is_ok());
    assert!(calculator1::TermParser::new()
        .parse("((22)")
        .is_err());
}
```

### Step 6

Run:

```
cargo test
```

And see a bunch of errors like:

```
error[E0432]: unresolved import `self::__lalrpop_util::lexer`
   --> /Users/alan/Desktop/tmp/calculator/target/debug/build/calculator-4eb3fb97eeab7b69/out/calculator1.rs:388:38
    |
388 | pub(crate) use self::__lalrpop_util::lexer::Token;
    |                                      ^^^^^ could not find `lexer` in `__lalrpop_util`

error[E0433]: failed to resolve: could not find `lexer` in `__lalrpop_util`
   --> /Users/alan/Desktop/tmp/calculator/target/debug/build/calculator-4eb3fb97eeab7b69/out/calculator1.rs:217:34
    |
217 |         builder: __lalrpop_util::lexer::MatcherBuilder,
    |                                  ^^^^^ could not find `lexer` in `__lalrpop_util`
```


---

### Fix

The option I chose to get the test to run is to change the `Cargo.toml` to add `lalrpop` to `[dependencies]` so the file changes from this:


```toml
[package]
name = "calculator"
version = "0.1.0"
edition = "2021"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

[build-dependencies] # <-- We added this and everything after!
lalrpop = "0.19.8"

[dependencies]
lalrpop-util = "0.19.8"
regex = "1"
```

To this:

```toml
[package]
name = "calculator"
version = "0.1.0"
edition = "2021"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

[build-dependencies] # <-- We added this and everything after!
lalrpop = "0.19.8"

[dependencies]
lalrpop = "0.19.8"
lalrpop-util = "0.19.8"
regex = "1"
```

As far as I can tell that's what needs to happen, but if there's a something better to do I'd be happy to hear about it. 