### PR TITLE
Fail CI if any lines fail

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -1,3 +1,5 @@
+set -e -u -o pipefail
+
 export RUST_BACKTRACE=1
 export CARGO_INCREMENTAL=0
 export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse


### PR DESCRIPTION
The default bash return code is the return code of the last function called.  This means that the CI will only mark as failed if the last command in ci.sh fails.

This can be observed in recent CI runs (for example https://github.com/lalrpop/lalrpop/actions/runs/4765777324/jobs/8471946793) where tests failed, but the CI marked as passed anyways.