### PR TITLE
remove gitter, promote discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # LALRPOP
 
-[![Join the chat at https://gitter.im/lalrpop/Lobby](https://badges.gitter.im/lalrpop/Lobby.svg)](https://gitter.im/lalrpop/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
 [![Build status](https://travis-ci.org/lalrpop/lalrpop.svg?branch=master)](https://travis-ci.org/lalrpop/lalrpop)
+
+**Questions?** Ask for help on [Github Discussions](https://github.com/lalrpop/lalrpop/discussions).
 
 LALRPOP is a Rust parser generator framework with *usability* as its
 primary goal. You should be able to write compact, DRY, readable


### PR DESCRIPTION
I'm trying to remove Gitter from my life -- too many chat apps! Also, I can't keep up. I propose we close that room and shift over to GH discussions. I'm open to pushback on this, though, if other folks are getting value out of Gitter.

Thoughts?