### PR TITLE
Avoid spurious expected tokens in error output

### DIFF
--- a/lalrpop-test/src/expected_tokens_reduce.lalrpop
+++ b/lalrpop-test/src/expected_tokens_reduce.lalrpop
@@ -1,0 +1,26 @@
+// Note: an error recovery expression is included below to prevent the recursive
+// ascent parser from being generated. At the time of writing that implementation
+// still has the issue which this code tests for, and running the trigger causes
+// an assert to trigger in generated code when the output of the two parsers are
+// not identical.
+
+grammar;
+
+pub Program: Vec<()> = Commands;
+
+Commands: Vec<()> = (<Command> ";")*;
+
+Command: () = {
+    "case" <_matched:Word> "in" <_cases: (<CaseItem> ";;")*> <_last:CaseItem?> "esac" => (),
+    Word => (),
+};
+
+CaseItem: () = {
+    "("? <_pattern:Word> ")" <_block:Commands> => (),
+    // error recovery is included only for side effects; see comment above
+    "(" ! ")" => unimplemented!(),
+};
+
+Word: () = {
+    r"[A-Z]+" => ()
+};

--- a/lalrpop-test/src/expected_tokens_reduce_lalr.lalrpop
+++ b/lalrpop-test/src/expected_tokens_reduce_lalr.lalrpop
@@ -1,0 +1,26 @@
+// Note: an error recovery expression is included below to prevent the recursive
+// ascent parser from being generated. At the time of writing that implementation
+// still has the issue which this code tests for, and running the trigger causes
+// an assert to trigger in generated code when the output of the two parsers are
+// not identical.
+
+grammar;
+
+pub Program: Vec<()> = Commands;
+
+Commands: Vec<()> = (<Command> ";")*;
+
+Command: () = {
+    "case" <_matched:Word> "in" <_cases: (<CaseItem> ";;")*> <_last:CaseItem?> "esac" => (),
+    Word => (),
+};
+
+CaseItem: () = {
+    "("? <_pattern:Word> ")" <_block:Commands> => (),
+    // error recovery is included only for side effects; see comment above
+    "(" ! ")" => unimplemented!(),
+};
+
+Word: () = {
+    r"[A-Z]+" => ()
+};

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -2987,7 +2987,6 @@ _ => 65,
 _ => 0,
 }
 }
-fn ___expected_tokens(___state: i16) -> alloc::vec::Vec<alloc::string::String> {
 const ___TERMINAL: &[&str] = &[
 r###""!""###,
 r###""!=""###,
@@ -3049,12 +3048,28 @@ r###""{""###,
 r###""}""###,
 r###""~~""###,
 ];
+fn ___expected_tokens(___state: i16) -> alloc::vec::Vec<alloc::string::String> {
 ___TERMINAL.iter().enumerate().filter_map(|(index, terminal)| {
 let next_state = ___action(___state, index);
 if next_state == 0 {
 None
 } else {
 Some(alloc::string::ToString::to_string(terminal))
+}
+}).collect()
+}
+fn ___expected_tokens_from_states<
+    'input,
+>(
+___states: &[i16],
+_: core::marker::PhantomData<(&'input ())>,
+) -> alloc::vec::Vec<alloc::string::String>
+{
+___TERMINAL.iter().enumerate().filter_map(|(index, terminal)| {
+if ___accepts(None, ___states, Some(index), core::marker::PhantomData::<(&())>) {
+Some(alloc::string::ToString::to_string(terminal))
+} else {
+None
 }
 }).collect()
 }
@@ -3121,6 +3136,10 @@ fn expected_tokens(&self, state: i16) -> alloc::vec::Vec<alloc::string::String> 
 ___expected_tokens(state)
 }
 
+fn expected_tokens_from_states(&self, states: &[i16]) -> alloc::vec::Vec<alloc::string::String> {
+___expected_tokens_from_states(states, core::marker::PhantomData::<(&())>)
+}
+
 #[inline]
 fn uses_error_recovery(&self) -> bool {
 false
@@ -3152,7 +3171,7 @@ core::marker::PhantomData::<(&())>,
 }
 
 fn simulate_reduce(&self, action: i16) -> ___state_machine::SimulatedReduce<Self> {
-panic!("error recovery not enabled for this grammar")
+___simulate_reduce(action, core::marker::PhantomData::<(&())>)
 }
 }
 fn ___token_to_integer<
@@ -3242,6 +3261,3078 @@ _ => unreachable!(),
 _ => unreachable!(),
 }
 }
+fn ___simulate_reduce<
+    'input,
+>(
+___reduce_index: i16,
+_: core::marker::PhantomData<(&'input ())>,
+) -> ___state_machine::SimulatedReduce<___StateMachine<'input>>
+{
+match ___reduce_index {
+0 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 0,
+}
+}
+1 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 0,
+}
+}
+2 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 1,
+}
+}
+3 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 1,
+}
+}
+4 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 2,
+}
+}
+5 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 2,
+}
+}
+6 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 3,
+}
+}
+7 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 4,
+}
+}
+8 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 4,
+}
+}
+9 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 5,
+}
+}
+10 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 6,
+}
+}
+11 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 6,
+}
+}
+12 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 7,
+}
+}
+13 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 8,
+}
+}
+14 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 8,
+}
+}
+15 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 9,
+}
+}
+16 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 10,
+}
+}
+17 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 10,
+}
+}
+18 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 11,
+}
+}
+19 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 12,
+}
+}
+20 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 13,
+}
+}
+21 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 13,
+}
+}
+22 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 14,
+}
+}
+23 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 14,
+}
+}
+24 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 15,
+}
+}
+25 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 16,
+}
+}
+26 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 16,
+}
+}
+27 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 17,
+}
+}
+28 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 17,
+}
+}
+29 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 18,
+}
+}
+30 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 19,
+}
+}
+31 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 19,
+}
+}
+32 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 20,
+}
+}
+33 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 20,
+}
+}
+34 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 21,
+}
+}
+35 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 22,
+}
+}
+36 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 22,
+}
+}
+37 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 23,
+}
+}
+38 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 23,
+}
+}
+39 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 24,
+}
+}
+40 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 25,
+}
+}
+41 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 25,
+}
+}
+42 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 26,
+}
+}
+43 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 26,
+}
+}
+44 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 27,
+}
+}
+45 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 28,
+}
+}
+46 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 28,
+}
+}
+47 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 29,
+}
+}
+48 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 29,
+}
+}
+49 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 30,
+}
+}
+50 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 31,
+}
+}
+51 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 31,
+}
+}
+52 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 32,
+}
+}
+53 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 32,
+}
+}
+54 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 33,
+}
+}
+55 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 34,
+}
+}
+56 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 34,
+}
+}
+57 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 35,
+}
+}
+58 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 35,
+}
+}
+59 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 36,
+}
+}
+60 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 37,
+}
+}
+61 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 37,
+}
+}
+62 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 38,
+}
+}
+63 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 38,
+}
+}
+64 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 39,
+}
+}
+65 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 40,
+}
+}
+66 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 40,
+}
+}
+67 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 41,
+}
+}
+68 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 41,
+}
+}
+69 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 42,
+}
+}
+70 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 43,
+}
+}
+71 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 43,
+}
+}
+72 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 44,
+}
+}
+73 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 44,
+}
+}
+74 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 45,
+}
+}
+75 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 46,
+}
+}
+76 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 46,
+}
+}
+77 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 47,
+}
+}
+78 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 47,
+}
+}
+79 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 48,
+}
+}
+80 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 49,
+}
+}
+81 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 49,
+}
+}
+82 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 50,
+}
+}
+83 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 50,
+}
+}
+84 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 51,
+}
+}
+85 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 52,
+}
+}
+86 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 52,
+}
+}
+87 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 53,
+}
+}
+88 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 53,
+}
+}
+89 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 54,
+}
+}
+90 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 55,
+}
+}
+91 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 55,
+}
+}
+92 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 56,
+}
+}
+93 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 56,
+}
+}
+94 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 57,
+}
+}
+95 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 58,
+}
+}
+96 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 58,
+}
+}
+97 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 59,
+}
+}
+98 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 59,
+}
+}
+99 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 60,
+}
+}
+100 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 61,
+}
+}
+101 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 62,
+}
+}
+102 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 62,
+}
+}
+103 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 62,
+}
+}
+104 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 62,
+}
+}
+105 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 63,
+}
+}
+106 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 63,
+}
+}
+107 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 64,
+}
+}
+108 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 64,
+}
+}
+109 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 64,
+}
+}
+110 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 64,
+}
+}
+111 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 64,
+}
+}
+112 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 64,
+}
+}
+113 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 64,
+}
+}
+114 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 64,
+}
+}
+115 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 64,
+}
+}
+116 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 64,
+}
+}
+117 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 65,
+}
+}
+118 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 65,
+}
+}
+119 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 66,
+}
+}
+120 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 66,
+}
+}
+121 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 66,
+}
+}
+122 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 67,
+}
+}
+123 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 67,
+}
+}
+124 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 68,
+}
+}
+125 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 68,
+}
+}
+126 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 69,
+}
+}
+127 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 69,
+}
+}
+128 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 70,
+}
+}
+129 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 71,
+}
+}
+130 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 71,
+}
+}
+131 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 72,
+}
+}
+132 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 73,
+}
+}
+133 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 73,
+}
+}
+134 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 74,
+}
+}
+135 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 74,
+}
+}
+136 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 75,
+}
+}
+137 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 75,
+}
+}
+138 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 75,
+}
+}
+139 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 75,
+}
+}
+140 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 76,
+}
+}
+141 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 76,
+}
+}
+142 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 76,
+}
+}
+143 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 76,
+}
+}
+144 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 77,
+}
+}
+145 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 77,
+}
+}
+146 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 77,
+}
+}
+147 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 77,
+}
+}
+148 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 78,
+}
+}
+149 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 78,
+}
+}
+150 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 78,
+}
+}
+151 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 78,
+}
+}
+152 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 79,
+}
+}
+153 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 79,
+}
+}
+154 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 79,
+}
+}
+155 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 79,
+}
+}
+156 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 80,
+}
+}
+157 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 80,
+}
+}
+158 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 80,
+}
+}
+159 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 80,
+}
+}
+160 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 81,
+}
+}
+161 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 81,
+}
+}
+162 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 81,
+}
+}
+163 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 81,
+}
+}
+164 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 82,
+}
+}
+165 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 82,
+}
+}
+166 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 82,
+}
+}
+167 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 82,
+}
+}
+168 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 83,
+}
+}
+169 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 83,
+}
+}
+170 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 83,
+}
+}
+171 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 83,
+}
+}
+172 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 84,
+}
+}
+173 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 84,
+}
+}
+174 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 84,
+}
+}
+175 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 84,
+}
+}
+176 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 85,
+}
+}
+177 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 85,
+}
+}
+178 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 85,
+}
+}
+179 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 85,
+}
+}
+180 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 86,
+}
+}
+181 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 86,
+}
+}
+182 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 86,
+}
+}
+183 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 86,
+}
+}
+184 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 87,
+}
+}
+185 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 88,
+}
+}
+186 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 88,
+}
+}
+187 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 88,
+}
+}
+188 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 88,
+}
+}
+189 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 89,
+}
+}
+190 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 90,
+}
+}
+191 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 90,
+}
+}
+192 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 91,
+}
+}
+193 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 92,
+}
+}
+194 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 93,
+}
+}
+195 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 93,
+}
+}
+196 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 94,
+}
+}
+197 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 94,
+}
+}
+198 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 94,
+}
+}
+199 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 94,
+}
+}
+200 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 94,
+}
+}
+201 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 94,
+}
+}
+202 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 95,
+}
+}
+203 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 96,
+}
+}
+204 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 96,
+}
+}
+205 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 97,
+}
+}
+206 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 97,
+}
+}
+207 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+208 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+209 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+210 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+211 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+212 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+213 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+214 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+215 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+216 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+217 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+218 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+219 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 98,
+}
+}
+220 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+221 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+222 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+223 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+224 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+225 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+226 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+227 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 98,
+}
+}
+228 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+229 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+230 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+231 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 98,
+}
+}
+232 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+233 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+234 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+235 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 98,
+}
+}
+236 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 98,
+}
+}
+237 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 98,
+}
+}
+238 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+239 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+240 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+241 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+242 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 8,
+nonterminal_produced: 98,
+}
+}
+243 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+244 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+245 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+246 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+247 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+248 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+249 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+250 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+251 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+252 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+253 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+254 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+255 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+256 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+257 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+258 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+259 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+260 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+261 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+262 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+263 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+264 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+265 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+266 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+267 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 98,
+}
+}
+268 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+269 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+270 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+271 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+272 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+273 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+274 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 8,
+nonterminal_produced: 98,
+}
+}
+275 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+276 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+277 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+278 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+279 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+280 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+281 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+282 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+283 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+284 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+285 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+286 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+287 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+288 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+289 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+290 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+291 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+292 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+293 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+294 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+295 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+296 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+297 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+298 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+299 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 98,
+}
+}
+300 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+301 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+302 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+303 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+304 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 8,
+nonterminal_produced: 98,
+}
+}
+305 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 8,
+nonterminal_produced: 98,
+}
+}
+306 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 9,
+nonterminal_produced: 98,
+}
+}
+307 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+308 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+309 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+310 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 8,
+nonterminal_produced: 98,
+}
+}
+311 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+312 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+313 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+314 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 8,
+nonterminal_produced: 98,
+}
+}
+315 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+316 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+317 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+318 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+319 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+320 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+321 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+322 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 8,
+nonterminal_produced: 98,
+}
+}
+323 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+324 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+325 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+326 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+327 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+328 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+329 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+330 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 98,
+}
+}
+331 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 98,
+}
+}
+332 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+333 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 98,
+}
+}
+334 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 98,
+}
+}
+335 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 99,
+}
+}
+336 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 99,
+}
+}
+337 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 99,
+}
+}
+338 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 99,
+}
+}
+339 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 100,
+}
+}
+340 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 100,
+}
+}
+341 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 101,
+}
+}
+342 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 101,
+}
+}
+343 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 102,
+}
+}
+344 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 103,
+}
+}
+345 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 103,
+}
+}
+346 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 104,
+}
+}
+347 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 105,
+}
+}
+348 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 105,
+}
+}
+349 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 106,
+}
+}
+350 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 107,
+}
+}
+351 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 107,
+}
+}
+352 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 108,
+}
+}
+353 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 108,
+}
+}
+354 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 108,
+}
+}
+355 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 109,
+}
+}
+356 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 109,
+}
+}
+357 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 110,
+}
+}
+358 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 111,
+}
+}
+359 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 111,
+}
+}
+360 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 112,
+}
+}
+361 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 112,
+}
+}
+362 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 113,
+}
+}
+363 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 114,
+}
+}
+364 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 114,
+}
+}
+365 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 115,
+}
+}
+366 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 116,
+}
+}
+367 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 117,
+}
+}
+368 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 117,
+}
+}
+369 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 117,
+}
+}
+370 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 118,
+}
+}
+371 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 118,
+}
+}
+372 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 119,
+}
+}
+373 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 119,
+}
+}
+374 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 120,
+}
+}
+375 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 121,
+}
+}
+376 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 122,
+}
+}
+377 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 122,
+}
+}
+378 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 123,
+}
+}
+379 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 123,
+}
+}
+380 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 123,
+}
+}
+381 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 123,
+}
+}
+382 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 124,
+}
+}
+383 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 124,
+}
+}
+384 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 124,
+}
+}
+385 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 125,
+}
+}
+386 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 126,
+}
+}
+387 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 126,
+}
+}
+388 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 127,
+}
+}
+389 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 127,
+}
+}
+390 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 127,
+}
+}
+391 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 127,
+}
+}
+392 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 128,
+}
+}
+393 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 129,
+}
+}
+394 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 129,
+}
+}
+395 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 130,
+}
+}
+396 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 130,
+}
+}
+397 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 130,
+}
+}
+398 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 130,
+}
+}
+399 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 130,
+}
+}
+400 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 130,
+}
+}
+401 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 130,
+}
+}
+402 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 130,
+}
+}
+403 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 130,
+}
+}
+404 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 130,
+}
+}
+405 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 130,
+}
+}
+406 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 130,
+}
+}
+407 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 130,
+}
+}
+408 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 130,
+}
+}
+409 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 131,
+}
+}
+410 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 131,
+}
+}
+411 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 131,
+}
+}
+412 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 131,
+}
+}
+413 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 132,
+}
+}
+414 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 132,
+}
+}
+415 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 132,
+}
+}
+416 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 132,
+}
+}
+417 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 133,
+}
+}
+418 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 133,
+}
+}
+419 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 134,
+}
+}
+420 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 135,
+}
+}
+421 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 136,
+}
+}
+422 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 136,
+}
+}
+423 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 136,
+}
+}
+424 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 137,
+}
+}
+425 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 138,
+}
+}
+426 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 138,
+}
+}
+427 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 139,
+}
+}
+428 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 139,
+}
+}
+429 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 140,
+}
+}
+430 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 141,
+}
+}
+431 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 142,
+}
+}
+432 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 142,
+}
+}
+433 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 142,
+}
+}
+434 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 142,
+}
+}
+435 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 143,
+}
+}
+436 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 143,
+}
+}
+437 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 144,
+}
+}
+438 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 144,
+}
+}
+439 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 145,
+}
+}
+440 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 145,
+}
+}
+441 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 146,
+}
+}
+442 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 147,
+}
+}
+443 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 147,
+}
+}
+444 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 148,
+}
+}
+445 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 148,
+}
+}
+446 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 148,
+}
+}
+447 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 148,
+}
+}
+448 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 148,
+}
+}
+449 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 148,
+}
+}
+450 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 148,
+}
+}
+451 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 148,
+}
+}
+452 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 149,
+}
+}
+453 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 149,
+}
+}
+454 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 150,
+}
+}
+455 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 150,
+}
+}
+456 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 150,
+}
+}
+457 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 150,
+}
+}
+458 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 150,
+}
+}
+459 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 151,
+}
+}
+460 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 10,
+nonterminal_produced: 151,
+}
+}
+461 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 6,
+nonterminal_produced: 151,
+}
+}
+462 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 8,
+nonterminal_produced: 151,
+}
+}
+463 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 151,
+}
+}
+464 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 8,
+nonterminal_produced: 151,
+}
+}
+465 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 151,
+}
+}
+466 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 151,
+}
+}
+467 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 151,
+}
+}
+468 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 152,
+}
+}
+469 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 152,
+}
+}
+470 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 153,
+}
+}
+471 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 153,
+}
+}
+472 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 153,
+}
+}
+473 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 154,
+}
+}
+474 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 154,
+}
+}
+475 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 155,
+}
+}
+476 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 156,
+}
+}
+477 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 156,
+}
+}
+478 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 157,
+}
+}
+479 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 157,
+}
+}
+480 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 158,
+}
+}
+481 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 158,
+}
+}
+482 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 158,
+}
+}
+483 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 158,
+}
+}
+484 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 158,
+}
+}
+485 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 3,
+nonterminal_produced: 158,
+}
+}
+486 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 158,
+}
+}
+487 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 158,
+}
+}
+488 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 158,
+}
+}
+489 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 158,
+}
+}
+490 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 158,
+}
+}
+491 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 11,
+nonterminal_produced: 158,
+}
+}
+492 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 7,
+nonterminal_produced: 158,
+}
+}
+493 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 9,
+nonterminal_produced: 158,
+}
+}
+494 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 158,
+}
+}
+495 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 159,
+}
+}
+496 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 159,
+}
+}
+497 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 160,
+}
+}
+498 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 160,
+}
+}
+499 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 161,
+}
+}
+500 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 161,
+}
+}
+501 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 162,
+}
+}
+502 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 163,
+}
+}
+503 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 163,
+}
+}
+504 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 164,
+}
+}
+505 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 2,
+nonterminal_produced: 164,
+}
+}
+506 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 4,
+nonterminal_produced: 165,
+}
+}
+507 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 5,
+nonterminal_produced: 165,
+}
+}
+508 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 1,
+nonterminal_produced: 165,
+}
+}
+509 => {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop: 0,
+nonterminal_produced: 165,
+}
+}
+510 => ___state_machine::SimulatedReduce::Accept,
+_ => panic!("invalid reduction index {}", ___reduce_index)
+}
+}
 pub struct TopParser {
 _priv: (),
 }
@@ -3273,6 +6364,39 @@ ___phantom: core::marker::PhantomData::<(&())>,
 },
 ___tokens,
 )
+}
+}
+fn ___accepts<
+    'input,
+>(
+___error_state: Option<i16>,
+___states: &[i16],
+___opt_integer: Option<usize>,
+_: core::marker::PhantomData<(&'input ())>,
+) -> bool
+{
+let mut ___states = ___states.to_vec();
+___states.extend(___error_state);
+loop {
+let mut ___states_len = ___states.len();
+let ___top = ___states[___states_len - 1];
+let ___action = match ___opt_integer {
+None => ___EOF_ACTION[___top as usize],
+Some(___integer) => ___action(___top, ___integer),
+};
+if ___action == 0 { return false; }
+if ___action > 0 { return true; }
+let (___to_pop, ___nt) = match ___simulate_reduce(-(___action + 1), core::marker::PhantomData::<(&())>) {
+___state_machine::SimulatedReduce::Reduce {
+states_to_pop, nonterminal_produced
+} => (states_to_pop, nonterminal_produced),
+___state_machine::SimulatedReduce::Accept => return true,
+};
+___states_len -= ___to_pop;
+___states.truncate(___states_len);
+let ___top = ___states[___states_len - 1];
+let ___next_state = ___goto(___top, ___nt);
+___states.push(___next_state);
 }
 }
 pub(crate) fn ___reduce<


### PR DESCRIPTION
This pull request tries to fix the issue described in #736, where the expected tokens given in UnrecognizedToken and UnrecognizedEOF errors include values that would always be rejected if inserted at the error site. The idea is to reuse the existing logic for error recovery in order to filter the expected tokens down to ones which could actually be parsed at the point of the error. The strategy here is:

1. Cause some of the support code for error recovery (specifically `__simulate_reduce()` and `__accepts()`) to always be generated.
  Unfortunately this entails some extra code size, even for grammars that don't actually have states where invalid error output could be generated. However, it looks like `__simulate_reduce()` used to always be generated prior to #510 and it doesn't seem like there was any particular impetus to make it conditional beyond avoiding dead code. The size of the `__accepts()` function doesn't vary based on the input grammar.

2. Add a defaulted method `expected_tokens_from_states` to `lalrpop_util::state_machine::ParserDefinition` in order to provide the generated parser definition with enough context to correctly identify the legal tokens. The existing `expected_tokens` method is left alone, which makes this pull request partly backwards compatible; a lalrpop_util version with this pull request can be used with a preexisting generated grammar, although a generated grammar incorporating the changes here needs to use an updated lalrpop_util. If that makes this PR a breaking change then there's no need to keep `ParserDefinition::expected_tokens` in its current form.

This only fixes the issue for the table-based parser codegen. Fixing it for the recursive ascent codegen seems more difficult, which I imagine is why error recovery isn't implemented there either.