### PR TITLE
Enable 'unicode' feature on regex-syntax

### DIFF
--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -24,7 +24,7 @@ is-terminal = "0.4.2"
 itertools = { version = "0.10", default_features = false, features = ["use_std"] }
 petgraph = { version = "0.6", default_features = false }
 regex = { version = "1", default_features = false, features = ["std"] }
-regex-syntax = { version = "0.6", default_features = false }
+regex-syntax = { version = "0.6", default_features = false, features = ["unicode"] }
 string_cache = { version = "0.8", default_features = false }
 term = { version = "0.7", default_features = false }
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }


### PR DESCRIPTION
This fixes a compatibility issue with regex 1.8

Closes #750