### PR TITLE
Improve compilation speed by up to 2x

### DIFF
--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -123,7 +123,9 @@ impl<'grammar, L: LookaheadBuild> LR<'grammar, L> {
                             index,
                             lookahead,
                         },
-                    )| { (symbol, (Item::lr0(production, index), lookahead)) },
+                    )| {
+                        (symbol.clone(), (Item::lr0(production, index), lookahead))
+                    },
                 )
                 .collect();
 

--- a/lalrpop/src/lr1/codegen/ascent.rs
+++ b/lalrpop/src/lr1/codegen/ascent.rs
@@ -682,27 +682,22 @@ impl<'ascent, 'grammar, W: Write>
     ) -> io::Result<StackSuffix<'grammar>> {
         let mut result = inputs;
 
-        let top_opt = self
-            .custom
-            .graph
-            .successors(state_index)
-            .iter()
-            .any(|succ_state| {
-                let succ_inputs = &self.custom.state_inputs[succ_state.0];
+        let top_opt = self.custom.graph.successors(state_index).any(|succ_state| {
+            let succ_inputs = &self.custom.state_inputs[succ_state.0];
 
-                // Check for a successor state with a suffix like:
-                //
-                //     ... OPT_1 ... OPT_N FIXED_1
-                //
-                // (Remember that *every* successor state will have
-                // at least one fixed input.)
-                //
-                // So basically we are looking for states
-                // that, when they return, may *optionally* have consumed
-                // the top of our stack.
-                assert!(!succ_inputs.fixed().is_empty());
-                succ_inputs.fixed().len() == 1 && !succ_inputs.optional().is_empty()
-            });
+            // Check for a successor state with a suffix like:
+            //
+            //     ... OPT_1 ... OPT_N FIXED_1
+            //
+            // (Remember that *every* successor state will have
+            // at least one fixed input.)
+            //
+            // So basically we are looking for states
+            // that, when they return, may *optionally* have consumed
+            // the top of our stack.
+            assert!(!succ_inputs.fixed().is_empty());
+            succ_inputs.fixed().len() == 1 && !succ_inputs.optional().is_empty()
+        });
 
         // If we find a successor that may optionally consume the top
         // of our stack, convert our fixed inputs into optional ones.

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -74,7 +74,7 @@ impl<'grammar, L: Lookahead> Item<'grammar, L> {
 
     pub fn can_shift_nonterminal(&self, nt: &NonterminalString) -> bool {
         match self.shift_symbol() {
-            Some((Symbol::Nonterminal(shifted), _)) => shifted == *nt,
+            Some((Symbol::Nonterminal(shifted), _)) => shifted == nt,
             _ => false,
         }
     }
@@ -83,10 +83,10 @@ impl<'grammar, L: Lookahead> Item<'grammar, L> {
         self.index == self.production.symbols.len()
     }
 
-    pub fn shifted_item(&self) -> Option<(Symbol, Item<'grammar, L>)> {
+    pub fn shifted_item(&self) -> Option<(&Symbol, Item<'grammar, L>)> {
         if self.can_shift() {
             Some((
-                self.production.symbols[self.index].clone(),
+                &self.production.symbols[self.index],
                 Item {
                     production: self.production,
                     index: self.index + 1,
@@ -98,10 +98,10 @@ impl<'grammar, L: Lookahead> Item<'grammar, L> {
         }
     }
 
-    pub fn shift_symbol(&self) -> Option<(Symbol, &[Symbol])> {
+    pub fn shift_symbol(&self) -> Option<(&Symbol, &[Symbol])> {
         if self.can_shift() {
             Some((
-                self.production.symbols[self.index].clone(),
+                &self.production.symbols[self.index],
                 &self.production.symbols[self.index + 1..],
             ))
         } else {

--- a/lalrpop/src/lr1/error/mod.rs
+++ b/lalrpop/src/lr1/error/mod.rs
@@ -690,8 +690,8 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
         shift_upcoming
             .iter()
             .zip(reduce_upcoming)
-            .filter_map(|(shift_sym, reduce_sym)| match (shift_sym, reduce_sym) {
-                (ExampleSymbol::Symbol(ref shift_sym), ExampleSymbol::Symbol(reduce_sym)) => {
+            .find_map(|(shift_sym, reduce_sym)| match (shift_sym, reduce_sym) {
+                (ExampleSymbol::Symbol(shift_sym), ExampleSymbol::Symbol(reduce_sym)) => {
                     if shift_sym == reduce_sym {
                         // same symbol on both; we'll be able to shift them
                         None
@@ -701,13 +701,9 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
                         // consider a suffix matching epsilon to be
                         // potentially overlapping, though we could
                         // supply the actual lookahead for more precision.
-                        let shift_first = self.first_sets.first0(&[shift_sym.clone()]);
-                        let reduce_first = self.first_sets.first0(&[reduce_sym.clone()]);
-                        if shift_first.is_disjoint(&reduce_first) {
-                            Some(true)
-                        } else {
-                            Some(false)
-                        }
+                        let shift_first = self.first_sets.first0(std::iter::once(shift_sym));
+                        let reduce_first = self.first_sets.first0(std::iter::once(reduce_sym));
+                        Some(shift_first.is_disjoint(&reduce_first))
                     }
                 }
                 _ => {
@@ -718,7 +714,6 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
                     Some(false)
                 }
             })
-            .next()
             .unwrap_or(false)
     }
 

--- a/lalrpop/src/lr1/lane_table/lane/mod.rs
+++ b/lalrpop/src/lr1/lane_table/lane/mod.rs
@@ -90,11 +90,11 @@ impl<'trace, 'grammar, L: Lookahead> LaneTracer<'trace, 'grammar, L> {
             // reached by shifting T. Those predecessors will contain
             // an item like `X = ...p (*) T ...s`, which we will then
             // process in turn.
-            let shifted_symbol = item.production.symbols[item.index - 1].clone();
             let unshifted_item = Item {
                 index: item.index - 1,
                 ..item
             };
+            let shifted_symbol = &item.production.symbols[unshifted_item.index];
             let predecessors = self.state_graph.predecessors(state, shifted_symbol);
             for predecessor in predecessors {
                 self.table.add_successor(predecessor, state);

--- a/lalrpop/src/lr1/lookahead.rs
+++ b/lalrpop/src/lr1/lookahead.rs
@@ -181,11 +181,19 @@ impl TokenSet {
     }
 
     fn bit(&self, lookahead: &Token) -> usize {
+        with(|t| self.bit_with(lookahead, t))
+    }
+
+    fn bit_with(&self, lookahead: &Token, terminals: &TerminalSet) -> usize {
         match *lookahead {
-            Token::EOF => self.eof_bit(),
-            Token::Error => self.eof_bit() + 1,
-            Token::Terminal(ref t) => with(|terminals| terminals.bits[t]),
+            Token::EOF => terminals.all.len(),
+            Token::Error => terminals.all.len() + 1,
+            Token::Terminal(ref t) => terminals.bits[t],
         }
+    }
+
+    pub fn reserve(&mut self, len: usize) {
+        self.bit_set.reserve_len(len)
     }
 
     pub fn len(&self) -> usize {
@@ -194,6 +202,11 @@ impl TokenSet {
 
     pub fn insert(&mut self, lookahead: Token) -> bool {
         let bit = self.bit(&lookahead);
+        self.bit_set.insert(bit)
+    }
+
+    pub fn insert_with(&mut self, lookahead: Token, terminals: &TerminalSet) -> bool {
+        let bit = self.bit_with(&lookahead, terminals);
         self.bit_set.insert(bit)
     }
 

--- a/lalrpop/src/lr1/tls.rs
+++ b/lalrpop/src/lr1/tls.rs
@@ -2,24 +2,18 @@
 
 use crate::grammar::repr::TerminalSet;
 use std::cell::RefCell;
-use std::mem;
-use std::sync::Arc;
 
 thread_local! {
-    static TERMINALS: RefCell<Option<Arc<TerminalSet>>> = RefCell::new(None)
+    static TERMINALS: RefCell<Option<TerminalSet>> = const { RefCell::new(None) }
 }
 
 pub struct Lr1Tls {
-    old_value: Option<Arc<TerminalSet>>,
+    old_value: Option<TerminalSet>,
 }
 
 impl Lr1Tls {
     pub fn install(terminals: TerminalSet) -> Lr1Tls {
-        let old_value = TERMINALS.with(|s| {
-            let mut s = s.borrow_mut();
-            mem::replace(&mut *s, Some(Arc::new(terminals)))
-        });
-
+        let old_value = TERMINALS.with(|s| s.borrow_mut().replace(terminals));
         Lr1Tls { old_value }
     }
 


### PR DESCRIPTION
Running [samply](https://github.com/mstange/samply) to profile `lalrpop`, I found that most of the time spent during the `LR(1) state construction (lane)` phase is in the `continue_trace` recursive function, which calls `can_shift_nonterminal` in a loop. This last function looks like it should just perform a simple equality on two symbol references, but instead unnecessarily clones a symbol.
Other changes include reducing allocations and minor clippy fixes throughout the entire crate.

I've measured both [Solang] and [Rust Python], which yielded similar times, by using the time printed with the `--level verbose` flag:

-   debug: ~7.9s -> ~6.8s
-   release: ~1.1s -> ~0.45s

[solang]: https://github.com/hyperledger/solang/blob/a14139e916a6a89875d4a1e15c9548d0038b24cd/solang-parser/src/solidity.lalrpop
[rust python]: https://github.com/RustPython/RustPython/blob/c9546c2419f2e4db7e2987f30f0508dc29b30035/compiler/parser/python.lalrpop#L1

Another similar performance improvement can be seen by switching the `Map` and `Set` types to the standard `HashMap` with the [`Fx` hasher][fx], but I ran into a lot of test failures so I didn't include it in this PR. If this change is implemented correctly, I believe it can save another 1-2s on the debug build and ~0.1s on the release build.

[fx]: https://github.com/rust-lang/rustc-hash
