### PR TITLE
Clippy --all-targets and RangeInclusive

### DIFF
--- a/doc/whitespace/src/lexer.rs
+++ b/doc/whitespace/src/lexer.rs
@@ -49,8 +49,5 @@ fn skip_comments() {
 
     assert_eq!(Lexer::new(source).count(), 8);
 
-    assert!(Lexer::new(source).all(|tok| match tok {
-        Ok((_, Tok::Space, _)) => true,
-        _ => false,
-    }));
+    assert!(Lexer::new(source).all(|tok| matches!(tok, Ok((_, Tok::Space, _)))));
 }

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -1039,7 +1039,7 @@ fn verify_lalrpop_generates_itself() {
     fs::copy(&grammar_file, &copied_grammar_file).expect("no grammar file found");
 
     assert!(Command::new("../target/debug/lalrpop")
-        .args(&[
+        .args([
             "--force",
             "--no-whitespace",
             "--out-dir",

--- a/lalrpop-test/src/util/mod.rs
+++ b/lalrpop-test/src/util/mod.rs
@@ -1,7 +1,6 @@
 //! Utilities for testing.
 
 use crate::util::tok::Tok;
-use diff;
 use lalrpop_util::ParseError;
 use std::fmt::{Debug, Error, Formatter};
 

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -17,7 +17,6 @@ use crate::util::Sep;
 use is_terminal::IsTerminal;
 use itertools::Itertools;
 use lalrpop_util::ParseError;
-use term;
 use tiny_keccak::{Hasher, Sha3};
 
 use std::fs;

--- a/lalrpop/src/lexer/dfa/interpret.rs
+++ b/lalrpop/src/lexer/dfa/interpret.rs
@@ -11,7 +11,7 @@ pub fn interpret<'text>(dfa: &DFA, input: &'text str) -> Option<(NFAIndex, &'tex
             .state(state_index)
             .test_edges
             .iter()
-            .filter_map(|&(test, target)| {
+            .filter_map(|(test, target)| {
                 if test.contains_char(ch) {
                     Some(target)
                 } else {
@@ -21,7 +21,7 @@ pub fn interpret<'text>(dfa: &DFA, input: &'text str) -> Option<(NFAIndex, &'tex
             .next();
 
         if let Some(target) = target {
-            state_index = target;
+            state_index = *target;
         } else {
             state_index = state.other_edge;
         }

--- a/lalrpop/src/lexer/dfa/mod.rs
+++ b/lalrpop/src/lexer/dfa/mod.rs
@@ -122,7 +122,7 @@ impl<'nfa> DFABuilder<'nfa> {
                 .flat_map(|&item| {
                     self.nfa(item)
                         .edges::<Test>(item.nfa_state)
-                        .map(|edge| edge.label)
+                        .map(|edge| edge.label.clone())
                 })
                 .collect();
             let tests = overlap::remove_overlap(&tests);
@@ -167,12 +167,12 @@ impl<'nfa> DFABuilder<'nfa> {
             // for each specific test, find what happens if we see a
             // character matching that test
             let mut test_edges: Vec<(Test, DFAStateIndex)> = tests
-                .iter()
-                .map(|&test| {
+                .into_iter()
+                .map(|test| {
                     let items: Vec<_> = item_set
                         .items
                         .iter()
-                        .filter_map(|&item| self.accept_test(item, test))
+                        .filter_map(|&item| self.accept_test(item, &test))
                         .collect();
 
                     // at least one of those items should accept this test
@@ -225,7 +225,7 @@ impl<'nfa> DFABuilder<'nfa> {
         kernel_set.add_state(item_set)
     }
 
-    fn accept_test(&self, item: Item, test: Test) -> Option<Item> {
+    fn accept_test(&self, item: Item, test: &Test) -> Option<Item> {
         let nfa = self.nfa(item);
 
         let matching_test = nfa

--- a/lalrpop/src/main.rs
+++ b/lalrpop/src/main.rs
@@ -179,24 +179,24 @@ mod test {
         vals.iter().map(|v| v.into()).collect()
     }
 
-    fn parse_args_vec(args: &Vec<&str>) -> Args {
+    fn parse_args(args: &[&str]) -> Args {
         parse_args(Arguments::from_vec(os_vec(args))).unwrap()
     }
 
     #[test]
     fn test_usage_help() {
-        assert!(parse_args_vec(&vec!["--help"]).flag_help);
+        assert!(parse_args_vec(&["--help"]).flag_help);
     }
 
     #[test]
     fn test_usage_version() {
-        assert!(parse_args_vec(&vec!["--version"]).flag_version);
+        assert!(parse_args_vec(&["--version"]).flag_version);
     }
 
     #[test]
     fn test_usage_single_input() {
         assert_eq!(
-            parse_args_vec(&vec!["file.lalrpop"]).arg_inputs,
+            parse_args_vec(&["file.lalrpop"]).arg_inputs,
             ["file.lalrpop"]
         );
     }
@@ -209,21 +209,21 @@ mod test {
 
     #[test]
     fn test_usage_out_dir() {
-        let args = parse_args_vec(&vec!["--out-dir", "abc", "file.lalrpop"]);
+        let args = parse_args_vec(&["--out-dir", "abc", "file.lalrpop"]);
         assert_eq!(args.flag_out_dir, Some(PathBuf::from_str("abc").unwrap()));
         assert_eq!(args.arg_inputs, ["file.lalrpop"]);
     }
 
     #[test]
     fn test_usage_features() {
-        let args = parse_args_vec(&vec!["--features", "test,abc", "file.lalrpop"]);
+        let args = parse_args_vec(&["--features", "test,abc", "file.lalrpop"]);
         assert_eq!(args.flag_features, Some("test,abc".into()));
         assert_eq!(args.arg_inputs, ["file.lalrpop"]);
     }
 
     #[test]
     fn test_usage_emit_whitespace() {
-        let args = parse_args_vec(&vec!["--no-whitespace", "file.lalrpop"]);
+        let args = parse_args_vec(&["--no-whitespace", "file.lalrpop"]);
         assert!(args.flag_no_whitespace);
         assert_eq!(args.arg_inputs, ["file.lalrpop"]);
     }
@@ -231,7 +231,7 @@ mod test {
     #[test]
     fn test_usage_level() {
         assert_eq!(
-            parse_args_vec(&vec!["-l", "info"]).flag_level,
+            parse_args_vec(&["-l", "info"]).flag_level,
             Some(LevelFlag::Info)
         );
     }

--- a/lalrpop/src/message/mod.rs
+++ b/lalrpop/src/message/mod.rs
@@ -6,6 +6,7 @@ use std::fmt::Debug;
 pub mod builder;
 pub mod horiz;
 pub mod indent;
+#[allow(clippy::module_inception)] // A little silly but otherwise fine
 pub mod message;
 pub mod styled;
 #[cfg(test)]

--- a/lalrpop/src/parser/mod.rs
+++ b/lalrpop/src/parser/mod.rs
@@ -3,7 +3,6 @@ use std::iter;
 use crate::grammar::parse_tree::*;
 use crate::grammar::pattern::*;
 use crate::tok;
-use lalrpop_util;
 
 #[cfg(not(feature = "test"))]
 #[rustfmt::skip]

--- a/lalrpop/src/test_util.rs
+++ b/lalrpop/src/test_util.rs
@@ -1,7 +1,6 @@
 use crate::grammar::parse_tree as pt;
 use crate::grammar::repr as r;
 use crate::normalize::NormError;
-use diff;
 use regex::Regex;
 use std::fmt::{Debug, Error, Formatter};
 
@@ -44,7 +43,7 @@ pub fn compare<D: Debug, E: Debug>(actual: D, expected: E) {
             }
         }
 
-        assert!(false);
+        panic!();
     }
 
     /// Ignore differences in `Span` values, by replacing them all with fixed

--- a/lalrpop/src/tok/test.rs
+++ b/lalrpop/src/tok/test.rs
@@ -33,8 +33,8 @@ fn gen_test(input: &str, expected: Vec<(&str, Expectation)>) {
         }
     }
 
-    let tokenizer = Tokenizer::new(&input, 0);
-    assert_eq!(None, tokenizer.skip(len).next());
+    let mut tokenizer = Tokenizer::new(&input, 0);
+    assert_eq!(None, tokenizer.nth(len));
 }
 
 fn test(input: &str, expected: Vec<(&str, Tok)>) {


### PR DESCRIPTION
One more pr with clippy lints from `cargo clippy --all-targets`.

With this, there are three sets of lints left.

- Acronym lints which will be fixed with #740 
- unused import in the nested test case #675
- `#[default]` lint #744

Adjusting `Test` in the lexer to use an actual `Range` was non-trivial. The ranges are documented in comments as being inclusive, though the translation to using `RangeInclusive` was a bit more than expected. I think at some times the ranges were actually treated as exclusive as well, as denoted by the tests. I believe it is now consistent, passing tests, and satisfying the clippy lint but that commit could use an extra look.

Using `RangeInclusive` does mean the struct is no longer `Copy` but I don't think that's too much of an issue.