### PR TITLE
update lalrpop/lalrpop-test to 2021 edition

### DIFF
--- a/lalrpop-test/Cargo.toml
+++ b/lalrpop-test/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0 OR MIT"
 build = "build.rs"
 workspace = ".."
+edition = "2021"
 
 [dependencies]
 diff = "0.1.12"

--- a/lalrpop-test/src/associated_types.lalrpop
+++ b/lalrpop-test/src/associated_types.lalrpop
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use associated_types_lib::ParseCallbacks;
+use crate::associated_types_lib::ParseCallbacks;
 
 grammar<P>(callbacks: &mut P) where P: ParseCallbacks;
 

--- a/lalrpop-test/src/error.lalrpop
+++ b/lalrpop-test/src/error.lalrpop
@@ -1,4 +1,4 @@
-use util::tok::Tok;
+use crate::util::tok::Tok;
 use lalrpop_util::ParseError;
 
 grammar<'input>();

--- a/lalrpop-test/src/error_recovery.lalrpop
+++ b/lalrpop-test/src/error_recovery.lalrpop
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 
-use util::tok::Tok;
+use crate::util::tok::Tok;
 use lalrpop_util::ErrorRecovery;
 
 grammar<'e, 'input>(errors: &'e RefCell<Vec<ErrorRecovery<(), Tok<'input>, &'static str>>>);

--- a/lalrpop-test/src/error_recovery_issue_240.lalrpop
+++ b/lalrpop-test/src/error_recovery_issue_240.lalrpop
@@ -1,4 +1,4 @@
-use util::tok::Tok;
+use crate::util::tok::Tok;
 use lalrpop_util::ErrorRecovery;
 
 #[LALR]

--- a/lalrpop-test/src/error_recovery_lalr_loop.lalrpop
+++ b/lalrpop-test/src/error_recovery_lalr_loop.lalrpop
@@ -1,4 +1,4 @@
-use util::tok::Tok;
+use crate::util::tok::Tok;
 use lalrpop_util::ErrorRecovery;
 
 #[LALR]

--- a/lalrpop-test/src/error_recovery_lock_in.lalrpop
+++ b/lalrpop-test/src/error_recovery_lock_in.lalrpop
@@ -1,4 +1,4 @@
-use util::tok::Tok;
+use crate::util::tok::Tok;
 use lalrpop_util::ErrorRecovery;
 
 grammar<'input, 'e>(errors: &'e mut Vec<(usize, ErrorRecovery<usize, Tok<'input>, &'static str>, usize)>);

--- a/lalrpop-test/src/error_recovery_pull_182.lalrpop
+++ b/lalrpop-test/src/error_recovery_pull_182.lalrpop
@@ -1,5 +1,5 @@
 
-use util::tok::Tok;
+use crate::util::tok::Tok;
 use lalrpop_util::ErrorRecovery;
 
 grammar<'input, 'e>(errors: &'e mut Vec<ErrorRecovery<(), Tok<'input>, &'static str>>);

--- a/lalrpop-test/src/error_recovery_span.lalrpop
+++ b/lalrpop-test/src/error_recovery_span.lalrpop
@@ -1,4 +1,4 @@
-use util::tok::Tok;
+use crate::util::tok::Tok;
 
 grammar<'e, 'input>(errors: &'e mut Vec<(usize, usize)>);
 

--- a/lalrpop-test/src/error_recovery_type_in_macro.lalrpop
+++ b/lalrpop-test/src/error_recovery_type_in_macro.lalrpop
@@ -1,5 +1,5 @@
 
-use util::tok::Tok;
+use crate::util::tok::Tok;
 
 #[LALR]
 grammar<'input>();
@@ -18,4 +18,3 @@ Macro<T>: T = {
 pub Expr: ()  = {
     Macro<!> => (),
 };
-

--- a/lalrpop-test/src/expr.lalrpop
+++ b/lalrpop-test/src/expr.lalrpop
@@ -1,6 +1,6 @@
 grammar<'input>(scale: i32);
 
-use util::tok::Tok;
+use crate::util::tok::Tok;
 
 extern {
     enum Tok<'input> {

--- a/lalrpop-test/src/expr_arena.lalrpop
+++ b/lalrpop-test/src/expr_arena.lalrpop
@@ -1,5 +1,5 @@
-use expr_arena_ast::{Arena, Node, Op};
-use util::tok::Tok;
+use crate::expr_arena_ast::{Arena, Node, Op};
+use crate::util::tok::Tok;
 
 grammar<'ast, 'input>(arena: &'ast Arena<'ast>);
 

--- a/lalrpop-test/src/expr_lalr.lalrpop
+++ b/lalrpop-test/src/expr_lalr.lalrpop
@@ -1,7 +1,7 @@
 #[LALR]
 grammar<'input>(scale: i32);
 
-use util::tok::Tok;
+use crate::util::tok::Tok;
 
 extern {
     enum Tok<'input> {

--- a/lalrpop-test/src/expr_module_attributes.lalrpop
+++ b/lalrpop-test/src/expr_module_attributes.lalrpop
@@ -1,6 +1,6 @@
 grammar<'input>(scale: i32);
 
-use util::tok::Tok;
+use crate::util::tok::Tok;
 
 extern {
     enum Tok<'input> {

--- a/lalrpop-test/src/generics_issue_104.lalrpop
+++ b/lalrpop-test/src/generics_issue_104.lalrpop
@@ -1,4 +1,4 @@
-use generics_issue_104_lib::Generator;
+use crate::generics_issue_104_lib::Generator;
 
 grammar<T> where T: Generator;
 

--- a/lalrpop-test/src/generics_issue_417.lalrpop
+++ b/lalrpop-test/src/generics_issue_417.lalrpop
@@ -1,4 +1,4 @@
-use generics_issue_104_lib::Generator;
+use crate::generics_issue_104_lib::Generator;
 
 grammar<T> where T: Generator;
 

--- a/lalrpop-test/src/lifetime_tok.lalrpop
+++ b/lalrpop-test/src/lifetime_tok.lalrpop
@@ -5,7 +5,7 @@
 
 grammar<'input>;
 
-use lifetime_tok_lib::LtTok;
+use crate::lifetime_tok_lib::LtTok;
 
 extern {
     enum LtTok<'input> {

--- a/lalrpop-test/src/loc.lalrpop
+++ b/lalrpop-test/src/loc.lalrpop
@@ -1,4 +1,4 @@
-use util::tok::Tok;
+use crate::util::tok::Tok;
 
 grammar<'input>;
 

--- a/lalrpop-test/src/loc_issue_90.lalrpop
+++ b/lalrpop-test/src/loc_issue_90.lalrpop
@@ -1,4 +1,4 @@
-use loc_issue_90_lib::Expr;
+use crate::loc_issue_90_lib::Expr;
 
 grammar;
 

--- a/lalrpop-test/src/nested.lalrpop
+++ b/lalrpop-test/src/nested.lalrpop
@@ -1,6 +1,6 @@
 grammar<'input>;
 
-use util::tok::{Tok, Delim};
+use crate::util::tok::{Tok, Delim};
 
 extern {
     enum Tok<'input> {

--- a/lalrpop-test/src/pub_in.lalrpop
+++ b/lalrpop-test/src/pub_in.lalrpop
@@ -1,6 +1,6 @@
 grammar<'input>;
 
-use util::tok::Tok;
+use crate::util::tok::Tok;
 
 extern {
     enum Tok<'input> {

--- a/lalrpop-test/src/sub.lalrpop
+++ b/lalrpop-test/src/sub.lalrpop
@@ -1,6 +1,6 @@
 grammar<'input>;
 
-use util::tok::Tok;
+use crate::util::tok::Tok;
 
 extern {
     enum Tok<'input> {
@@ -22,4 +22,3 @@ T = {
     <Num>,
     "(" <E> ")",
 };
-

--- a/lalrpop-test/src/sub_ascent.lalrpop
+++ b/lalrpop-test/src/sub_ascent.lalrpop
@@ -3,7 +3,7 @@
 #[recursive_ascent]
 grammar<'input>;
 
-use util::tok::Tok;
+use crate::util::tok::Tok;
 
 extern {
     enum Tok<'input> {
@@ -26,4 +26,3 @@ T = {
     <Num>,
     "(" <E> ")",
 };
-

--- a/lalrpop-test/src/sub_table.lalrpop
+++ b/lalrpop-test/src/sub_table.lalrpop
@@ -3,7 +3,7 @@
 #[table_driven]
 grammar<'input>;
 
-use util::tok::Tok;
+use crate::util::tok::Tok;
 
 extern {
     enum Tok<'input> {
@@ -25,4 +25,3 @@ T = {
     <Num>,
     "(" <E> ")",
 };
-

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["parsing"]
 license = "Apache-2.0 OR MIT"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 workspace = ".."
+edition = "2021"
 
 exclude = ["build.rs"]
 


### PR DESCRIPTION
As noted in https://github.com/lalrpop/lalrpop/pull/744#issuecomment-1514099999, #727 did not update the edition in all of the workspace members.

I've taken the liberty to update the two remaining `Cargo.toml` files and update the corresponding tests. I think some 2015 edition idioms were left over?

I was thinking about putting the edition in the workspace toml file using https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table, though that uses Rust 1.64 (related to #742).