### PR TITLE
Clippy(mostly in generated code)

### DIFF
--- a/doc/calculator/src/calculator2b.lalrpop
+++ b/doc/calculator/src/calculator2b.lalrpop
@@ -3,7 +3,7 @@ grammar;
 pub Term = {
     Num,
     "(" <Term> ")",
-    "22" => format!("Twenty-two!"),
+    "22" => "Twenty-two!".to_string(),
     ID => format!("Id({})", <>),
 };
 

--- a/doc/calculator/src/calculator7.lalrpop
+++ b/doc/calculator/src/calculator7.lalrpop
@@ -44,4 +44,3 @@ Term: Box<Expr> = {
 Num: i32 = {
     r"[0-9]+" => i32::from_str(<>).unwrap()
 };
-

--- a/doc/calculator/src/main.rs
+++ b/doc/calculator/src/main.rs
@@ -5,7 +5,6 @@ macro_rules! lalrpop_mod_doc {
         lalrpop_util::lalrpop_mod!(
             #[allow(clippy::ptr_arg)]
             #[allow(clippy::vec_box)]
-            #[allow(clippy::needless_lifetimes)]
             $vis $name);
     }
 }

--- a/doc/calculator/src/main.rs
+++ b/doc/calculator/src/main.rs
@@ -2,7 +2,12 @@ use lalrpop_util::lalrpop_mod;
 
 macro_rules! lalrpop_mod_doc {
     ($vis:vis $name:ident) => {
-        lalrpop_util::lalrpop_mod!(#[allow(clippy::all)] $vis $name);
+        lalrpop_util::lalrpop_mod!(
+            #[allow(clippy::ptr_arg)]
+            #[allow(clippy::vec_box)]
+            #[allow(clippy::needless_lifetimes)]
+            #[allow(clippy::just_underscores_and_digits)]
+            $vis $name);
     }
 }
 

--- a/doc/calculator/src/main.rs
+++ b/doc/calculator/src/main.rs
@@ -6,7 +6,6 @@ macro_rules! lalrpop_mod_doc {
             #[allow(clippy::ptr_arg)]
             #[allow(clippy::vec_box)]
             #[allow(clippy::needless_lifetimes)]
-            #[allow(clippy::just_underscores_and_digits)]
             $vis $name);
     }
 }

--- a/doc/pascal/lalrpop/src/main.rs
+++ b/doc/pascal/lalrpop/src/main.rs
@@ -13,9 +13,6 @@ use pico_args::Arguments;
 lalrpop_mod!(
     #[allow(clippy::ptr_arg)]
     #[allow(clippy::vec_box)]
-    #[allow(clippy::needless_lifetimes)]
-    #[allow(clippy::let_unit_value)]
-    #[allow(clippy::too_many_arguments)]
     pascal
 );
 

--- a/doc/pascal/lalrpop/src/main.rs
+++ b/doc/pascal/lalrpop/src/main.rs
@@ -11,7 +11,12 @@ use std::time::Instant;
 use pico_args::Arguments;
 
 lalrpop_mod!(
-    #[allow(clippy::all)]
+    #[allow(clippy::ptr_arg)]
+    #[allow(clippy::vec_box)]
+    #[allow(clippy::needless_lifetimes)]
+    #[allow(clippy::just_underscores_and_digits)]
+    #[allow(clippy::let_unit_value)]
+    #[allow(clippy::too_many_arguments)]
     pascal
 );
 

--- a/doc/pascal/lalrpop/src/main.rs
+++ b/doc/pascal/lalrpop/src/main.rs
@@ -14,7 +14,6 @@ lalrpop_mod!(
     #[allow(clippy::ptr_arg)]
     #[allow(clippy::vec_box)]
     #[allow(clippy::needless_lifetimes)]
-    #[allow(clippy::just_underscores_and_digits)]
     #[allow(clippy::let_unit_value)]
     #[allow(clippy::too_many_arguments)]
     pascal

--- a/doc/src/lexer_tutorial/001_lexer_gen.md
+++ b/doc/src/lexer_tutorial/001_lexer_gen.md
@@ -124,7 +124,7 @@ if to produce a **string**, and we'll add an "easter egg" so that `22`
 pub Term = {
     Num,
     "(" <Term> ")",
-    "22" => format!("Twenty-two!"),
+    "22" => "Twenty-two!".to_string(),
 };
 
 Num: String = r"[0-9]+" => <>.to_string();
@@ -299,7 +299,7 @@ And then adjusting the definition of `Term` to reference `ID` instead:
 pub Term = {
     Num,
     "(" <Term> ")",
-    "22" => format!("Twenty-two!"),
+    "22" => "Twenty-two!".to_string(),
     ID => format!("Id({})", <>), // <-- changed this
 };
 ```

--- a/doc/whitespace/src/lib.rs
+++ b/doc/whitespace/src/lib.rs
@@ -5,7 +5,7 @@ pub mod ast;
 pub mod eval;
 pub mod lexer;
 
-lalrpop_mod!(#[allow(clippy::all)] pub parser);
+lalrpop_mod!(pub parser);
 
 pub fn compile(input: &str) -> Result<ast::Program, String> {
     match parser::ProgramParser::new().parse(lexer::Lexer::new(input)) {

--- a/lalrpop-test/src/error_recovery_span.lalrpop
+++ b/lalrpop-test/src/error_recovery_span.lalrpop
@@ -34,7 +34,7 @@ pub Expr: String = {
 
     <@L> ! <@R> => {
         errors.push((<>));
-        format!("!")
+        "!".to_string()
     },
 };
 

--- a/lalrpop-test/src/expr_arena_ast.rs
+++ b/lalrpop-test/src/expr_arena_ast.rs
@@ -21,6 +21,8 @@ pub enum Node<'ast> {
 }
 
 pub struct Arena<'ast> {
+    // Allowed because we want to give out pointers to the underlying elements, not to the vec itself(which can be moved on resize).
+    #[allow(clippy::vec_box)]
     data: RefCell<Vec<Box<Node<'ast>>>>,
 }
 

--- a/lalrpop-test/src/inline.lalrpop
+++ b/lalrpop-test/src/inline.lalrpop
@@ -2,12 +2,12 @@
 grammar;
 
 pub E: String = {
-    "L" => format!("L"),
+    "L" => "L".to_string(),
     "&" <OPT_L> <E> => format!("& {} {}", <>),
 };
 
 #[inline] // without this, it'd be a SR conflict
 OPT_L: String = {
-    () => format!("()"),
-    "L" => format!("L"),
+    () => "()".to_string(),
+    "L" => "L".to_string(),
 };

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -21,7 +21,6 @@ macro_rules! lalrpop_mod_test {
         lalrpop_mod!(
             #[allow(clippy::ptr_arg)]
             #[allow(clippy::vec_box)]
-            #[allow(clippy::needless_lifetimes)]
             $(#[$attr])* $vis $modname);
     }
 }

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -18,7 +18,11 @@ mod util;
 
 macro_rules! lalrpop_mod_test {
     ($(#[$attr:meta])* $vis:vis $modname:ident) => {
-        lalrpop_mod!(#[allow(clippy::all)] $(#[$attr])* $vis $modname);
+        lalrpop_mod!(
+            #[allow(clippy::ptr_arg)]
+            #[allow(clippy::vec_box)]
+            #[allow(clippy::needless_lifetimes)]
+            $(#[$attr])* $vis $modname);
     }
 }
 

--- a/lalrpop-test/src/pub_in.rs
+++ b/lalrpop-test/src/pub_in.rs
@@ -3,7 +3,7 @@
 
 mod outer {
     pub(crate) mod inner {
-        lalrpop_util::lalrpop_mod!(#[allow(clippy::all)] pub(crate) pub_in);
+        lalrpop_util::lalrpop_mod!(pub(crate) pub_in);
     }
 
     #[test]

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -191,6 +191,8 @@ macro_rules! lalrpop_mod {
 
     ($(#[$attr:meta])* $vis:vis $modname:ident, $source:expr) => {
         #[rustfmt::skip]
+        #[allow(clippy::extra_unused_lifetimes)]
+        #[allow(clippy::just_underscores_and_digits)]
         $(#[$attr])* $vis mod $modname { include!(concat!(env!("OUT_DIR"), $source)); }
     };
 }

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -192,6 +192,8 @@ macro_rules! lalrpop_mod {
     ($(#[$attr:meta])* $vis:vis $modname:ident, $source:expr) => {
         #[rustfmt::skip]
         #[allow(clippy::extra_unused_lifetimes)]
+        #[allow(clippy::needless_lifetimes)]
+        #[allow(clippy::let_unit_value)]
         #[allow(clippy::just_underscores_and_digits)]
         $(#[$attr])* $vis mod $modname { include!(concat!(env!("OUT_DIR"), $source)); }
     };

--- a/lalrpop/src/build/action.rs
+++ b/lalrpop/src/build/action.rs
@@ -130,7 +130,12 @@ fn emit_user_action_code<W: Write>(
     .emit()?;
 
     rust!(rust, "{{");
-    rust!(rust, "{}", data.code);
+
+    // The user did not provide any code
+    if data.code != "()" {
+        rust!(rust, "{}", data.code);
+    }
+
     rust!(rust, "}}");
     Ok(())
 }

--- a/lalrpop/src/build/action.rs
+++ b/lalrpop/src/build/action.rs
@@ -120,6 +120,7 @@ fn emit_user_action_code<W: Write>(
         ]);
     }
 
+    rust!(rust, "#[allow(clippy::too_many_arguments)]");
     rust.fn_header(
         &r::Visibility::Priv,
         format!("{}action{}", grammar.prefix, index),
@@ -174,11 +175,11 @@ fn emit_lookaround_action_code<W: Write>(
             // at EOF, so taker the lookbehind (end of last
             // pushed token); if that is missing too, then
             // supply default.
-            rust!(rust, "{}lookahead.clone()", grammar.prefix);
+            rust!(rust, "*{}lookahead", grammar.prefix);
         }
         r::LookaroundActionFnDefn::Lookbehind => {
             // take lookbehind or supply default
-            rust!(rust, "{}lookbehind.clone()", grammar.prefix);
+            rust!(rust, "*{}lookbehind", grammar.prefix);
         }
     }
     rust!(rust, "}}");
@@ -233,6 +234,7 @@ fn emit_inline_action_code<W: Write>(
         ]);
     }
 
+    rust!(rust, "#[allow(clippy::too_many_arguments)]");
     rust.fn_header(
         &r::Visibility::Priv,
         format!("{}action{}", grammar.prefix, index),

--- a/lalrpop/src/build/action.rs
+++ b/lalrpop/src/build/action.rs
@@ -256,7 +256,7 @@ fn emit_inline_action_code<W: Write>(
 
                     rust!(
                         rust,
-                        "let {}start{} = {}{}.0.clone();",
+                        "let {}start{} = {}{}.0;",
                         grammar.prefix,
                         temp_counter,
                         grammar.prefix,
@@ -266,7 +266,7 @@ fn emit_inline_action_code<W: Write>(
                     let last_arg_index = arg_counter + syms.len() - 1;
                     rust!(
                         rust,
-                        "let {}end{} = {}{}.2.clone();",
+                        "let {}end{} = {}{}.2;",
                         grammar.prefix,
                         temp_counter,
                         grammar.prefix,
@@ -282,7 +282,7 @@ fn emit_inline_action_code<W: Write>(
                     if arg_counter > 0 {
                         rust!(
                             rust,
-                            "let {}start{} = {}{}.2.clone();",
+                            "let {}start{} = {}{}.2;",
                             grammar.prefix,
                             temp_counter,
                             grammar.prefix,
@@ -291,7 +291,7 @@ fn emit_inline_action_code<W: Write>(
                     } else if num_flat_args > 0 {
                         rust!(
                             rust,
-                            "let {}start{} = {}{}.0.clone();",
+                            "let {}start{} = {}{}.0;",
                             grammar.prefix,
                             temp_counter,
                             grammar.prefix,
@@ -300,7 +300,7 @@ fn emit_inline_action_code<W: Write>(
                     } else {
                         rust!(
                             rust,
-                            "let {}start{} = {}lookbehind.clone();",
+                            "let {}start{} = *{}lookbehind;",
                             grammar.prefix,
                             temp_counter,
                             grammar.prefix
@@ -310,7 +310,7 @@ fn emit_inline_action_code<W: Write>(
                     if arg_counter < num_flat_args {
                         rust!(
                             rust,
-                            "let {}end{} = {}{}.0.clone();",
+                            "let {}end{} = {}{}.0;",
                             grammar.prefix,
                             temp_counter,
                             grammar.prefix,
@@ -319,7 +319,7 @@ fn emit_inline_action_code<W: Write>(
                     } else if num_flat_args > 0 {
                         rust!(
                             rust,
-                            "let {}end{} = {}{}.2.clone();",
+                            "let {}end{} = {}{}.2;",
                             grammar.prefix,
                             temp_counter,
                             grammar.prefix,
@@ -328,7 +328,7 @@ fn emit_inline_action_code<W: Write>(
                     } else {
                         rust!(
                             rust,
-                            "let {}end{} = {}lookahead.clone();",
+                            "let {}end{} = *{}lookahead;",
                             grammar.prefix,
                             temp_counter,
                             grammar.prefix

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -443,6 +443,7 @@ fn emit_recursive_ascent(
 
     action::emit_action_code(grammar, &mut rust)?;
 
+    rust!(rust, "#[allow(clippy::type_complexity)]");
     emit_to_triple_trait(grammar, &mut rust)?;
 
     Ok(rust.into_inner())

--- a/lalrpop/src/lexer/re/mod.rs
+++ b/lalrpop/src/lexer/re/mod.rs
@@ -7,7 +7,7 @@ use regex_syntax::{self, Error, Parser};
 mod test;
 
 pub type Regex = Hir;
-pub type RegexError = Error;
+pub type RegexError = Box<Error>;
 
 /// Convert a string literal into a parsed regular expression.
 pub fn parse_literal(s: &str) -> Regex {

--- a/lalrpop/src/lr1/codegen/ascent.rs
+++ b/lalrpop/src/lr1/codegen/ascent.rs
@@ -851,13 +851,8 @@ impl<'ascent, 'grammar, W: Write>
         // reducing; but in the case of an empty production, it will come from the
         // lookahead or the end of the last symbol pushed
         if let (Some(first_sym), Some(last_sym)) = (transfer_syms.first(), transfer_syms.last()) {
-            rust!(
-                self.out,
-                "let {}start = {}.0.clone();",
-                self.prefix,
-                first_sym
-            );
-            rust!(self.out, "let {}end = {}.2.clone();", self.prefix, last_sym);
+            rust!(self.out, "let {}start = {}.0;", self.prefix, first_sym);
+            rust!(self.out, "let {}end = {}.2;", self.prefix, last_sym);
         } else if stack_suffix.len() > 0 {
             // we pop no symbols, so grab from the top of the stack
             // (unless we are in the start state)

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -44,6 +44,7 @@ pub struct CodeGenerator<'codegen, 'grammar: 'codegen, W: Write + 'codegen, C> {
 }
 
 impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         grammar: &'grammar Grammar,
         user_start_symbol: NonterminalString,

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -1067,11 +1067,11 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
         if let (Some(first_sym), Some(last_sym)) = (transfer_syms.first(), transfer_syms.last()) {
             rust!(
                 self.out,
-                "let {}start = {}.0.clone();",
+                "let {}start = {}.0;",
                 self.prefix,
                 first_sym
             );
-            rust!(self.out, "let {}end = {}.2.clone();", self.prefix, last_sym);
+            rust!(self.out, "let {}end = {}.2;", self.prefix, last_sym);
         } else {
             // we pop no symbols, so grab from the top of the stack
             // (unless we are in the start state, in which case the

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -1065,12 +1065,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
         // reducing; but in the case of an empty production, it will come from the
         // lookahead
         if let (Some(first_sym), Some(last_sym)) = (transfer_syms.first(), transfer_syms.last()) {
-            rust!(
-                self.out,
-                "let {}start = {}.0;",
-                self.prefix,
-                first_sym
-            );
+            rust!(self.out, "let {}start = {}.0;", self.prefix, first_sym);
             rust!(self.out, "let {}end = {}.2;", self.prefix, last_sym);
         } else {
             // we pop no symbols, so grab from the top of the stack

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -79,13 +79,6 @@ impl<'grammar, L: Lookahead> Item<'grammar, L> {
         }
     }
 
-    pub fn can_shift_terminal(&self, term: &TerminalString) -> bool {
-        match self.shift_symbol() {
-            Some((Symbol::Terminal(shifted), _)) => shifted == *term,
-            _ => false,
-        }
-    }
-
     pub fn can_reduce(&self) -> bool {
         self.index == self.production.symbols.len()
     }

--- a/lalrpop/src/normalize/lower/mod.rs
+++ b/lalrpop/src/normalize/lower/mod.rs
@@ -400,7 +400,7 @@ impl<'s> LowerState<'s> {
                             let name_str = {
                                 let name_strs: Vec<_> = names
                                     .iter()
-                                    .map(|(_, name, _)| format!("{0}:{0}", &*name.name))
+                                    .map(|(_, name, _)| format!("{}", name.name))
                                     .collect();
                                 name_strs.join(", ")
                             };

--- a/lalrpop/src/rust/mod.rs
+++ b/lalrpop/src/rust/mod.rs
@@ -243,7 +243,11 @@ impl<'me, W: Write> FnHeader<'me, W> {
             rust!(self.write, "{},", parameter);
         }
 
-        rust!(self.write, ") -> {}", self.return_type);
+        if self.return_type == "()" {
+            rust!(self.write, ")");
+        } else {
+            rust!(self.write, ") -> {}", self.return_type);
+        }
 
         if !self.where_clauses.is_empty() {
             rust!(self.write, "where");


### PR DESCRIPTION
Inspired by recent movement/discussion. I wanted to take a crack at some of the suppressed clippy lints, largely in generated code which I think hasn't been touched on yet.

In doing so, I also suggest a series of four lints that I think always want to be suppressed or atleast can be handled/fix more specifically.

```
        #[allow(clippy::extra_unused_lifetimes)]
        #[allow(clippy::needless_lifetimes)]
        #[allow(clippy::let_unit_value)]
        #[allow(clippy::just_underscores_and_digits)]
```

I roughly tried to keep things to separate commits but am happy to clean the history up/explain things as needed.

