### PR TITLE
Fix tests

### DIFF
--- a/lalrpop/src/main.rs
+++ b/lalrpop/src/main.rs
@@ -179,7 +179,7 @@ mod test {
         vals.iter().map(|v| v.into()).collect()
     }
 
-    fn parse_args(args: &[&str]) -> Args {
+    fn parse_args_vec(args: &[&str]) -> Args {
         parse_args(Arguments::from_vec(os_vec(args))).unwrap()
     }
 

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -3859,8 +3859,8 @@ ___reduce188(text, ___lookahead_start, ___symbols, core::marker::PhantomData::<(
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant1(___symbols);
 let ___sym0 = ___pop_Variant85(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = match super::___action430::<>(text, ___sym0, ___sym1) {
 Ok(v) => v,
 Err(e) => return Some(Err(e)),
@@ -4410,8 +4410,8 @@ ___reduce368(text, ___lookahead_start, ___symbols, core::marker::PhantomData::<(
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant1(___symbols);
 let ___sym0 = ___pop_Variant76(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = match super::___action438::<>(text, ___sym0, ___sym1) {
 Ok(v) => v,
 Err(e) => return Some(Err(e)),
@@ -4599,8 +4599,8 @@ ___reduce428(text, ___lookahead_start, ___symbols, core::marker::PhantomData::<(
 429 => {
 // StringConstant = "StringLiteral" => ActionFn(417);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = match super::___action417::<>(text, ___sym0) {
 Ok(v) => v,
 Err(e) => return Some(Err(e)),
@@ -4611,8 +4611,8 @@ ___symbols.push((___start, ___Symbol::Variant87(___nt), ___end));
 430 => {
 // StringLiteral = "StringLiteral" => ActionFn(418);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = match super::___action418::<>(text, ___sym0) {
 Ok(v) => v,
 Err(e) => return Some(Err(e)),
@@ -4860,8 +4860,8 @@ ___reduce509(text, ___lookahead_start, ___symbols, core::marker::PhantomData::<(
 510 => {
 // ___Top = Top => ActionFn(0);
 let ___sym0 = ___pop_Variant91(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action0::<>(text, ___sym0);
 return Some(Ok(___nt));
 }
@@ -5945,8 +5945,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // "::"? = "::" => ActionFn(137);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action137::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant2(___nt), ___end));
 (1, 0)
@@ -5978,8 +5978,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // ";"? = ";" => ActionFn(154);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action154::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant2(___nt), ___end));
 (1, 1)
@@ -6011,8 +6011,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // "mut"? = "mut" => ActionFn(143);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action143::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant2(___nt), ___end));
 (1, 2)
@@ -6046,8 +6046,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant3(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action170::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (2, 3)
@@ -6065,8 +6065,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant3(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action311::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant4(___nt), ___end));
 (2, 4)
@@ -6100,8 +6100,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant3(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action162::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (2, 5)
@@ -6119,8 +6119,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant3(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action316::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant4(___nt), ___end));
 (2, 6)
@@ -6155,8 +6155,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant5(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action166::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant5(___nt), ___end));
 (3, 7)
@@ -6175,8 +6175,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant5(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action319::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant6(___nt), ___end));
 (3, 8)
@@ -6210,8 +6210,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant7(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action151::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant7(___nt), ___end));
 (2, 9)
@@ -6229,8 +6229,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant7(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action322::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant8(___nt), ___end));
 (2, 10)
@@ -6280,8 +6280,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant10(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action243::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant10(___nt), ___end));
 (2, 12)
@@ -6313,8 +6313,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<Alternative> ",")* = (<Alternative> ",")+ => ActionFn(242);
 let ___sym0 = ___pop_Variant11(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action242::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant11(___nt), ___end));
 (1, 13)
@@ -6332,8 +6332,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant10(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action329::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant11(___nt), ___end));
 (2, 14)
@@ -6352,8 +6352,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant10(___symbols);
 let ___sym0 = ___pop_Variant11(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action330::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant11(___nt), ___end));
 (3, 14)
@@ -6371,8 +6371,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant12(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action267::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant12(___nt), ___end));
 (2, 15)
@@ -6404,8 +6404,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<Conversion> ",")* = (<Conversion> ",")+ => ActionFn(266);
 let ___sym0 = ___pop_Variant13(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action266::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant13(___nt), ___end));
 (1, 16)
@@ -6423,8 +6423,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant12(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action333::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant13(___nt), ___end));
 (2, 17)
@@ -6443,8 +6443,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant12(___symbols);
 let ___sym0 = ___pop_Variant13(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action334::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant13(___nt), ___end));
 (3, 17)
@@ -6462,8 +6462,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant14(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action128::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant14(___nt), ___end));
 (2, 18)
@@ -6495,8 +6495,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<FieldPattern> ",")* = (<FieldPattern> ",")+ => ActionFn(127);
 let ___sym0 = ___pop_Variant15(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action127::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant15(___nt), ___end));
 (1, 19)
@@ -6514,8 +6514,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant14(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action337::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant15(___nt), ___end));
 (2, 20)
@@ -6534,8 +6534,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant14(___symbols);
 let ___sym0 = ___pop_Variant15(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action338::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant15(___nt), ___end));
 (3, 20)
@@ -6553,8 +6553,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant16(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action233::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant16(___nt), ___end));
 (2, 21)
@@ -6586,8 +6586,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<GrammarParameter> ",")* = (<GrammarParameter> ",")+ => ActionFn(232);
 let ___sym0 = ___pop_Variant17(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action232::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant17(___nt), ___end));
 (1, 22)
@@ -6605,8 +6605,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant16(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action343::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant17(___nt), ___end));
 (2, 23)
@@ -6625,8 +6625,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant16(___symbols);
 let ___sym0 = ___pop_Variant17(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action344::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant17(___nt), ___end));
 (3, 23)
@@ -6644,8 +6644,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant18(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action210::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant18(___nt), ___end));
 (2, 24)
@@ -6677,8 +6677,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<GrammarWhereClause> ",")* = (<GrammarWhereClause> ",")+ => ActionFn(209);
 let ___sym0 = ___pop_Variant19(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action209::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant19(___nt), ___end));
 (1, 25)
@@ -6696,8 +6696,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant18(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action347::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant19(___nt), ___end));
 (2, 26)
@@ -6716,8 +6716,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant18(___symbols);
 let ___sym0 = ___pop_Variant19(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action348::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant19(___nt), ___end));
 (3, 26)
@@ -6735,8 +6735,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant20(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action136::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant20(___nt), ___end));
 (2, 27)
@@ -6768,8 +6768,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<Id> "::")* = (<Id> "::")+ => ActionFn(135);
 let ___sym0 = ___pop_Variant21(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action135::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant21(___nt), ___end));
 (1, 28)
@@ -6787,8 +6787,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant20(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action351::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant21(___nt), ___end));
 (2, 29)
@@ -6807,8 +6807,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant20(___symbols);
 let ___sym0 = ___pop_Variant21(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action352::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant21(___nt), ___end));
 (3, 29)
@@ -6826,8 +6826,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant22(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action213::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant22(___nt), ___end));
 (2, 30)
@@ -6859,8 +6859,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<Lifetime> "+")* = (<Lifetime> "+")+ => ActionFn(212);
 let ___sym0 = ___pop_Variant23(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action212::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant23(___nt), ___end));
 (1, 31)
@@ -6878,8 +6878,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant22(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action357::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant23(___nt), ___end));
 (2, 32)
@@ -6898,8 +6898,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant22(___symbols);
 let ___sym0 = ___pop_Variant23(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action358::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant23(___nt), ___end));
 (3, 32)
@@ -6917,8 +6917,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant24(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action262::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant24(___nt), ___end));
 (2, 33)
@@ -6950,8 +6950,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<MatchItem> ",")* = (<MatchItem> ",")+ => ActionFn(261);
 let ___sym0 = ___pop_Variant25(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action261::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant25(___nt), ___end));
 (1, 34)
@@ -6969,8 +6969,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant24(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action361::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant25(___nt), ___end));
 (2, 35)
@@ -6989,8 +6989,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant24(___symbols);
 let ___sym0 = ___pop_Variant25(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action362::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant25(___nt), ___end));
 (3, 35)
@@ -7008,8 +7008,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant26(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action238::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant26(___nt), ___end));
 (2, 36)
@@ -7041,8 +7041,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<NotMacroId> ",")* = (<NotMacroId> ",")+ => ActionFn(237);
 let ___sym0 = ___pop_Variant27(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action237::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant27(___nt), ___end));
 (1, 37)
@@ -7060,8 +7060,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant26(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action365::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant27(___nt), ___end));
 (2, 38)
@@ -7080,8 +7080,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant26(___symbols);
 let ___sym0 = ___pop_Variant27(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action366::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant27(___nt), ___end));
 (3, 38)
@@ -7099,8 +7099,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant28(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action272::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant28(___nt), ___end));
 (2, 39)
@@ -7132,8 +7132,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<Pattern> ",")* = (<Pattern> ",")+ => ActionFn(271);
 let ___sym0 = ___pop_Variant29(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action271::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant29(___nt), ___end));
 (1, 40)
@@ -7151,8 +7151,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant28(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action369::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant29(___nt), ___end));
 (2, 41)
@@ -7171,8 +7171,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant28(___symbols);
 let ___sym0 = ___pop_Variant29(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action370::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant29(___nt), ___end));
 (3, 41)
@@ -7190,8 +7190,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant30(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action248::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant30(___nt), ___end));
 (2, 42)
@@ -7223,8 +7223,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<Symbol> ",")* = (<Symbol> ",")+ => ActionFn(247);
 let ___sym0 = ___pop_Variant31(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action247::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant31(___nt), ___end));
 (1, 43)
@@ -7242,8 +7242,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant30(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action373::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant31(___nt), ___end));
 (2, 44)
@@ -7262,8 +7262,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant30(___symbols);
 let ___sym0 = ___pop_Variant31(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action374::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant31(___nt), ___end));
 (3, 44)
@@ -7281,8 +7281,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant32(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action218::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant32(___nt), ___end));
 (2, 45)
@@ -7314,8 +7314,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<TypeBound> "+")* = (<TypeBound> "+")+ => ActionFn(217);
 let ___sym0 = ___pop_Variant33(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action217::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant33(___nt), ___end));
 (1, 46)
@@ -7333,8 +7333,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant32(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action377::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant33(___nt), ___end));
 (2, 47)
@@ -7353,8 +7353,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant32(___symbols);
 let ___sym0 = ___pop_Variant33(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action378::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant33(___nt), ___end));
 (3, 47)
@@ -7372,8 +7372,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant34(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action228::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant34(___nt), ___end));
 (2, 48)
@@ -7405,8 +7405,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<TypeBoundParameter> ",")* = (<TypeBoundParameter> ",")+ => ActionFn(227);
 let ___sym0 = ___pop_Variant35(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action227::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant35(___nt), ___end));
 (1, 49)
@@ -7424,8 +7424,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant34(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action381::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant35(___nt), ___end));
 (2, 50)
@@ -7444,8 +7444,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant34(___symbols);
 let ___sym0 = ___pop_Variant35(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action382::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant35(___nt), ___end));
 (3, 50)
@@ -7463,8 +7463,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant36(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action205::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant36(___nt), ___end));
 (2, 51)
@@ -7496,8 +7496,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<TypeParameter> ",")* = (<TypeParameter> ",")+ => ActionFn(204);
 let ___sym0 = ___pop_Variant37(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action204::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant37(___nt), ___end));
 (1, 52)
@@ -7515,8 +7515,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant36(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action385::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant37(___nt), ___end));
 (2, 53)
@@ -7535,8 +7535,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant36(___symbols);
 let ___sym0 = ___pop_Variant37(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action386::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant37(___nt), ___end));
 (3, 53)
@@ -7554,8 +7554,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant3(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action223::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (2, 54)
@@ -7587,8 +7587,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<TypeRef> ",")* = (<TypeRef> ",")+ => ActionFn(222);
 let ___sym0 = ___pop_Variant38(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action222::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant38(___nt), ___end));
 (1, 55)
@@ -7606,8 +7606,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant3(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action389::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant38(___nt), ___end));
 (2, 56)
@@ -7626,8 +7626,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant3(___symbols);
 let ___sym0 = ___pop_Variant38(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action390::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant38(___nt), ___end));
 (3, 56)
@@ -7645,8 +7645,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant3(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action253::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (2, 57)
@@ -7678,8 +7678,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // (<TypeRefOrLifetime> ",")* = (<TypeRefOrLifetime> ",")+ => ActionFn(252);
 let ___sym0 = ___pop_Variant38(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action252::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant38(___nt), ___end));
 (1, 58)
@@ -7697,8 +7697,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant3(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action393::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant38(___nt), ___end));
 (2, 59)
@@ -7717,8 +7717,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant3(___symbols);
 let ___sym0 = ___pop_Variant38(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action394::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant38(___nt), ___end));
 (3, 59)
@@ -7766,8 +7766,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Action = "=>@L" => ActionFn(43);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action43::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant40(___nt), ___end));
 (1, 62)
@@ -7783,8 +7783,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Action = "=>@R" => ActionFn(44);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action44::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant40(___nt), ___end));
 (1, 62)
@@ -7800,8 +7800,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Action = "=>" => ActionFn(45);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action45::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant40(___nt), ___end));
 (1, 62)
@@ -7817,8 +7817,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Action = "=>?" => ActionFn(46);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action46::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant40(___nt), ___end));
 (1, 62)
@@ -7834,8 +7834,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Action? = Action => ActionFn(147);
 let ___sym0 = ___pop_Variant40(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action147::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant41(___nt), ___end));
 (1, 63)
@@ -7871,8 +7871,8 @@ let ___sym3 = ___pop_Variant40(___symbols);
 let ___sym2 = ___pop_Variant7(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant31(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action456::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant10(___nt), ___end));
 (4, 64)
@@ -7893,8 +7893,8 @@ let ___sym3 = ___pop_Variant7(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant31(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action457::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant10(___nt), ___end));
 (5, 64)
@@ -7913,8 +7913,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant7(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant31(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action458::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant10(___nt), ___end));
 (3, 64)
@@ -7934,8 +7934,8 @@ let ___sym3 = ___pop_Variant7(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant31(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action459::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant10(___nt), ___end));
 (4, 64)
@@ -7953,8 +7953,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant40(___symbols);
 let ___sym0 = ___pop_Variant31(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action460::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant10(___nt), ___end));
 (2, 64)
@@ -7973,8 +7973,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant40(___symbols);
 let ___sym1 = ___pop_Variant31(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action461::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant10(___nt), ___end));
 (3, 64)
@@ -7990,8 +7990,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Alternative = Symbol+ => ActionFn(462);
 let ___sym0 = ___pop_Variant31(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action462::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant10(___nt), ___end));
 (1, 64)
@@ -8009,8 +8009,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant31(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action463::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant10(___nt), ___end));
 (2, 64)
@@ -8029,8 +8029,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant40(___symbols);
 let ___sym1 = ___pop_Variant7(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action425::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant10(___nt), ___end));
 (3, 64)
@@ -8046,8 +8046,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Alternative = Action => ActionFn(426);
 let ___sym0 = ___pop_Variant40(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action426::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant10(___nt), ___end));
 (1, 64)
@@ -8063,8 +8063,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Alternative? = Alternative => ActionFn(239);
 let ___sym0 = ___pop_Variant10(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action239::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant42(___nt), ___end));
 (1, 65)
@@ -8098,8 +8098,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant10(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action39::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant43(___nt), ___end));
 (2, 66)
@@ -8119,8 +8119,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant43(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action305::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant43(___nt), ___end));
 (4, 66)
@@ -8139,8 +8139,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant43(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action306::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant43(___nt), ___end));
 (3, 66)
@@ -8161,8 +8161,8 @@ let ___sym3 = ___pop_Variant46(___symbols);
 let ___sym2 = ___pop_Variant20(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action470::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant44(___nt), ___end));
 (5, 67)
@@ -8182,8 +8182,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant20(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action471::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant44(___nt), ___end));
 (4, 67)
@@ -8215,8 +8215,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Annotation* = Annotation+ => ActionFn(188);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action188::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant45(___nt), ___end));
 (1, 68)
@@ -8232,8 +8232,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Annotation+ = Annotation => ActionFn(197);
 let ___sym0 = ___pop_Variant44(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action197::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant45(___nt), ___end));
 (1, 69)
@@ -8251,8 +8251,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant44(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action198::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant45(___nt), ___end));
 (2, 69)
@@ -8273,8 +8273,8 @@ let ___sym3 = ___pop_Variant1(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant20(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action34::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant46(___nt), ___end));
 (5, 70)
@@ -8290,8 +8290,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // AnnotationArg? = AnnotationArg => ActionFn(158);
 let ___sym0 = ___pop_Variant46(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action158::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant47(___nt), ___end));
 (1, 71)
@@ -8328,8 +8328,8 @@ let ___sym3 = ___pop_Variant3(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant20(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action428::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant48(___nt), ___end));
 (5, 72)
@@ -8361,8 +8361,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // AssociatedType* = AssociatedType+ => ActionFn(133);
 let ___sym0 = ___pop_Variant49(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action133::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant49(___nt), ___end));
 (1, 73)
@@ -8378,8 +8378,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // AssociatedType+ = AssociatedType => ActionFn(256);
 let ___sym0 = ___pop_Variant48(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action256::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant49(___nt), ___end));
 (1, 74)
@@ -8397,8 +8397,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant48(___symbols);
 let ___sym0 = ___pop_Variant49(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action257::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant49(___nt), ___end));
 (2, 74)
@@ -8414,8 +8414,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<Alternative> = Alternative => ActionFn(452);
 let ___sym0 = ___pop_Variant10(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action452::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant43(___nt), ___end));
 (1, 75)
@@ -8449,8 +8449,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant10(___symbols);
 let ___sym0 = ___pop_Variant11(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action454::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant43(___nt), ___end));
 (2, 75)
@@ -8466,8 +8466,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<Alternative> = (<Alternative> ",")+ => ActionFn(455);
 let ___sym0 = ___pop_Variant11(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action455::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant43(___nt), ___end));
 (1, 75)
@@ -8483,8 +8483,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<Conversion> = Conversion => ActionFn(478);
 let ___sym0 = ___pop_Variant12(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action478::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant50(___nt), ___end));
 (1, 76)
@@ -8518,8 +8518,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant12(___symbols);
 let ___sym0 = ___pop_Variant13(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action480::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant50(___nt), ___end));
 (2, 76)
@@ -8535,8 +8535,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<Conversion> = (<Conversion> ",")+ => ActionFn(481);
 let ___sym0 = ___pop_Variant13(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action481::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant50(___nt), ___end));
 (1, 76)
@@ -8552,8 +8552,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<GrammarParameter> = GrammarParameter => ActionFn(504);
 let ___sym0 = ___pop_Variant16(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action504::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant51(___nt), ___end));
 (1, 77)
@@ -8587,8 +8587,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant16(___symbols);
 let ___sym0 = ___pop_Variant17(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action506::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant51(___nt), ___end));
 (2, 77)
@@ -8604,8 +8604,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<GrammarParameter> = (<GrammarParameter> ",")+ => ActionFn(507);
 let ___sym0 = ___pop_Variant17(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action507::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant51(___nt), ___end));
 (1, 77)
@@ -8621,8 +8621,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<GrammarWhereClause> = GrammarWhereClause => ActionFn(532);
 let ___sym0 = ___pop_Variant18(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action532::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant52(___nt), ___end));
 (1, 78)
@@ -8656,8 +8656,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant18(___symbols);
 let ___sym0 = ___pop_Variant19(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action534::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant52(___nt), ___end));
 (2, 78)
@@ -8673,8 +8673,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<GrammarWhereClause> = (<GrammarWhereClause> ",")+ => ActionFn(535);
 let ___sym0 = ___pop_Variant19(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action535::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant52(___nt), ___end));
 (1, 78)
@@ -8690,8 +8690,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<MatchItem> = MatchItem => ActionFn(576);
 let ___sym0 = ___pop_Variant24(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action576::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant53(___nt), ___end));
 (1, 79)
@@ -8725,8 +8725,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant24(___symbols);
 let ___sym0 = ___pop_Variant25(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action578::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant53(___nt), ___end));
 (2, 79)
@@ -8742,8 +8742,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<MatchItem> = (<MatchItem> ",")+ => ActionFn(579);
 let ___sym0 = ___pop_Variant25(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action579::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant53(___nt), ___end));
 (1, 79)
@@ -8759,8 +8759,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<NotMacroId> = NotMacroId => ActionFn(580);
 let ___sym0 = ___pop_Variant26(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action580::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant54(___nt), ___end));
 (1, 80)
@@ -8794,8 +8794,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant26(___symbols);
 let ___sym0 = ___pop_Variant27(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action582::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant54(___nt), ___end));
 (2, 80)
@@ -8811,8 +8811,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<NotMacroId> = (<NotMacroId> ",")+ => ActionFn(583);
 let ___sym0 = ___pop_Variant27(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action583::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant54(___nt), ___end));
 (1, 80)
@@ -8828,8 +8828,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<Pattern> = Pattern => ActionFn(584);
 let ___sym0 = ___pop_Variant28(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action584::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant55(___nt), ___end));
 (1, 81)
@@ -8863,8 +8863,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant28(___symbols);
 let ___sym0 = ___pop_Variant29(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action586::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant55(___nt), ___end));
 (2, 81)
@@ -8880,8 +8880,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<Pattern> = (<Pattern> ",")+ => ActionFn(587);
 let ___sym0 = ___pop_Variant29(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action587::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant55(___nt), ___end));
 (1, 81)
@@ -8897,8 +8897,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<Symbol> = Symbol => ActionFn(654);
 let ___sym0 = ___pop_Variant30(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action654::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant56(___nt), ___end));
 (1, 82)
@@ -8932,8 +8932,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant30(___symbols);
 let ___sym0 = ___pop_Variant31(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action656::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant56(___nt), ___end));
 (2, 82)
@@ -8949,8 +8949,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<Symbol> = (<Symbol> ",")+ => ActionFn(657);
 let ___sym0 = ___pop_Variant31(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action657::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant56(___nt), ___end));
 (1, 82)
@@ -8966,8 +8966,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<TypeBoundParameter> = TypeBoundParameter => ActionFn(662);
 let ___sym0 = ___pop_Variant34(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action662::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant5(___nt), ___end));
 (1, 83)
@@ -9001,8 +9001,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant34(___symbols);
 let ___sym0 = ___pop_Variant35(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action664::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant5(___nt), ___end));
 (2, 83)
@@ -9018,8 +9018,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<TypeBoundParameter> = (<TypeBoundParameter> ",")+ => ActionFn(665);
 let ___sym0 = ___pop_Variant35(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action665::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant5(___nt), ___end));
 (1, 83)
@@ -9035,8 +9035,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<TypeParameter> = TypeParameter => ActionFn(666);
 let ___sym0 = ___pop_Variant36(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action666::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant57(___nt), ___end));
 (1, 84)
@@ -9070,8 +9070,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant36(___symbols);
 let ___sym0 = ___pop_Variant37(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action668::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant57(___nt), ___end));
 (2, 84)
@@ -9087,8 +9087,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<TypeParameter> = (<TypeParameter> ",")+ => ActionFn(669);
 let ___sym0 = ___pop_Variant37(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action669::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant57(___nt), ___end));
 (1, 84)
@@ -9104,8 +9104,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<TypeRef> = TypeRef => ActionFn(670);
 let ___sym0 = ___pop_Variant3(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action670::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant58(___nt), ___end));
 (1, 85)
@@ -9139,8 +9139,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant3(___symbols);
 let ___sym0 = ___pop_Variant38(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action672::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant58(___nt), ___end));
 (2, 85)
@@ -9156,8 +9156,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<TypeRef> = (<TypeRef> ",")+ => ActionFn(673);
 let ___sym0 = ___pop_Variant38(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action673::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant58(___nt), ___end));
 (1, 85)
@@ -9173,8 +9173,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<TypeRefOrLifetime> = TypeRefOrLifetime => ActionFn(674);
 let ___sym0 = ___pop_Variant3(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action674::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant58(___nt), ___end));
 (1, 86)
@@ -9208,8 +9208,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant3(___symbols);
 let ___sym0 = ___pop_Variant38(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action676::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant58(___nt), ___end));
 (2, 86)
@@ -9225,8 +9225,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Comma<TypeRefOrLifetime> = (<TypeRefOrLifetime> ",")+ => ActionFn(677);
 let ___sym0 = ___pop_Variant38(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action677::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant58(___nt), ___end));
 (1, 86)
@@ -9245,8 +9245,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant20(___symbols);
 let ___sym1 = ___pop_Variant59(___symbols);
 let ___sym0 = ___pop_Variant26(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action429::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant7(___nt), ___end));
 (3, 87)
@@ -9262,8 +9262,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // CondOp = "==" => ActionFn(48);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action48::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant59(___nt), ___end));
 (1, 88)
@@ -9279,8 +9279,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // CondOp = "!=" => ActionFn(49);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action49::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant59(___nt), ___end));
 (1, 88)
@@ -9296,8 +9296,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // CondOp = "~~" => ActionFn(50);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action50::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant59(___nt), ___end));
 (1, 88)
@@ -9313,8 +9313,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // CondOp = "!~" => ActionFn(51);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action51::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant59(___nt), ___end));
 (1, 88)
@@ -9330,8 +9330,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Conversion? = Conversion => ActionFn(263);
 let ___sym0 = ___pop_Variant12(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action263::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant60(___nt), ___end));
 (1, 90)
@@ -9368,8 +9368,8 @@ let ___sym3 = ___pop_Variant50(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant3(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action431::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant61(___nt), ___end));
 (5, 91)
@@ -9385,8 +9385,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Escape = "Escape" => ActionFn(113);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action113::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant20(___nt), ___end));
 (1, 92)
@@ -9418,8 +9418,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // ExprSymbol = Symbol+ => ActionFn(653);
 let ___sym0 = ___pop_Variant31(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action653::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant62(___nt), ___end));
 (1, 93)
@@ -9439,8 +9439,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant61(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action472::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (4, 94)
@@ -9461,8 +9461,8 @@ let ___sym3 = ___pop_Variant49(___symbols);
 let ___sym2 = ___pop_Variant61(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action473::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (5, 94)
@@ -9483,8 +9483,8 @@ let ___sym3 = ___pop_Variant61(___symbols);
 let ___sym2 = ___pop_Variant49(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action474::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (5, 94)
@@ -9506,8 +9506,8 @@ let ___sym3 = ___pop_Variant61(___symbols);
 let ___sym2 = ___pop_Variant49(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action475::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (6, 94)
@@ -9526,8 +9526,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action476::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (3, 94)
@@ -9547,8 +9547,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant49(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action477::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (4, 94)
@@ -9567,8 +9567,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant28(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant20(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action434::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant14(___nt), ___end));
 (3, 95)
@@ -9584,8 +9584,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // FieldPattern? = FieldPattern => ActionFn(124);
 let ___sym0 = ___pop_Variant14(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action124::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant64(___nt), ___end));
 (1, 96)
@@ -9621,8 +9621,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action13::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant57(___nt), ___end));
 (4, 97)
@@ -9659,8 +9659,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant57(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action678::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -9682,8 +9682,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action679::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -9705,8 +9705,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action680::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -9729,8 +9729,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action681::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -9750,8 +9750,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant57(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action682::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -9772,8 +9772,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action683::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -9794,8 +9794,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action684::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -9817,8 +9817,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action685::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -9838,8 +9838,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant52(___symbols);
 let ___sym1 = ___pop_Variant51(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action686::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -9860,8 +9860,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action687::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -9882,8 +9882,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action688::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -9905,8 +9905,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action689::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -9925,8 +9925,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant51(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action690::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (3, 98)
@@ -9946,8 +9946,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action691::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -9967,8 +9967,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action692::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -9989,8 +9989,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action693::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -10010,8 +10010,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant52(___symbols);
 let ___sym1 = ___pop_Variant57(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action694::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -10032,8 +10032,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action695::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -10054,8 +10054,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action696::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -10077,8 +10077,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action697::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -10097,8 +10097,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant57(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action698::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (3, 98)
@@ -10118,8 +10118,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action699::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -10139,8 +10139,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action700::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -10161,8 +10161,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action701::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -10181,8 +10181,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant52(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action702::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (3, 98)
@@ -10202,8 +10202,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant52(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action703::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -10223,8 +10223,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant52(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action704::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -10245,8 +10245,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action705::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -10264,8 +10264,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action706::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (2, 98)
@@ -10284,8 +10284,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action707::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (3, 98)
@@ -10304,8 +10304,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action708::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (3, 98)
@@ -10325,8 +10325,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action709::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -10348,8 +10348,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant57(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action710::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -10372,8 +10372,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action711::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -10396,8 +10396,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action712::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -10421,8 +10421,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym7.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym7.2;
 let ___nt = super::___action713::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6, ___sym7);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (8, 98)
@@ -10443,8 +10443,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant57(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action714::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -10466,8 +10466,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action715::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -10489,8 +10489,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action716::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -10513,8 +10513,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action717::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -10535,8 +10535,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant52(___symbols);
 let ___sym1 = ___pop_Variant51(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action718::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -10558,8 +10558,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action719::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -10581,8 +10581,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action720::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -10605,8 +10605,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action721::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -10626,8 +10626,8 @@ let ___sym3 = ___pop_Variant66(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant51(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action722::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -10648,8 +10648,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action723::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -10670,8 +10670,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action724::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -10693,8 +10693,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action725::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -10715,8 +10715,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant52(___symbols);
 let ___sym1 = ___pop_Variant57(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action726::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -10738,8 +10738,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action727::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -10761,8 +10761,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action728::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -10785,8 +10785,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action729::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -10806,8 +10806,8 @@ let ___sym3 = ___pop_Variant66(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant57(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action730::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -10828,8 +10828,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action731::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -10850,8 +10850,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action732::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -10873,8 +10873,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action733::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -10894,8 +10894,8 @@ let ___sym3 = ___pop_Variant66(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant52(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action734::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -10916,8 +10916,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant52(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action735::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -10938,8 +10938,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant52(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action736::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -10961,8 +10961,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action737::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -10981,8 +10981,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant66(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action738::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (3, 98)
@@ -11002,8 +11002,8 @@ let ___sym3 = ___pop_Variant66(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action739::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -11023,8 +11023,8 @@ let ___sym3 = ___pop_Variant66(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action740::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -11045,8 +11045,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action741::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -11068,8 +11068,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action742::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -11092,8 +11092,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action743::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -11116,8 +11116,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action744::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -11141,8 +11141,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym7.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym7.2;
 let ___nt = super::___action745::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6, ___sym7);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (8, 98)
@@ -11163,8 +11163,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action746::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -11186,8 +11186,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action747::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -11209,8 +11209,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action748::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -11233,8 +11233,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action749::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -11255,8 +11255,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action750::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -11278,8 +11278,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action751::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -11301,8 +11301,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action752::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -11325,8 +11325,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action753::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -11346,8 +11346,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action754::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -11368,8 +11368,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action755::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -11390,8 +11390,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action756::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -11413,8 +11413,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action757::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -11435,8 +11435,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action758::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -11458,8 +11458,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action759::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -11481,8 +11481,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action760::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -11505,8 +11505,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action761::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -11526,8 +11526,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action762::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -11548,8 +11548,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action763::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -11570,8 +11570,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action764::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -11593,8 +11593,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action765::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -11614,8 +11614,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant52(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action766::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -11636,8 +11636,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action767::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -11658,8 +11658,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action768::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -11681,8 +11681,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action769::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -11701,8 +11701,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action770::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (3, 98)
@@ -11722,8 +11722,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action771::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -11743,8 +11743,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action772::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -11765,8 +11765,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action773::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -11789,8 +11789,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action774::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -11814,8 +11814,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym7.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym7.2;
 let ___nt = super::___action775::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6, ___sym7);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (8, 98)
@@ -11839,8 +11839,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym7.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym7.2;
 let ___nt = super::___action776::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6, ___sym7);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (8, 98)
@@ -11865,8 +11865,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym8.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym8.2;
 let ___nt = super::___action777::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6, ___sym7, ___sym8);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (9, 98)
@@ -11888,8 +11888,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action778::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -11912,8 +11912,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action779::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -11936,8 +11936,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action780::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -11961,8 +11961,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym7.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym7.2;
 let ___nt = super::___action781::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6, ___sym7);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (8, 98)
@@ -11984,8 +11984,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action782::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -12008,8 +12008,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action783::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -12032,8 +12032,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action784::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -12057,8 +12057,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym7.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym7.2;
 let ___nt = super::___action785::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6, ___sym7);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (8, 98)
@@ -12079,8 +12079,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant51(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action786::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -12102,8 +12102,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action787::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -12125,8 +12125,8 @@ let ___sym3 = ___pop_Variant51(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action788::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -12149,8 +12149,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action789::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -12172,8 +12172,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action790::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -12196,8 +12196,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action791::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -12220,8 +12220,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action792::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -12245,8 +12245,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym7.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym7.2;
 let ___nt = super::___action793::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6, ___sym7);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (8, 98)
@@ -12267,8 +12267,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action794::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -12290,8 +12290,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action795::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -12313,8 +12313,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action796::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -12337,8 +12337,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action797::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -12359,8 +12359,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant52(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action798::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -12382,8 +12382,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action799::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -12405,8 +12405,8 @@ let ___sym3 = ___pop_Variant52(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action800::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -12429,8 +12429,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action801::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (7, 98)
@@ -12450,8 +12450,8 @@ let ___sym3 = ___pop_Variant66(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action802::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (4, 98)
@@ -12472,8 +12472,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action803::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -12494,8 +12494,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant45(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action804::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (5, 98)
@@ -12517,8 +12517,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant45(___symbols);
 let ___sym1 = ___pop_Variant66(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action805::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant65(___nt), ___end));
 (6, 98)
@@ -12534,8 +12534,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // GrammarItem = Use => ActionFn(24);
 let ___sym0 = ___pop_Variant63(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action24::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (1, 99)
@@ -12551,8 +12551,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // GrammarItem = MatchToken => ActionFn(25);
 let ___sym0 = ___pop_Variant63(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action25::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (1, 99)
@@ -12568,8 +12568,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // GrammarItem = ExternToken => ActionFn(26);
 let ___sym0 = ___pop_Variant63(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action26::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (1, 99)
@@ -12585,8 +12585,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // GrammarItem = Nonterminal => ActionFn(27);
 let ___sym0 = ___pop_Variant63(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action27::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (1, 99)
@@ -12618,8 +12618,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // GrammarItem* = GrammarItem+ => ActionFn(178);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action178::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant66(___nt), ___end));
 (1, 100)
@@ -12635,8 +12635,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // GrammarItem+ = GrammarItem => ActionFn(199);
 let ___sym0 = ___pop_Variant63(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action199::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant66(___nt), ___end));
 (1, 101)
@@ -12654,8 +12654,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant63(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action200::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant66(___nt), ___end));
 (2, 101)
@@ -12674,8 +12674,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant3(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant20(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action23::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant16(___nt), ___end));
 (3, 102)
@@ -12691,8 +12691,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // GrammarParameter? = GrammarParameter => ActionFn(229);
 let ___sym0 = ___pop_Variant16(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action229::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant67(___nt), ___end));
 (1, 103)
@@ -12727,8 +12727,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant51(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action22::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant51(___nt), ___end));
 (3, 104)
@@ -12744,8 +12744,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // GrammarParameters? = GrammarParameters => ActionFn(181);
 let ___sym0 = ___pop_Variant51(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action181::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant68(___nt), ___end));
 (1, 105)
@@ -12780,8 +12780,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant57(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action7::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant57(___nt), ___end));
 (3, 106)
@@ -12797,8 +12797,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // GrammarTypeParameters? = GrammarTypeParameters => ActionFn(183);
 let ___sym0 = ___pop_Variant57(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action183::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant69(___nt), ___end));
 (1, 107)
@@ -12833,8 +12833,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant83(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant22(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action11::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant18(___nt), ___end));
 (3, 108)
@@ -12857,8 +12857,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action486::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant18(___nt), ___end));
 (7, 108)
@@ -12877,8 +12877,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant84(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant3(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action487::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant18(___nt), ___end));
 (3, 108)
@@ -12894,8 +12894,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // GrammarWhereClause? = GrammarWhereClause => ActionFn(206);
 let ___sym0 = ___pop_Variant18(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action206::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant70(___nt), ___end));
 (1, 109)
@@ -12929,8 +12929,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant52(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action10::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant52(___nt), ___end));
 (2, 110)
@@ -12946,8 +12946,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // GrammarWhereClauses? = GrammarWhereClauses => ActionFn(179);
 let ___sym0 = ___pop_Variant52(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action179::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant71(___nt), ___end));
 (1, 111)
@@ -12979,8 +12979,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Id = "Id" => ActionFn(111);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action111::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant20(___nt), ___end));
 (1, 112)
@@ -12996,8 +12996,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Id = "MacroId" => ActionFn(112);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action112::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant20(___nt), ___end));
 (1, 112)
@@ -13013,8 +13013,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Lifetime = "Lifetime" => ActionFn(114);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action114::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant22(___nt), ___end));
 (1, 113)
@@ -13030,8 +13030,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Lifetime? = Lifetime => ActionFn(140);
 let ___sym0 = ___pop_Variant22(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action140::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant72(___nt), ___end));
 (1, 114)
@@ -13063,8 +13063,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // MacroId = "MacroId" => ActionFn(109);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action109::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant26(___nt), ___end));
 (1, 115)
@@ -13080,8 +13080,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // MatchContents = Comma<MatchItem> => ActionFn(87);
 let ___sym0 = ___pop_Variant53(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action87::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant73(___nt), ___end));
 (1, 116)
@@ -13097,8 +13097,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // MatchItem = "_" => ActionFn(436);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action436::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant24(___nt), ___end));
 (1, 117)
@@ -13114,8 +13114,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // MatchItem = MatchSymbol => ActionFn(437);
 let ___sym0 = ___pop_Variant76(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action437::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant24(___nt), ___end));
 (1, 117)
@@ -13131,8 +13131,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // MatchItem? = MatchItem => ActionFn(258);
 let ___sym0 = ___pop_Variant24(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action258::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant74(___nt), ___end));
 (1, 118)
@@ -13164,8 +13164,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // MatchMapping = Terminal => ActionFn(92);
 let ___sym0 = ___pop_Variant85(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action92::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant75(___nt), ___end));
 (1, 119)
@@ -13183,8 +13183,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action93::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant75(___nt), ___end));
 (2, 119)
@@ -13200,8 +13200,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // MatchSymbol = QuotedLiteral => ActionFn(91);
 let ___sym0 = ___pop_Variant76(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action91::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant76(___nt), ___end));
 (1, 120)
@@ -13217,8 +13217,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // MatchToken = MatchTokenInt => ActionFn(84);
 let ___sym0 = ___pop_Variant77(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action84::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (1, 121)
@@ -13239,8 +13239,8 @@ let ___sym3 = ___pop_Variant73(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant77(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action85::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant77(___nt), ___end));
 (5, 122)
@@ -13260,8 +13260,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant73(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action439::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant77(___nt), ___end));
 (4, 122)
@@ -13283,8 +13283,8 @@ let ___sym3 = ___pop_Variant3(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant78(___symbols);
 let ___sym0 = ___pop_Variant95(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action466::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (6, 123)
@@ -13307,8 +13307,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant78(___symbols);
 let ___sym1 = ___pop_Variant95(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action467::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (7, 123)
@@ -13328,8 +13328,8 @@ let ___sym3 = ___pop_Variant43(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant78(___symbols);
 let ___sym0 = ___pop_Variant95(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action468::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (4, 123)
@@ -13350,8 +13350,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant78(___symbols);
 let ___sym1 = ___pop_Variant95(___symbols);
 let ___sym0 = ___pop_Variant45(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action469::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (5, 123)
@@ -13371,8 +13371,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant54(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant26(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action36::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant78(___nt), ___end));
 (4, 124)
@@ -13388,8 +13388,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // NonterminalName = NotMacroId => ActionFn(37);
 let ___sym0 = ___pop_Variant26(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action37::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant78(___nt), ___end));
 (1, 124)
@@ -13405,8 +13405,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // NonterminalName = "Escape" => ActionFn(38);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action38::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant78(___nt), ___end));
 (1, 124)
@@ -13422,8 +13422,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // NotMacroId = "Id" => ActionFn(110);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action110::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant26(___nt), ___end));
 (1, 125)
@@ -13439,8 +13439,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // NotMacroId? = NotMacroId => ActionFn(234);
 let ___sym0 = ___pop_Variant26(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action234::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant79(___nt), ___end));
 (1, 126)
@@ -13474,8 +13474,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant20(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action353::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant80(___nt), ___end));
 (2, 127)
@@ -13494,8 +13494,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant20(___symbols);
 let ___sym1 = ___pop_Variant21(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action354::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant80(___nt), ___end));
 (3, 127)
@@ -13511,8 +13511,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Path = Id => ActionFn(355);
 let ___sym0 = ___pop_Variant20(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action355::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant80(___nt), ___end));
 (1, 127)
@@ -13530,8 +13530,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant20(___symbols);
 let ___sym0 = ___pop_Variant21(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action356::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant80(___nt), ___end));
 (2, 127)
@@ -13547,8 +13547,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Pattern = PatternKind => ActionFn(442);
 let ___sym0 = ___pop_Variant82(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action442::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant28(___nt), ___end));
 (1, 128)
@@ -13564,8 +13564,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Pattern? = Pattern => ActionFn(268);
 let ___sym0 = ___pop_Variant28(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action268::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant81(___nt), ___end));
 (1, 129)
@@ -13601,8 +13601,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant55(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant80(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action98::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant82(___nt), ___end));
 (4, 130)
@@ -13622,8 +13622,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant14(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant80(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action482::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant82(___nt), ___end));
 (4, 130)
@@ -13642,8 +13642,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant80(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action483::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant82(___nt), ___end));
 (3, 130)
@@ -13664,8 +13664,8 @@ let ___sym3 = ___pop_Variant14(___symbols);
 let ___sym2 = ___pop_Variant15(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant80(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action484::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant82(___nt), ___end));
 (5, 130)
@@ -13685,8 +13685,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant15(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant80(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action485::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant82(___nt), ___end));
 (4, 130)
@@ -13706,8 +13706,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant80(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action341::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant82(___nt), ___end));
 (4, 130)
@@ -13728,8 +13728,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant15(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant80(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action342::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant82(___nt), ___end));
 (5, 130)
@@ -13745,8 +13745,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // PatternKind = "_" => ActionFn(101);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action101::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant82(___nt), ___end));
 (1, 130)
@@ -13762,8 +13762,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // PatternKind = ".." => ActionFn(102);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action102::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant82(___nt), ___end));
 (1, 130)
@@ -13782,8 +13782,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant3(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action103::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant82(___nt), ___end));
 (3, 130)
@@ -13802,8 +13802,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant55(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action104::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant82(___nt), ___end));
 (3, 130)
@@ -13819,8 +13819,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // PatternKind = "CharLiteral" => ActionFn(105);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action105::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant82(___nt), ___end));
 (1, 130)
@@ -13836,8 +13836,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // PatternKind = Path => ActionFn(106);
 let ___sym0 = ___pop_Variant80(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action106::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant82(___nt), ___end));
 (1, 130)
@@ -13853,8 +13853,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // PatternKind = StringConstant => ActionFn(107);
 let ___sym0 = ___pop_Variant87(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action107::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant82(___nt), ___end));
 (1, 130)
@@ -13870,8 +13870,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Plus<Lifetime> = Lifetime => ActionFn(568);
 let ___sym0 = ___pop_Variant22(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action568::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant83(___nt), ___end));
 (1, 131)
@@ -13905,8 +13905,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant22(___symbols);
 let ___sym0 = ___pop_Variant23(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action570::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant83(___nt), ___end));
 (2, 131)
@@ -13922,8 +13922,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Plus<Lifetime> = (<Lifetime> "+")+ => ActionFn(571);
 let ___sym0 = ___pop_Variant23(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action571::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant83(___nt), ___end));
 (1, 131)
@@ -13939,8 +13939,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Plus<TypeBound> = TypeBound => ActionFn(658);
 let ___sym0 = ___pop_Variant32(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action658::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant84(___nt), ___end));
 (1, 132)
@@ -13974,8 +13974,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant32(___symbols);
 let ___sym0 = ___pop_Variant33(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action660::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant84(___nt), ___end));
 (2, 132)
@@ -13991,8 +13991,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Plus<TypeBound> = (<TypeBound> "+")+ => ActionFn(661);
 let ___sym0 = ___pop_Variant33(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action661::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant84(___nt), ___end));
 (1, 132)
@@ -14008,8 +14008,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // QuotedLiteral = StringLiteral => ActionFn(118);
 let ___sym0 = ___pop_Variant20(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action118::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant76(___nt), ___end));
 (1, 133)
@@ -14025,8 +14025,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // QuotedLiteral = RegexLiteral => ActionFn(119);
 let ___sym0 = ___pop_Variant20(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action119::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant76(___nt), ___end));
 (1, 133)
@@ -14042,8 +14042,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // QuotedTerminal = QuotedLiteral => ActionFn(117);
 let ___sym0 = ___pop_Variant76(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action117::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant85(___nt), ___end));
 (1, 134)
@@ -14059,8 +14059,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // RegexLiteral = "RegexLiteral" => ActionFn(122);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action122::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant20(___nt), ___end));
 (1, 135)
@@ -14076,8 +14076,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // RepeatOp = "+" => ActionFn(58);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action58::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant86(___nt), ___end));
 (1, 136)
@@ -14093,8 +14093,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // RepeatOp = "*" => ActionFn(59);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action59::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant86(___nt), ___end));
 (1, 136)
@@ -14110,8 +14110,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // RepeatOp = "?" => ActionFn(60);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action60::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant86(___nt), ___end));
 (1, 136)
@@ -14127,8 +14127,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // ShebangAttribute = "#![...]" => ActionFn(123);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action123::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant87(___nt), ___end));
 (1, 137)
@@ -14160,8 +14160,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // ShebangAttribute* = ShebangAttribute+ => ActionFn(192);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action192::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant88(___nt), ___end));
 (1, 138)
@@ -14177,8 +14177,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // ShebangAttribute+ = ShebangAttribute => ActionFn(193);
 let ___sym0 = ___pop_Variant87(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action193::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant88(___nt), ___end));
 (1, 139)
@@ -14196,8 +14196,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant87(___symbols);
 let ___sym0 = ___pop_Variant88(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action194::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant88(___nt), ___end));
 (2, 139)
@@ -14219,8 +14219,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant20(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action443::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant30(___nt), ___end));
 (6, 142)
@@ -14241,8 +14241,8 @@ let ___sym3 = ___pop_Variant30(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant20(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action444::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant30(___nt), ___end));
 (5, 142)
@@ -14261,8 +14261,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant30(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action445::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant30(___nt), ___end));
 (3, 142)
@@ -14278,8 +14278,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Symbol = Symbol0 => ActionFn(55);
 let ___sym0 = ___pop_Variant30(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action55::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant30(___nt), ___end));
 (1, 142)
@@ -14311,8 +14311,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Symbol* = Symbol+ => ActionFn(146);
 let ___sym0 = ___pop_Variant31(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action146::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant31(___nt), ___end));
 (1, 143)
@@ -14328,8 +14328,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Symbol+ = Symbol => ActionFn(152);
 let ___sym0 = ___pop_Variant30(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action152::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant31(___nt), ___end));
 (1, 144)
@@ -14347,8 +14347,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant30(___symbols);
 let ___sym0 = ___pop_Variant31(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action153::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant31(___nt), ___end));
 (2, 144)
@@ -14364,8 +14364,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Symbol0 = Symbol1 => ActionFn(56);
 let ___sym0 = ___pop_Variant30(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action56::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant30(___nt), ___end));
 (1, 145)
@@ -14383,8 +14383,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant86(___symbols);
 let ___sym0 = ___pop_Variant30(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action446::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant30(___nt), ___end));
 (2, 145)
@@ -14400,8 +14400,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Symbol1 = SymbolKind1 => ActionFn(447);
 let ___sym0 = ___pop_Variant90(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action447::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant30(___nt), ___end));
 (1, 146)
@@ -14417,8 +14417,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Symbol? = Symbol => ActionFn(244);
 let ___sym0 = ___pop_Variant30(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action244::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant89(___nt), ___end));
 (1, 147)
@@ -14454,8 +14454,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant56(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant26(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action62::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant90(___nt), ___end));
 (4, 148)
@@ -14471,8 +14471,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // SymbolKind1 = QuotedTerminal => ActionFn(63);
 let ___sym0 = ___pop_Variant85(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action63::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant90(___nt), ___end));
 (1, 148)
@@ -14488,8 +14488,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // SymbolKind1 = "Id" => ActionFn(64);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action64::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant90(___nt), ___end));
 (1, 148)
@@ -14505,8 +14505,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // SymbolKind1 = Escape => ActionFn(65);
 let ___sym0 = ___pop_Variant20(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action65::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant90(___nt), ___end));
 (1, 148)
@@ -14525,8 +14525,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant62(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action66::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant90(___nt), ___end));
 (3, 148)
@@ -14542,8 +14542,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // SymbolKind1 = "@L" => ActionFn(67);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action67::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant90(___nt), ___end));
 (1, 148)
@@ -14559,8 +14559,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // SymbolKind1 = "@R" => ActionFn(68);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action68::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant90(___nt), ___end));
 (1, 148)
@@ -14576,8 +14576,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // SymbolKind1 = "!" => ActionFn(69);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action69::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant90(___nt), ___end));
 (1, 148)
@@ -14593,8 +14593,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Terminal = QuotedTerminal => ActionFn(115);
 let ___sym0 = ___pop_Variant85(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action115::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant85(___nt), ___end));
 (1, 149)
@@ -14610,8 +14610,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Terminal = "Id" => ActionFn(116);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action116::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant85(___nt), ___end));
 (1, 149)
@@ -14629,8 +14629,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant65(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action1::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant91(___nt), ___end));
 (2, 150)
@@ -14648,8 +14648,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant28(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action2::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant91(___nt), ___end));
 (2, 150)
@@ -14667,8 +14667,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant75(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action3::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant91(___nt), ___end));
 (2, 150)
@@ -14686,8 +14686,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant3(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action4::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant91(___nt), ___end));
 (2, 150)
@@ -14705,8 +14705,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant52(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action5::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant91(___nt), ___end));
 (2, 150)
@@ -14722,8 +14722,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // TypeBound = Lifetime => ActionFn(16);
 let ___sym0 = ___pop_Variant22(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action16::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant32(___nt), ___end));
 (1, 151)
@@ -14749,8 +14749,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym9.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym9.2;
 let ___nt = super::___action488::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6, ___sym7, ___sym8, ___sym9);
 ___symbols.push((___start, ___Symbol::Variant32(___nt), ___end));
 (10, 151)
@@ -14772,8 +14772,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant58(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant80(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym5.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym5.2;
 let ___nt = super::___action489::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5);
 ___symbols.push((___start, ___Symbol::Variant32(___nt), ___end));
 (6, 151)
@@ -14797,8 +14797,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym7.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym7.2;
 let ___nt = super::___action490::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6, ___sym7);
 ___symbols.push((___start, ___Symbol::Variant32(___nt), ___end));
 (8, 151)
@@ -14818,8 +14818,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant58(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant80(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action491::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant32(___nt), ___end));
 (4, 151)
@@ -14843,8 +14843,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym7.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym7.2;
 let ___nt = super::___action492::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6, ___sym7);
 ___symbols.push((___start, ___Symbol::Variant32(___nt), ___end));
 (8, 151)
@@ -14864,8 +14864,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant5(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant80(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action493::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant32(___nt), ___end));
 (4, 151)
@@ -14886,8 +14886,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant57(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action494::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant32(___nt), ___end));
 (5, 151)
@@ -14903,8 +14903,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // TypeBound = Path => ActionFn(495);
 let ___sym0 = ___pop_Variant80(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action495::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant32(___nt), ___end));
 (1, 151)
@@ -14920,8 +14920,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // TypeBound? = TypeBound => ActionFn(214);
 let ___sym0 = ___pop_Variant32(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action214::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant92(___nt), ___end));
 (1, 152)
@@ -14953,8 +14953,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // TypeBoundParameter = Lifetime => ActionFn(19);
 let ___sym0 = ___pop_Variant22(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action19::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant34(___nt), ___end));
 (1, 153)
@@ -14970,8 +14970,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // TypeBoundParameter = TypeRef => ActionFn(20);
 let ___sym0 = ___pop_Variant3(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action20::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant34(___nt), ___end));
 (1, 153)
@@ -14990,8 +14990,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant3(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant20(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action21::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant34(___nt), ___end));
 (3, 153)
@@ -15007,8 +15007,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // TypeBoundParameter? = TypeBoundParameter => ActionFn(224);
 let ___sym0 = ___pop_Variant34(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action224::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant93(___nt), ___end));
 (1, 154)
@@ -15040,8 +15040,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // TypeBounds = Plus<TypeBound> => ActionFn(15);
 let ___sym0 = ___pop_Variant84(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action15::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant84(___nt), ___end));
 (1, 155)
@@ -15057,8 +15057,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // TypeParameter = Lifetime => ActionFn(8);
 let ___sym0 = ___pop_Variant22(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action8::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant36(___nt), ___end));
 (1, 156)
@@ -15074,8 +15074,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // TypeParameter = Id => ActionFn(9);
 let ___sym0 = ___pop_Variant20(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action9::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant36(___nt), ___end));
 (1, 156)
@@ -15091,8 +15091,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // TypeParameter? = TypeParameter => ActionFn(201);
 let ___sym0 = ___pop_Variant36(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action201::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant94(___nt), ___end));
 (1, 157)
@@ -15127,8 +15127,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant58(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action70::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (3, 158)
@@ -15147,8 +15147,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant3(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action71::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (3, 158)
@@ -15167,8 +15167,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant30(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action72::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (3, 158)
@@ -15188,8 +15188,8 @@ let ___sym3 = ___pop_Variant3(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant22(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action572::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (4, 158)
@@ -15208,8 +15208,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant3(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action573::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (3, 158)
@@ -15228,8 +15228,8 @@ assert!(___symbols.len() >= 3);
 let ___sym2 = ___pop_Variant3(___symbols);
 let ___sym1 = ___pop_Variant22(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym2.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym2.2;
 let ___nt = super::___action574::<>(text, ___sym0, ___sym1, ___sym2);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (3, 158)
@@ -15247,8 +15247,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant3(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action575::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (2, 158)
@@ -15268,8 +15268,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant58(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant80(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action74::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (4, 158)
@@ -15285,8 +15285,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // TypeRef = Path => ActionFn(75);
 let ___sym0 = ___pop_Variant80(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action75::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (1, 158)
@@ -15307,8 +15307,8 @@ let ___sym3 = ___pop_Variant58(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant80(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action76::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (5, 158)
@@ -15326,8 +15326,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant80(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action77::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (2, 158)
@@ -15354,8 +15354,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym10.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym10.2;
 let ___nt = super::___action496::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6, ___sym7, ___sym8, ___sym9, ___sym10);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (11, 158)
@@ -15378,8 +15378,8 @@ let ___sym3 = ___pop_Variant58(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant80(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym6.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym6.2;
 let ___nt = super::___action497::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (7, 158)
@@ -15404,8 +15404,8 @@ let ___sym3 = ___pop_Variant57(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym8.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym8.2;
 let ___nt = super::___action498::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4, ___sym5, ___sym6, ___sym7, ___sym8);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (9, 158)
@@ -15426,8 +15426,8 @@ let ___sym3 = ___pop_Variant58(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant80(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action499::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (5, 158)
@@ -15443,8 +15443,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // TypeRef? = TypeRef => ActionFn(219);
 let ___sym0 = ___pop_Variant3(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action219::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant4(___nt), ___end));
 (1, 159)
@@ -15476,8 +15476,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // TypeRefOrLifetime = TypeRef => ActionFn(79);
 let ___sym0 = ___pop_Variant3(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action79::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (1, 160)
@@ -15493,8 +15493,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // TypeRefOrLifetime = Lifetime => ActionFn(80);
 let ___sym0 = ___pop_Variant22(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action80::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant3(___nt), ___end));
 (1, 160)
@@ -15510,8 +15510,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // TypeRefOrLifetime? = TypeRefOrLifetime => ActionFn(249);
 let ___sym0 = ___pop_Variant3(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action249::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant4(___nt), ___end));
 (1, 161)
@@ -15545,8 +15545,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant1(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action28::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant63(___nt), ___end));
 (2, 162)
@@ -15578,8 +15578,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Use* = Use+ => ActionFn(190);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action190::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant66(___nt), ___end));
 (1, 163)
@@ -15595,8 +15595,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Use+ = Use => ActionFn(195);
 let ___sym0 = ___pop_Variant63(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action195::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant66(___nt), ___end));
 (1, 164)
@@ -15614,8 +15614,8 @@ _: core::marker::PhantomData<(&'input ())>,
 assert!(___symbols.len() >= 2);
 let ___sym1 = ___pop_Variant63(___symbols);
 let ___sym0 = ___pop_Variant66(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym1.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym1.2;
 let ___nt = super::___action196::<>(text, ___sym0, ___sym1);
 ___symbols.push((___start, ___Symbol::Variant66(___nt), ___end));
 (2, 164)
@@ -15635,8 +15635,8 @@ let ___sym3 = ___pop_Variant0(___symbols);
 let ___sym2 = ___pop_Variant80(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym3.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym3.2;
 let ___nt = super::___action29::<>(text, ___sym0, ___sym1, ___sym2, ___sym3);
 ___symbols.push((___start, ___Symbol::Variant95(___nt), ___end));
 (4, 165)
@@ -15657,8 +15657,8 @@ let ___sym3 = ___pop_Variant80(___symbols);
 let ___sym2 = ___pop_Variant0(___symbols);
 let ___sym1 = ___pop_Variant0(___symbols);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym4.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym4.2;
 let ___nt = super::___action30::<>(text, ___sym0, ___sym1, ___sym2, ___sym3, ___sym4);
 ___symbols.push((___start, ___Symbol::Variant95(___nt), ___end));
 (5, 165)
@@ -15674,8 +15674,8 @@ _: core::marker::PhantomData<(&'input ())>,
 {
 // Visibility = "pub" => ActionFn(31);
 let ___sym0 = ___pop_Variant0(___symbols);
-let ___start = ___sym0.0.clone();
-let ___end = ___sym0.2.clone();
+let ___start = ___sym0.0;
+let ___end = ___sym0.2;
 let ___nt = super::___action31::<>(text, ___sym0);
 ___symbols.push((___start, ___Symbol::Variant95(___nt), ___end));
 (1, 165)
@@ -15700,6 +15700,7 @@ ___symbols.push((___start, ___Symbol::Variant95(___nt), ___end));
 pub use self::___parse___Top::TopParser;
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action0<
     'input,
 >(
@@ -15711,6 +15712,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action1<
     'input,
 >(
@@ -15723,6 +15725,7 @@ Top::Grammar(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action2<
     'input,
 >(
@@ -15735,6 +15738,7 @@ Top::Pattern(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action3<
     'input,
 >(
@@ -15747,6 +15751,7 @@ Top::MatchMapping(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action4<
     'input,
 >(
@@ -15759,6 +15764,7 @@ Top::TypeRef(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action5<
     'input,
 >(
@@ -15771,6 +15777,7 @@ Top::GrammarWhereClauses(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action6<
     'input,
 >(
@@ -15801,6 +15808,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action7<
     'input,
 >(
@@ -15814,6 +15822,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action8<
     'input,
 >(
@@ -15825,6 +15834,7 @@ TypeParameter::Lifetime(l)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action9<
     'input,
 >(
@@ -15836,6 +15846,7 @@ TypeParameter::Id(l)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action10<
     'input,
 >(
@@ -15848,6 +15859,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action11<
     'input,
 >(
@@ -15861,6 +15873,7 @@ WhereClause::Lifetime { lifetime: l, bounds }
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action12<
     'input,
 >(
@@ -15875,6 +15888,7 @@ WhereClause::Type { forall: f, ty, bounds }
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action13<
     'input,
 >(
@@ -15889,6 +15903,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action14<
     'input,
 >(
@@ -15900,6 +15915,7 @@ vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action15<
     'input,
 >(
@@ -15911,6 +15927,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action16<
     'input,
 >(
@@ -15922,6 +15939,7 @@ TypeBound::Lifetime(l)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action17<
     'input,
 >(
@@ -15938,6 +15956,7 @@ TypeBound::Fn { forall: f, path: p, parameters: params, ret }
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action18<
     'input,
 >(
@@ -15951,6 +15970,7 @@ TypeBound::Trait { forall: f, path: p, parameters: params.unwrap_or(vec![]) }
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action19<
     'input,
 >(
@@ -15962,6 +15982,7 @@ TypeBoundParameter::Lifetime(l)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action20<
     'input,
 >(
@@ -15973,6 +15994,7 @@ TypeBoundParameter::TypeParameter(ty)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action21<
     'input,
 >(
@@ -15986,6 +16008,7 @@ TypeBoundParameter::Associated(id, ty)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action22<
     'input,
 >(
@@ -15999,6 +16022,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action23<
     'input,
 >(
@@ -16012,6 +16036,7 @@ Parameter { name: id, ty }
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action24<
     'input,
 >(
@@ -16023,6 +16048,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action25<
     'input,
 >(
@@ -16034,6 +16060,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action26<
     'input,
 >(
@@ -16045,6 +16072,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action27<
     'input,
 >(
@@ -16056,6 +16084,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action28<
     'input,
 >(
@@ -16068,6 +16097,7 @@ GrammarItem::Use(strip(u).to_string())
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action29<
     'input,
 >(
@@ -16082,6 +16112,7 @@ Visibility::Pub(Some(p))
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action30<
     'input,
 >(
@@ -16097,6 +16128,7 @@ Visibility::PubIn(p)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action31<
     'input,
 >(
@@ -16108,6 +16140,7 @@ Visibility::Pub(None)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action32<
     'input,
 >(
@@ -16119,6 +16152,7 @@ Visibility::Priv
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action33<
     'input,
 >(
@@ -16145,6 +16179,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action34<
     'input,
 >(
@@ -16160,6 +16195,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action35<
     'input,
 >(
@@ -16179,6 +16215,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action36<
     'input,
 >(
@@ -16193,6 +16230,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action37<
     'input,
 >(
@@ -16204,6 +16242,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action38<
     'input,
 >(
@@ -16215,6 +16254,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action39<
     'input,
 >(
@@ -16227,6 +16267,7 @@ vec![a]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action40<
     'input,
 >(
@@ -16241,6 +16282,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action41<
     'input,
 >(
@@ -16265,6 +16307,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action42<
     'input,
 >(
@@ -16287,6 +16330,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action43<
     'input,
 >(
@@ -16298,6 +16342,7 @@ ActionKind::Lookahead
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action44<
     'input,
 >(
@@ -16309,6 +16354,7 @@ ActionKind::Lookbehind
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action45<
     'input,
 >(
@@ -16320,6 +16366,7 @@ ActionKind::User(strip(c).to_string())
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action46<
     'input,
 >(
@@ -16331,6 +16378,7 @@ ActionKind::Fallible(strip(c).to_string())
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action47<
     'input,
 >(
@@ -16348,6 +16396,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action48<
     'input,
 >(
@@ -16359,6 +16408,7 @@ ConditionOp::Equals
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action49<
     'input,
 >(
@@ -16370,6 +16420,7 @@ ConditionOp::NotEquals
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action50<
     'input,
 >(
@@ -16381,6 +16432,7 @@ ConditionOp::Match
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action51<
     'input,
 >(
@@ -16392,6 +16444,7 @@ ConditionOp::NotMatch
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action52<
     'input,
 >(
@@ -16403,6 +16456,7 @@ ExprSymbol { symbols: ___0 }
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action53<
     'input,
 >(
@@ -16422,6 +16476,7 @@ Symbol::new(Span(lo, hi), SymbolKind::Name(Name::new(m.is_some(), l), Box::new(s
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action54<
     'input,
 >(
@@ -16437,6 +16492,7 @@ Symbol::new(Span(lo, hi), SymbolKind::Choose(Box::new(s)))
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action55<
     'input,
 >(
@@ -16448,6 +16504,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action56<
     'input,
 >(
@@ -16459,6 +16516,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action57<
     'input,
 >(
@@ -16473,6 +16531,7 @@ Symbol::new(Span(lhs.span.0, hi),
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action58<
     'input,
 >(
@@ -16484,6 +16543,7 @@ RepeatOp::Plus
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action59<
     'input,
 >(
@@ -16495,6 +16555,7 @@ RepeatOp::Star
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action60<
     'input,
 >(
@@ -16506,6 +16567,7 @@ RepeatOp::Question
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action61<
     'input,
 >(
@@ -16519,6 +16581,7 @@ Symbol::new(Span(lo, hi), sk)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action62<
     'input,
 >(
@@ -16533,6 +16596,7 @@ SymbolKind::Macro(MacroSymbol { name, args })
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action63<
     'input,
 >(
@@ -16544,6 +16608,7 @@ SymbolKind::Terminal(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action64<
     'input,
 >(
@@ -16555,6 +16620,7 @@ SymbolKind::AmbiguousId(Atom::from(___0))
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action65<
     'input,
 >(
@@ -16566,6 +16632,7 @@ SymbolKind::Nonterminal(NonterminalString(___0))
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action66<
     'input,
 >(
@@ -16579,6 +16646,7 @@ SymbolKind::Expr(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action67<
     'input,
 >(
@@ -16590,6 +16658,7 @@ SymbolKind::Lookahead
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action68<
     'input,
 >(
@@ -16601,6 +16670,7 @@ SymbolKind::Lookbehind
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action69<
     'input,
 >(
@@ -16612,6 +16682,7 @@ SymbolKind::Error
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action70<
     'input,
 >(
@@ -16625,6 +16696,7 @@ TypeRef::Tuple(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action71<
     'input,
 >(
@@ -16638,6 +16710,7 @@ TypeRef::Slice(Box::new(___0))
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action72<
     'input,
 >(
@@ -16653,6 +16726,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action73<
     'input,
 >(
@@ -16669,6 +16743,7 @@ TypeRef::Ref { lifetime: l,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action74<
     'input,
 >(
@@ -16679,10 +16754,11 @@ text: &'input str,
 (_, _, _): (usize, Tok<'input>, usize),
 ) -> TypeRef
 {
-TypeRef::Nominal { path:path, types:types }
+TypeRef::Nominal { path, types }
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action75<
     'input,
 >(
@@ -16697,6 +16773,7 @@ match p.as_id() {
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action76<
     'input,
 >(
@@ -16708,10 +16785,11 @@ text: &'input str,
 (_, _, _): (usize, Tok<'input>, usize),
 ) -> TypeRef
 {
-TypeRef::TraitObject { path:path, types:types }
+TypeRef::TraitObject { path, types }
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action77<
     'input,
 >(
@@ -16724,6 +16802,7 @@ TypeRef::TraitObject { path, types: vec![] }
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action78<
     'input,
 >(
@@ -16741,6 +16820,7 @@ TypeRef::Fn { forall, path, parameters, ret: ret.map(Box::new) }
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action79<
     'input,
 >(
@@ -16752,6 +16832,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action80<
     'input,
 >(
@@ -16763,6 +16844,7 @@ TypeRef::Lifetime(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action81<
     'input,
 >(
@@ -16779,6 +16861,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action82<
     'input,
 >(
@@ -16803,6 +16886,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action83<
     'input,
 >(
@@ -16825,6 +16909,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action84<
     'input,
 >(
@@ -16836,6 +16921,7 @@ GrammarItem::MatchToken(t)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action85<
     'input,
 >(
@@ -16851,6 +16937,7 @@ t.add(c)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action86<
     'input,
 >(
@@ -16867,6 +16954,7 @@ MatchToken::new(c, Span(lo, hi))
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action87<
     'input,
 >(
@@ -16878,6 +16966,7 @@ MatchContents { items }
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action88<
     'input,
 >(
@@ -16891,6 +16980,7 @@ MatchItem::CatchAll(Span(lo, hi))
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action89<
     'input,
 >(
@@ -16904,6 +16994,7 @@ MatchItem::Unmapped(s, Span(lo, hi))
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action90<
     'input,
 >(
@@ -16922,6 +17013,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action91<
     'input,
 >(
@@ -16933,6 +17025,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action92<
     'input,
 >(
@@ -16944,6 +17037,7 @@ MatchMapping::Terminal(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action93<
     'input,
 >(
@@ -16956,6 +17050,7 @@ MatchMapping::Skip
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action94<
     'input,
 >(
@@ -16979,6 +17074,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action95<
     'input,
 >(
@@ -17000,6 +17096,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action96<
     'input,
 >(
@@ -17020,6 +17117,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action97<
     'input,
 >(
@@ -17033,6 +17131,7 @@ Pattern { span: Span(lo, hi), kind: k }
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action98<
     'input,
 >(
@@ -17047,6 +17146,7 @@ PatternKind::Enum(___0, ___1)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action99<
     'input,
 >(
@@ -17062,6 +17162,7 @@ PatternKind::Struct(p, a0.into_iter().chain(a1).collect(), false)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action100<
     'input,
 >(
@@ -17077,6 +17178,7 @@ PatternKind::Struct(p, a0, true)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action101<
     'input,
 >(
@@ -17088,6 +17190,7 @@ PatternKind::Underscore
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action102<
     'input,
 >(
@@ -17099,6 +17202,7 @@ PatternKind::DotDot
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action103<
     'input,
 >(
@@ -17112,6 +17216,7 @@ PatternKind::Choose(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action104<
     'input,
 >(
@@ -17125,6 +17230,7 @@ PatternKind::Tuple(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action105<
     'input,
 >(
@@ -17136,6 +17242,7 @@ PatternKind::CharLiteral(Atom::from(c))
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action106<
     'input,
 >(
@@ -17147,6 +17254,7 @@ PatternKind::Path(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action107<
     'input,
 >(
@@ -17158,6 +17266,7 @@ PatternKind::String(s)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action108<
     'input,
 >(
@@ -17177,6 +17286,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action109<
     'input,
 >(
@@ -17188,6 +17298,7 @@ NonterminalString(Atom::from(i))
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action110<
     'input,
 >(
@@ -17199,6 +17310,7 @@ NonterminalString(Atom::from(i))
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action111<
     'input,
 >(
@@ -17210,6 +17322,7 @@ Atom::from(i)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action112<
     'input,
 >(
@@ -17221,6 +17334,7 @@ Atom::from(i)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action113<
     'input,
 >(
@@ -17232,6 +17346,7 @@ Atom::from(i)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action114<
     'input,
 >(
@@ -17243,6 +17358,7 @@ Lifetime(Atom::from(i))
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action115<
     'input,
 >(
@@ -17254,6 +17370,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action116<
     'input,
 >(
@@ -17265,6 +17382,7 @@ TerminalString::Bare(Atom::from(i))
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action117<
     'input,
 >(
@@ -17276,6 +17394,7 @@ TerminalString::Literal(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action118<
     'input,
 >(
@@ -17287,6 +17406,7 @@ TerminalLiteral::Quoted(s)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action119<
     'input,
 >(
@@ -17298,6 +17418,7 @@ TerminalLiteral::Regex(s)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action120<
     'input,
 >(
@@ -17314,6 +17435,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action121<
     'input,
 >(
@@ -17330,6 +17452,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action122<
     'input,
 >(
@@ -17341,6 +17464,7 @@ Atom::from(s)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action123<
     'input,
 >(
@@ -17352,6 +17476,7 @@ s.to_string()
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action124<
     'input,
 >(
@@ -17363,6 +17488,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action125<
     'input,
 >(
@@ -17375,6 +17501,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action126<
     'input,
 >(
@@ -17387,6 +17514,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action127<
     'input,
 >(
@@ -17398,6 +17526,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action128<
     'input,
 >(
@@ -17410,6 +17539,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action129<
     'input,
 >(
@@ -17422,6 +17552,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action130<
     'input,
 >(
@@ -17434,6 +17565,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action131<
     'input,
 >(
@@ -17446,6 +17578,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action132<
     'input,
 >(
@@ -17458,6 +17591,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action133<
     'input,
 >(
@@ -17469,6 +17603,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action134<
     'input,
 >(
@@ -17481,6 +17616,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action135<
     'input,
 >(
@@ -17492,6 +17628,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action136<
     'input,
 >(
@@ -17504,6 +17641,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action137<
     'input,
 >(
@@ -17515,6 +17653,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action138<
     'input,
 >(
@@ -17527,6 +17666,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action139<
     'input,
 >(
@@ -17539,6 +17679,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action140<
     'input,
 >(
@@ -17550,6 +17691,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action141<
     'input,
 >(
@@ -17562,6 +17704,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action142<
     'input,
 >(
@@ -17574,6 +17717,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action143<
     'input,
 >(
@@ -17585,6 +17729,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action144<
     'input,
 >(
@@ -17597,6 +17742,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action145<
     'input,
 >(
@@ -17609,6 +17755,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action146<
     'input,
 >(
@@ -17620,6 +17767,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action147<
     'input,
 >(
@@ -17631,6 +17779,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action148<
     'input,
 >(
@@ -17643,6 +17792,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action149<
     'input,
 >(
@@ -17654,6 +17804,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action150<
     'input,
 >(
@@ -17666,6 +17817,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action151<
     'input,
 >(
@@ -17678,6 +17830,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action152<
     'input,
 >(
@@ -17689,6 +17842,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action153<
     'input,
 >(
@@ -17701,6 +17855,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action154<
     'input,
 >(
@@ -17712,6 +17867,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action155<
     'input,
 >(
@@ -17724,6 +17880,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action156<
     'input,
 >(
@@ -17736,6 +17893,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action157<
     'input,
 >(
@@ -17748,6 +17906,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action158<
     'input,
 >(
@@ -17759,6 +17918,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action159<
     'input,
 >(
@@ -17771,6 +17931,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action160<
     'input,
 >(
@@ -17782,6 +17943,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action161<
     'input,
 >(
@@ -17794,6 +17956,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action162<
     'input,
 >(
@@ -17806,6 +17969,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action163<
     'input,
 >(
@@ -17818,6 +17982,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action164<
     'input,
 >(
@@ -17829,6 +17994,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action165<
     'input,
 >(
@@ -17841,6 +18007,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action166<
     'input,
 >(
@@ -17854,6 +18021,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action167<
     'input,
 >(
@@ -17866,6 +18034,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action168<
     'input,
 >(
@@ -17877,6 +18046,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action169<
     'input,
 >(
@@ -17889,6 +18059,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action170<
     'input,
 >(
@@ -17901,6 +18072,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action171<
     'input,
 >(
@@ -17913,6 +18085,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action172<
     'input,
 >(
@@ -17928,18 +18101,19 @@ match e {
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action173<
     'input,
 >(
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> ()
+)
 {
-()
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action174<
     'input,
 >(
@@ -17955,6 +18129,7 @@ match e {
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action175<
     'input,
 >(
@@ -17967,6 +18142,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action176<
     'input,
 >(
@@ -17979,6 +18155,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action177<
     'input,
 >(
@@ -17991,6 +18168,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action178<
     'input,
 >(
@@ -18002,6 +18180,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action179<
     'input,
 >(
@@ -18013,6 +18192,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action180<
     'input,
 >(
@@ -18025,6 +18205,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action181<
     'input,
 >(
@@ -18036,6 +18217,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action182<
     'input,
 >(
@@ -18048,6 +18230,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action183<
     'input,
 >(
@@ -18059,6 +18242,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action184<
     'input,
 >(
@@ -18079,7 +18263,7 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> usize
 {
-___lookbehind.clone()
+*___lookbehind
 }
 
 #[allow(unused_variables)]
@@ -18091,10 +18275,11 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> usize
 {
-___lookahead.clone()
+*___lookahead
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action187<
     'input,
 >(
@@ -18107,6 +18292,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action188<
     'input,
 >(
@@ -18118,6 +18304,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action189<
     'input,
 >(
@@ -18130,6 +18317,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action190<
     'input,
 >(
@@ -18141,6 +18329,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action191<
     'input,
 >(
@@ -18153,6 +18342,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action192<
     'input,
 >(
@@ -18164,6 +18354,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action193<
     'input,
 >(
@@ -18175,6 +18366,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action194<
     'input,
 >(
@@ -18187,6 +18379,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action195<
     'input,
 >(
@@ -18198,6 +18391,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action196<
     'input,
 >(
@@ -18210,6 +18404,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action197<
     'input,
 >(
@@ -18221,6 +18416,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action198<
     'input,
 >(
@@ -18233,6 +18429,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action199<
     'input,
 >(
@@ -18244,6 +18441,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action200<
     'input,
 >(
@@ -18256,6 +18454,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action201<
     'input,
 >(
@@ -18267,6 +18466,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action202<
     'input,
 >(
@@ -18279,6 +18479,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action203<
     'input,
 >(
@@ -18291,6 +18492,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action204<
     'input,
 >(
@@ -18302,6 +18504,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action205<
     'input,
 >(
@@ -18314,6 +18517,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action206<
     'input,
 >(
@@ -18325,6 +18529,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action207<
     'input,
 >(
@@ -18337,6 +18542,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action208<
     'input,
 >(
@@ -18349,6 +18555,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action209<
     'input,
 >(
@@ -18360,6 +18567,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action210<
     'input,
 >(
@@ -18372,6 +18580,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action211<
     'input,
 >(
@@ -18384,6 +18593,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action212<
     'input,
 >(
@@ -18395,6 +18605,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action213<
     'input,
 >(
@@ -18407,6 +18618,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action214<
     'input,
 >(
@@ -18418,6 +18630,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action215<
     'input,
 >(
@@ -18430,6 +18643,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action216<
     'input,
 >(
@@ -18442,6 +18656,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action217<
     'input,
 >(
@@ -18453,6 +18668,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action218<
     'input,
 >(
@@ -18465,6 +18681,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action219<
     'input,
 >(
@@ -18476,6 +18693,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action220<
     'input,
 >(
@@ -18488,6 +18706,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action221<
     'input,
 >(
@@ -18500,6 +18719,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action222<
     'input,
 >(
@@ -18511,6 +18731,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action223<
     'input,
 >(
@@ -18523,6 +18744,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action224<
     'input,
 >(
@@ -18534,6 +18756,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action225<
     'input,
 >(
@@ -18546,6 +18769,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action226<
     'input,
 >(
@@ -18558,6 +18782,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action227<
     'input,
 >(
@@ -18569,6 +18794,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action228<
     'input,
 >(
@@ -18581,6 +18807,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action229<
     'input,
 >(
@@ -18592,6 +18819,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action230<
     'input,
 >(
@@ -18604,6 +18832,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action231<
     'input,
 >(
@@ -18616,6 +18845,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action232<
     'input,
 >(
@@ -18627,6 +18857,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action233<
     'input,
 >(
@@ -18639,6 +18870,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action234<
     'input,
 >(
@@ -18650,6 +18882,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action235<
     'input,
 >(
@@ -18662,6 +18895,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action236<
     'input,
 >(
@@ -18674,6 +18908,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action237<
     'input,
 >(
@@ -18685,6 +18920,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action238<
     'input,
 >(
@@ -18697,6 +18933,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action239<
     'input,
 >(
@@ -18708,6 +18945,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action240<
     'input,
 >(
@@ -18720,6 +18958,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action241<
     'input,
 >(
@@ -18732,6 +18971,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action242<
     'input,
 >(
@@ -18743,6 +18983,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action243<
     'input,
 >(
@@ -18755,6 +18996,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action244<
     'input,
 >(
@@ -18766,6 +19008,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action245<
     'input,
 >(
@@ -18778,6 +19021,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action246<
     'input,
 >(
@@ -18790,6 +19034,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action247<
     'input,
 >(
@@ -18801,6 +19046,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action248<
     'input,
 >(
@@ -18813,6 +19059,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action249<
     'input,
 >(
@@ -18824,6 +19071,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action250<
     'input,
 >(
@@ -18836,6 +19084,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action251<
     'input,
 >(
@@ -18848,6 +19097,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action252<
     'input,
 >(
@@ -18859,6 +19109,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action253<
     'input,
 >(
@@ -18871,6 +19122,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action254<
     'input,
 >(
@@ -18882,6 +19134,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action255<
     'input,
 >(
@@ -18894,6 +19147,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action256<
     'input,
 >(
@@ -18905,6 +19159,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action257<
     'input,
 >(
@@ -18917,6 +19172,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action258<
     'input,
 >(
@@ -18928,6 +19184,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action259<
     'input,
 >(
@@ -18940,6 +19197,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action260<
     'input,
 >(
@@ -18952,6 +19210,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action261<
     'input,
 >(
@@ -18963,6 +19222,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action262<
     'input,
 >(
@@ -18975,6 +19235,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action263<
     'input,
 >(
@@ -18986,6 +19247,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action264<
     'input,
 >(
@@ -18998,6 +19260,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action265<
     'input,
 >(
@@ -19010,6 +19273,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action266<
     'input,
 >(
@@ -19021,6 +19285,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action267<
     'input,
 >(
@@ -19033,6 +19298,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action268<
     'input,
 >(
@@ -19044,6 +19310,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action269<
     'input,
 >(
@@ -19056,6 +19323,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action270<
     'input,
 >(
@@ -19068,6 +19336,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action271<
     'input,
 >(
@@ -19079,6 +19348,7 @@ v
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action272<
     'input,
 >(
@@ -19091,6 +19361,7 @@ ___0
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action273<
     'input,
 >(
@@ -19102,6 +19373,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action274<
     'input,
 >(
@@ -19114,6 +19386,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action275<
     'input,
 >(
@@ -19125,6 +19398,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action276<
     'input,
 >(
@@ -19137,6 +19411,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action277<
     'input,
 >(
@@ -19148,6 +19423,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action278<
     'input,
 >(
@@ -19160,6 +19436,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action279<
     'input,
 >(
@@ -19171,6 +19448,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action280<
     'input,
 >(
@@ -19183,6 +19461,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action281<
     'input,
 >(
@@ -19194,6 +19473,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action282<
     'input,
 >(
@@ -19206,6 +19486,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action283<
     'input,
 >(
@@ -19217,6 +19498,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action284<
     'input,
 >(
@@ -19229,6 +19511,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action285<
     'input,
 >(
@@ -19240,6 +19523,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action286<
     'input,
 >(
@@ -19252,6 +19536,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action287<
     'input,
 >(
@@ -19263,6 +19548,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action288<
     'input,
 >(
@@ -19275,6 +19561,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action289<
     'input,
 >(
@@ -19286,6 +19573,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action290<
     'input,
 >(
@@ -19298,6 +19586,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action291<
     'input,
 >(
@@ -19309,6 +19598,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action292<
     'input,
 >(
@@ -19321,6 +19611,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action293<
     'input,
 >(
@@ -19332,6 +19623,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action294<
     'input,
 >(
@@ -19344,6 +19636,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action295<
     'input,
 >(
@@ -19355,6 +19648,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action296<
     'input,
 >(
@@ -19367,6 +19661,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action297<
     'input,
 >(
@@ -19378,6 +19673,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action298<
     'input,
 >(
@@ -19390,6 +19686,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action299<
     'input,
 >(
@@ -19401,6 +19698,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action300<
     'input,
 >(
@@ -19413,6 +19711,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action301<
     'input,
 >(
@@ -19424,6 +19723,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action302<
     'input,
 >(
@@ -19436,6 +19736,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action303<
     'input,
 >(
@@ -19445,8 +19746,8 @@ ___1: (usize, alloc::vec::Vec<Atom>, usize),
 ___2: (usize, Atom, usize),
 ) -> Path
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action137(
 text,
 ___0,
@@ -19461,6 +19762,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action304<
     'input,
 >(
@@ -19469,8 +19771,8 @@ ___0: (usize, alloc::vec::Vec<Atom>, usize),
 ___1: (usize, Atom, usize),
 ) -> Path
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action138(
 text,
 &___start0,
@@ -19486,6 +19788,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action305<
     'input,
 >(
@@ -19496,8 +19799,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Vec<Alternative>
 {
-let ___start0 = ___3.0.clone();
-let ___end0 = ___3.2.clone();
+let ___start0 = ___3.0;
+let ___end0 = ___3.2;
 let ___temp0 = ___action154(
 text,
 ___3,
@@ -19513,6 +19816,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action306<
     'input,
 >(
@@ -19522,8 +19826,8 @@ ___1: (usize, Vec<Alternative>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> Vec<Alternative>
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___2.2;
 let ___temp0 = ___action155(
 text,
 &___start0,
@@ -19540,6 +19844,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action307<
     'input,
 >(
@@ -19555,8 +19860,8 @@ ___7: (usize, Tok<'input>, usize),
 ___8: (usize, usize, usize),
 ) -> Symbol
 {
-let ___start0 = ___2.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___2.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action143(
 text,
 ___2,
@@ -19577,6 +19882,7 @@ ___8,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action308<
     'input,
 >(
@@ -19591,8 +19897,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, usize, usize),
 ) -> Symbol
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___2.0.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___2.0;
 let ___temp0 = ___action144(
 text,
 &___start0,
@@ -19614,6 +19920,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action309<
     'input,
 >(
@@ -19624,8 +19931,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, TypeRef, usize),
 ) -> TypeRef
 {
-let ___start0 = ___2.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___2.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action143(
 text,
 ___2,
@@ -19641,6 +19948,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action310<
     'input,
 >(
@@ -19650,8 +19958,8 @@ ___1: (usize, core::option::Option<Lifetime>, usize),
 ___2: (usize, TypeRef, usize),
 ) -> TypeRef
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___2.0.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___2.0;
 let ___temp0 = ___action144(
 text,
 &___start0,
@@ -19668,6 +19976,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action311<
     'input,
 >(
@@ -19676,8 +19985,8 @@ ___0: (usize, Tok<'input>, usize),
 ___1: (usize, TypeRef, usize),
 ) -> core::option::Option<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action170(
 text,
 ___0,
@@ -19691,6 +20000,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action312<
     'input,
 >(
@@ -19704,8 +20014,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, TypeRef, usize),
 ) -> TypeBound<TypeRef>
 {
-let ___start0 = ___5.0.clone();
-let ___end0 = ___6.2.clone();
+let ___start0 = ___5.0;
+let ___end0 = ___6.2;
 let ___temp0 = ___action311(
 text,
 ___5,
@@ -19724,6 +20034,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action313<
     'input,
 >(
@@ -19735,8 +20046,8 @@ ___3: (usize, Vec<TypeRef>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> TypeBound<TypeRef>
 {
-let ___start0 = ___4.2.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.2;
+let ___end0 = ___4.2;
 let ___temp0 = ___action169(
 text,
 &___start0,
@@ -19755,6 +20066,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action314<
     'input,
 >(
@@ -19769,8 +20081,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, TypeRef, usize),
 ) -> TypeRef
 {
-let ___start0 = ___6.0.clone();
-let ___end0 = ___7.2.clone();
+let ___start0 = ___6.0;
+let ___end0 = ___7.2;
 let ___temp0 = ___action311(
 text,
 ___6,
@@ -19790,6 +20102,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action315<
     'input,
 >(
@@ -19802,8 +20115,8 @@ ___4: (usize, Vec<TypeRef>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> TypeRef
 {
-let ___start0 = ___5.2.clone();
-let ___end0 = ___5.2.clone();
+let ___start0 = ___5.2;
+let ___end0 = ___5.2;
 let ___temp0 = ___action169(
 text,
 &___start0,
@@ -19823,6 +20136,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action316<
     'input,
 >(
@@ -19831,8 +20145,8 @@ ___0: (usize, Tok<'input>, usize),
 ___1: (usize, TypeRef, usize),
 ) -> core::option::Option<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action162(
 text,
 ___0,
@@ -19846,6 +20160,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action317<
     'input,
 >(
@@ -19861,8 +20176,8 @@ ___7: (usize, Tok<'input>, usize),
 ___8: (usize, Vec<Alternative>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___5.0.clone();
-let ___end0 = ___6.2.clone();
+let ___start0 = ___5.0;
+let ___end0 = ___6.2;
 let ___temp0 = ___action316(
 text,
 ___5,
@@ -19883,6 +20198,7 @@ ___8,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action318<
     'input,
 >(
@@ -19896,8 +20212,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, Vec<Alternative>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___4.2.clone();
-let ___end0 = ___5.0.clone();
+let ___start0 = ___4.2;
+let ___end0 = ___5.0;
 let ___temp0 = ___action161(
 text,
 &___start0,
@@ -19918,6 +20234,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action319<
     'input,
 >(
@@ -19927,8 +20244,8 @@ ___1: (usize, Vec<TypeBoundParameter<TypeRef>>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> core::option::Option<Vec<TypeBoundParameter<TypeRef>>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action166(
 text,
 ___0,
@@ -19943,6 +20260,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action320<
     'input,
 >(
@@ -19954,8 +20272,8 @@ ___3: (usize, Vec<TypeBoundParameter<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> TypeBound<TypeRef>
 {
-let ___start0 = ___2.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___2.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action319(
 text,
 ___2,
@@ -19972,6 +20290,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action321<
     'input,
 >(
@@ -19980,8 +20299,8 @@ ___0: (usize, Vec<TypeParameter>, usize),
 ___1: (usize, Path, usize),
 ) -> TypeBound<TypeRef>
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___1.2;
 let ___temp0 = ___action165(
 text,
 &___start0,
@@ -19997,6 +20316,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action322<
     'input,
 >(
@@ -20005,8 +20325,8 @@ ___0: (usize, Tok<'input>, usize),
 ___1: (usize, Condition, usize),
 ) -> core::option::Option<Condition>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action151(
 text,
 ___0,
@@ -20020,6 +20340,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action323<
     'input,
 >(
@@ -20033,8 +20354,8 @@ ___5: (usize, core::option::Option<ActionKind>, usize),
 ___6: (usize, usize, usize),
 ) -> Alternative
 {
-let ___start0 = ___3.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___3.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action322(
 text,
 ___3,
@@ -20053,6 +20374,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action324<
     'input,
 >(
@@ -20064,8 +20386,8 @@ ___3: (usize, core::option::Option<ActionKind>, usize),
 ___4: (usize, usize, usize),
 ) -> Alternative
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___3.0.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___3.0;
 let ___temp0 = ___action150(
 text,
 &___start0,
@@ -20084,6 +20406,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action325<
     'input,
 >(
@@ -20095,8 +20418,8 @@ ___3: (usize, ActionKind, usize),
 ___4: (usize, usize, usize),
 ) -> Alternative
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action322(
 text,
 ___1,
@@ -20113,6 +20436,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action326<
     'input,
 >(
@@ -20122,8 +20446,8 @@ ___1: (usize, ActionKind, usize),
 ___2: (usize, usize, usize),
 ) -> Alternative
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action150(
 text,
 &___start0,
@@ -20140,6 +20464,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action327<
     'input,
 >(
@@ -20148,8 +20473,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Vec<TypeParameter>
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action173(
 text,
 &___start0,
@@ -20163,6 +20488,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action328<
     'input,
 >(
@@ -20171,8 +20497,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Visibility
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action173(
 text,
 &___start0,
@@ -20186,6 +20512,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action329<
     'input,
 >(
@@ -20194,8 +20521,8 @@ ___0: (usize, Alternative, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<Alternative>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action243(
 text,
 ___0,
@@ -20209,6 +20536,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action330<
     'input,
 >(
@@ -20218,8 +20546,8 @@ ___1: (usize, Alternative, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<Alternative>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action243(
 text,
 ___1,
@@ -20234,6 +20562,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action331<
     'input,
 >(
@@ -20241,8 +20570,8 @@ text: &'input str,
 ___0: (usize, core::option::Option<Alternative>, usize),
 ) -> Vec<Alternative>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action241(
 text,
 &___start0,
@@ -20257,6 +20586,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action332<
     'input,
 >(
@@ -20265,8 +20595,8 @@ ___0: (usize, alloc::vec::Vec<Alternative>, usize),
 ___1: (usize, core::option::Option<Alternative>, usize),
 ) -> Vec<Alternative>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action242(
 text,
 ___0,
@@ -20280,6 +20610,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action333<
     'input,
 >(
@@ -20288,8 +20619,8 @@ ___0: (usize, Conversion, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<Conversion>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action267(
 text,
 ___0,
@@ -20303,6 +20634,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action334<
     'input,
 >(
@@ -20312,8 +20644,8 @@ ___1: (usize, Conversion, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<Conversion>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action267(
 text,
 ___1,
@@ -20328,6 +20660,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action335<
     'input,
 >(
@@ -20335,8 +20668,8 @@ text: &'input str,
 ___0: (usize, core::option::Option<Conversion>, usize),
 ) -> Vec<Conversion>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action265(
 text,
 &___start0,
@@ -20351,6 +20684,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action336<
     'input,
 >(
@@ -20359,8 +20693,8 @@ ___0: (usize, alloc::vec::Vec<Conversion>, usize),
 ___1: (usize, core::option::Option<Conversion>, usize),
 ) -> Vec<Conversion>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action266(
 text,
 ___0,
@@ -20374,6 +20708,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action337<
     'input,
 >(
@@ -20382,8 +20717,8 @@ ___0: (usize, FieldPattern<TypeRef>, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<FieldPattern<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action128(
 text,
 ___0,
@@ -20397,6 +20732,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action338<
     'input,
 >(
@@ -20406,8 +20742,8 @@ ___1: (usize, FieldPattern<TypeRef>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<FieldPattern<TypeRef>>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action128(
 text,
 ___1,
@@ -20422,6 +20758,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action339<
     'input,
 >(
@@ -20432,8 +20769,8 @@ ___2: (usize, core::option::Option<FieldPattern<TypeRef>>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> PatternKind<TypeRef>
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___2.0.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___2.0;
 let ___temp0 = ___action126(
 text,
 &___start0,
@@ -20451,6 +20788,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action340<
     'input,
 >(
@@ -20462,8 +20800,8 @@ ___3: (usize, core::option::Option<FieldPattern<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> PatternKind<TypeRef>
 {
-let ___start0 = ___2.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___2.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action127(
 text,
 ___2,
@@ -20480,6 +20818,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action341<
     'input,
 >(
@@ -20490,8 +20829,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> PatternKind<TypeRef>
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___2.0.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___2.0;
 let ___temp0 = ___action126(
 text,
 &___start0,
@@ -20509,6 +20848,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action342<
     'input,
 >(
@@ -20520,8 +20860,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> PatternKind<TypeRef>
 {
-let ___start0 = ___2.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___2.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action127(
 text,
 ___2,
@@ -20538,6 +20878,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action343<
     'input,
 >(
@@ -20546,8 +20887,8 @@ ___0: (usize, Parameter, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<Parameter>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action233(
 text,
 ___0,
@@ -20561,6 +20902,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action344<
     'input,
 >(
@@ -20570,8 +20912,8 @@ ___1: (usize, Parameter, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<Parameter>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action233(
 text,
 ___1,
@@ -20586,6 +20928,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action345<
     'input,
 >(
@@ -20593,8 +20936,8 @@ text: &'input str,
 ___0: (usize, core::option::Option<Parameter>, usize),
 ) -> Vec<Parameter>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action231(
 text,
 &___start0,
@@ -20609,6 +20952,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action346<
     'input,
 >(
@@ -20617,8 +20961,8 @@ ___0: (usize, alloc::vec::Vec<Parameter>, usize),
 ___1: (usize, core::option::Option<Parameter>, usize),
 ) -> Vec<Parameter>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action232(
 text,
 ___0,
@@ -20632,6 +20976,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action347<
     'input,
 >(
@@ -20640,8 +20985,8 @@ ___0: (usize, WhereClause<TypeRef>, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<WhereClause<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action210(
 text,
 ___0,
@@ -20655,6 +21000,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action348<
     'input,
 >(
@@ -20664,8 +21010,8 @@ ___1: (usize, WhereClause<TypeRef>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<WhereClause<TypeRef>>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action210(
 text,
 ___1,
@@ -20680,6 +21026,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action349<
     'input,
 >(
@@ -20687,8 +21034,8 @@ text: &'input str,
 ___0: (usize, core::option::Option<WhereClause<TypeRef>>, usize),
 ) -> Vec<WhereClause<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action208(
 text,
 &___start0,
@@ -20703,6 +21050,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action350<
     'input,
 >(
@@ -20711,8 +21059,8 @@ ___0: (usize, alloc::vec::Vec<WhereClause<TypeRef>>, usize),
 ___1: (usize, core::option::Option<WhereClause<TypeRef>>, usize),
 ) -> Vec<WhereClause<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action209(
 text,
 ___0,
@@ -20726,6 +21074,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action351<
     'input,
 >(
@@ -20734,8 +21083,8 @@ ___0: (usize, Atom, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<Atom>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action136(
 text,
 ___0,
@@ -20749,6 +21098,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action352<
     'input,
 >(
@@ -20758,8 +21108,8 @@ ___1: (usize, Atom, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<Atom>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action136(
 text,
 ___1,
@@ -20774,6 +21124,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action353<
     'input,
 >(
@@ -20782,8 +21133,8 @@ ___0: (usize, Tok<'input>, usize),
 ___1: (usize, Atom, usize),
 ) -> Path
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action134(
 text,
 &___start0,
@@ -20799,6 +21150,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action354<
     'input,
 >(
@@ -20808,8 +21160,8 @@ ___1: (usize, alloc::vec::Vec<Atom>, usize),
 ___2: (usize, Atom, usize),
 ) -> Path
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action135(
 text,
 ___1,
@@ -20824,6 +21176,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action355<
     'input,
 >(
@@ -20831,8 +21184,8 @@ text: &'input str,
 ___0: (usize, Atom, usize),
 ) -> Path
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action134(
 text,
 &___start0,
@@ -20847,6 +21200,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action356<
     'input,
 >(
@@ -20855,8 +21209,8 @@ ___0: (usize, alloc::vec::Vec<Atom>, usize),
 ___1: (usize, Atom, usize),
 ) -> Path
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action135(
 text,
 ___0,
@@ -20870,6 +21224,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action357<
     'input,
 >(
@@ -20878,8 +21233,8 @@ ___0: (usize, Lifetime, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<Lifetime>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action213(
 text,
 ___0,
@@ -20893,6 +21248,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action358<
     'input,
 >(
@@ -20902,8 +21258,8 @@ ___1: (usize, Lifetime, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<Lifetime>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action213(
 text,
 ___1,
@@ -20918,6 +21274,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action359<
     'input,
 >(
@@ -20925,8 +21282,8 @@ text: &'input str,
 ___0: (usize, core::option::Option<Lifetime>, usize),
 ) -> Vec<Lifetime>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action211(
 text,
 &___start0,
@@ -20941,6 +21298,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action360<
     'input,
 >(
@@ -20949,8 +21307,8 @@ ___0: (usize, alloc::vec::Vec<Lifetime>, usize),
 ___1: (usize, core::option::Option<Lifetime>, usize),
 ) -> Vec<Lifetime>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action212(
 text,
 ___0,
@@ -20964,6 +21322,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action361<
     'input,
 >(
@@ -20972,8 +21331,8 @@ ___0: (usize, MatchItem, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<MatchItem>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action262(
 text,
 ___0,
@@ -20987,6 +21346,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action362<
     'input,
 >(
@@ -20996,8 +21356,8 @@ ___1: (usize, MatchItem, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<MatchItem>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action262(
 text,
 ___1,
@@ -21012,6 +21372,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action363<
     'input,
 >(
@@ -21019,8 +21380,8 @@ text: &'input str,
 ___0: (usize, core::option::Option<MatchItem>, usize),
 ) -> Vec<MatchItem>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action260(
 text,
 &___start0,
@@ -21035,6 +21396,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action364<
     'input,
 >(
@@ -21043,8 +21405,8 @@ ___0: (usize, alloc::vec::Vec<MatchItem>, usize),
 ___1: (usize, core::option::Option<MatchItem>, usize),
 ) -> Vec<MatchItem>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action261(
 text,
 ___0,
@@ -21058,6 +21420,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action365<
     'input,
 >(
@@ -21066,8 +21429,8 @@ ___0: (usize, NonterminalString, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<NonterminalString>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action238(
 text,
 ___0,
@@ -21081,6 +21444,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action366<
     'input,
 >(
@@ -21090,8 +21454,8 @@ ___1: (usize, NonterminalString, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<NonterminalString>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action238(
 text,
 ___1,
@@ -21106,6 +21470,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action367<
     'input,
 >(
@@ -21113,8 +21478,8 @@ text: &'input str,
 ___0: (usize, core::option::Option<NonterminalString>, usize),
 ) -> Vec<NonterminalString>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action236(
 text,
 &___start0,
@@ -21129,6 +21494,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action368<
     'input,
 >(
@@ -21137,8 +21503,8 @@ ___0: (usize, alloc::vec::Vec<NonterminalString>, usize),
 ___1: (usize, core::option::Option<NonterminalString>, usize),
 ) -> Vec<NonterminalString>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action237(
 text,
 ___0,
@@ -21152,6 +21518,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action369<
     'input,
 >(
@@ -21160,8 +21527,8 @@ ___0: (usize, Pattern<TypeRef>, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<Pattern<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action272(
 text,
 ___0,
@@ -21175,6 +21542,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action370<
     'input,
 >(
@@ -21184,8 +21552,8 @@ ___1: (usize, Pattern<TypeRef>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<Pattern<TypeRef>>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action272(
 text,
 ___1,
@@ -21200,6 +21568,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action371<
     'input,
 >(
@@ -21207,8 +21576,8 @@ text: &'input str,
 ___0: (usize, core::option::Option<Pattern<TypeRef>>, usize),
 ) -> Vec<Pattern<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action270(
 text,
 &___start0,
@@ -21223,6 +21592,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action372<
     'input,
 >(
@@ -21231,8 +21601,8 @@ ___0: (usize, alloc::vec::Vec<Pattern<TypeRef>>, usize),
 ___1: (usize, core::option::Option<Pattern<TypeRef>>, usize),
 ) -> Vec<Pattern<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action271(
 text,
 ___0,
@@ -21246,6 +21616,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action373<
     'input,
 >(
@@ -21254,8 +21625,8 @@ ___0: (usize, Symbol, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<Symbol>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action248(
 text,
 ___0,
@@ -21269,6 +21640,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action374<
     'input,
 >(
@@ -21278,8 +21650,8 @@ ___1: (usize, Symbol, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<Symbol>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action248(
 text,
 ___1,
@@ -21294,6 +21666,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action375<
     'input,
 >(
@@ -21301,8 +21674,8 @@ text: &'input str,
 ___0: (usize, core::option::Option<Symbol>, usize),
 ) -> Vec<Symbol>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action246(
 text,
 &___start0,
@@ -21317,6 +21690,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action376<
     'input,
 >(
@@ -21325,8 +21699,8 @@ ___0: (usize, alloc::vec::Vec<Symbol>, usize),
 ___1: (usize, core::option::Option<Symbol>, usize),
 ) -> Vec<Symbol>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action247(
 text,
 ___0,
@@ -21340,6 +21714,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action377<
     'input,
 >(
@@ -21348,8 +21723,8 @@ ___0: (usize, TypeBound<TypeRef>, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<TypeBound<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action218(
 text,
 ___0,
@@ -21363,6 +21738,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action378<
     'input,
 >(
@@ -21372,8 +21748,8 @@ ___1: (usize, TypeBound<TypeRef>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<TypeBound<TypeRef>>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action218(
 text,
 ___1,
@@ -21388,6 +21764,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action379<
     'input,
 >(
@@ -21395,8 +21772,8 @@ text: &'input str,
 ___0: (usize, core::option::Option<TypeBound<TypeRef>>, usize),
 ) -> Vec<TypeBound<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action216(
 text,
 &___start0,
@@ -21411,6 +21788,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action380<
     'input,
 >(
@@ -21419,8 +21797,8 @@ ___0: (usize, alloc::vec::Vec<TypeBound<TypeRef>>, usize),
 ___1: (usize, core::option::Option<TypeBound<TypeRef>>, usize),
 ) -> Vec<TypeBound<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action217(
 text,
 ___0,
@@ -21434,6 +21812,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action381<
     'input,
 >(
@@ -21442,8 +21821,8 @@ ___0: (usize, TypeBoundParameter<TypeRef>, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<TypeBoundParameter<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action228(
 text,
 ___0,
@@ -21457,6 +21836,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action382<
     'input,
 >(
@@ -21466,8 +21846,8 @@ ___1: (usize, TypeBoundParameter<TypeRef>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<TypeBoundParameter<TypeRef>>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action228(
 text,
 ___1,
@@ -21482,6 +21862,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action383<
     'input,
 >(
@@ -21489,8 +21870,8 @@ text: &'input str,
 ___0: (usize, core::option::Option<TypeBoundParameter<TypeRef>>, usize),
 ) -> Vec<TypeBoundParameter<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action226(
 text,
 &___start0,
@@ -21505,6 +21886,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action384<
     'input,
 >(
@@ -21513,8 +21895,8 @@ ___0: (usize, alloc::vec::Vec<TypeBoundParameter<TypeRef>>, usize),
 ___1: (usize, core::option::Option<TypeBoundParameter<TypeRef>>, usize),
 ) -> Vec<TypeBoundParameter<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action227(
 text,
 ___0,
@@ -21528,6 +21910,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action385<
     'input,
 >(
@@ -21536,8 +21919,8 @@ ___0: (usize, TypeParameter, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<TypeParameter>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action205(
 text,
 ___0,
@@ -21551,6 +21934,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action386<
     'input,
 >(
@@ -21560,8 +21944,8 @@ ___1: (usize, TypeParameter, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<TypeParameter>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action205(
 text,
 ___1,
@@ -21576,6 +21960,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action387<
     'input,
 >(
@@ -21583,8 +21968,8 @@ text: &'input str,
 ___0: (usize, core::option::Option<TypeParameter>, usize),
 ) -> Vec<TypeParameter>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action203(
 text,
 &___start0,
@@ -21599,6 +21984,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action388<
     'input,
 >(
@@ -21607,8 +21993,8 @@ ___0: (usize, alloc::vec::Vec<TypeParameter>, usize),
 ___1: (usize, core::option::Option<TypeParameter>, usize),
 ) -> Vec<TypeParameter>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action204(
 text,
 ___0,
@@ -21622,6 +22008,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action389<
     'input,
 >(
@@ -21630,8 +22017,8 @@ ___0: (usize, TypeRef, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action223(
 text,
 ___0,
@@ -21645,6 +22032,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action390<
     'input,
 >(
@@ -21654,8 +22042,8 @@ ___1: (usize, TypeRef, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<TypeRef>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action223(
 text,
 ___1,
@@ -21670,6 +22058,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action391<
     'input,
 >(
@@ -21677,8 +22066,8 @@ text: &'input str,
 ___0: (usize, core::option::Option<TypeRef>, usize),
 ) -> Vec<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action221(
 text,
 &___start0,
@@ -21693,6 +22082,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action392<
     'input,
 >(
@@ -21701,8 +22091,8 @@ ___0: (usize, alloc::vec::Vec<TypeRef>, usize),
 ___1: (usize, core::option::Option<TypeRef>, usize),
 ) -> Vec<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action222(
 text,
 ___0,
@@ -21716,6 +22106,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action393<
     'input,
 >(
@@ -21724,8 +22115,8 @@ ___0: (usize, TypeRef, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action253(
 text,
 ___0,
@@ -21739,6 +22130,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action394<
     'input,
 >(
@@ -21748,8 +22140,8 @@ ___1: (usize, TypeRef, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> alloc::vec::Vec<TypeRef>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action253(
 text,
 ___1,
@@ -21764,6 +22156,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action395<
     'input,
 >(
@@ -21771,8 +22164,8 @@ text: &'input str,
 ___0: (usize, core::option::Option<TypeRef>, usize),
 ) -> Vec<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action251(
 text,
 &___start0,
@@ -21787,6 +22180,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action396<
     'input,
 >(
@@ -21795,8 +22189,8 @@ ___0: (usize, alloc::vec::Vec<TypeRef>, usize),
 ___1: (usize, core::option::Option<TypeRef>, usize),
 ) -> Vec<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action252(
 text,
 ___0,
@@ -21810,6 +22204,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action397<
     'input,
 >(
@@ -21822,8 +22217,8 @@ ___4: (usize, core::option::Option<ActionKind>, usize),
 ___5: (usize, usize, usize),
 ) -> Alternative
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -21843,6 +22238,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action398<
     'input,
 >(
@@ -21853,8 +22249,8 @@ ___2: (usize, core::option::Option<ActionKind>, usize),
 ___3: (usize, usize, usize),
 ) -> Alternative
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -21872,6 +22268,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action399<
     'input,
 >(
@@ -21882,8 +22279,8 @@ ___2: (usize, ActionKind, usize),
 ___3: (usize, usize, usize),
 ) -> Alternative
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -21901,6 +22298,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action400<
     'input,
 >(
@@ -21909,8 +22307,8 @@ ___0: (usize, ActionKind, usize),
 ___1: (usize, usize, usize),
 ) -> Alternative
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -21926,6 +22324,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action401<
     'input,
 >(
@@ -21938,8 +22337,8 @@ ___4: (usize, usize, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Annotation
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___2.0.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___2.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -21959,6 +22358,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action402<
     'input,
 >(
@@ -21971,8 +22371,8 @@ ___4: (usize, TypeRef, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> AssociatedType
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -21992,6 +22392,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action403<
     'input,
 >(
@@ -22002,8 +22403,8 @@ ___2: (usize, Atom, usize),
 ___3: (usize, usize, usize),
 ) -> Condition
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22021,6 +22422,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action404<
     'input,
 >(
@@ -22030,10 +22432,10 @@ ___1: (usize, &'input str, usize),
 ___2: (usize, usize, usize),
 ) -> Result<Conversion,___lalrpop_util::ParseError<usize,Tok<'input>,tok::Error>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
-let ___start1 = ___0.2.clone();
-let ___end1 = ___1.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
+let ___start1 = ___0.2;
+let ___end1 = ___1.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22057,6 +22459,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action405<
     'input,
 >(
@@ -22069,8 +22472,8 @@ ___4: (usize, Vec<Conversion>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> EnumToken
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22090,6 +22493,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action406<
     'input,
 >(
@@ -22103,8 +22507,8 @@ ___5: (usize, alloc::vec::Vec<AssociatedType>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22125,6 +22529,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action407<
     'input,
 >(
@@ -22136,8 +22541,8 @@ ___3: (usize, alloc::vec::Vec<AssociatedType>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22156,6 +22561,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action408<
     'input,
 >(
@@ -22166,8 +22572,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Pattern<TypeRef>, usize),
 ) -> FieldPattern<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22185,6 +22591,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action409<
     'input,
 >(
@@ -22201,8 +22608,8 @@ ___8: (usize, Tok<'input>, usize),
 ___9: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___3.0.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___3.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22226,6 +22633,7 @@ ___9,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action410<
     'input,
 >(
@@ -22234,8 +22642,8 @@ ___0: (usize, Tok<'input>, usize),
 ___1: (usize, usize, usize),
 ) -> MatchItem
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22251,6 +22659,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action411<
     'input,
 >(
@@ -22259,8 +22668,8 @@ ___0: (usize, TerminalLiteral, usize),
 ___1: (usize, usize, usize),
 ) -> MatchItem
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22276,6 +22685,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action412<
     'input,
 >(
@@ -22285,10 +22695,10 @@ ___1: (usize, &'input str, usize),
 ___2: (usize, usize, usize),
 ) -> Result<MatchItem,___lalrpop_util::ParseError<usize,Tok<'input>,tok::Error>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
-let ___start1 = ___0.2.clone();
-let ___end1 = ___1.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
+let ___start1 = ___0.2;
+let ___end1 = ___1.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22312,6 +22722,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action413<
     'input,
 >(
@@ -22323,8 +22734,8 @@ ___3: (usize, MatchContents, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> MatchToken
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22343,6 +22754,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action414<
     'input,
 >(
@@ -22357,8 +22769,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, Vec<Alternative>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___2.0.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___2.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22380,6 +22792,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action415<
     'input,
 >(
@@ -22392,8 +22805,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, Vec<Alternative>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___2.0.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___2.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22413,6 +22826,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action416<
     'input,
 >(
@@ -22421,8 +22835,8 @@ ___0: (usize, PatternKind<TypeRef>, usize),
 ___1: (usize, usize, usize),
 ) -> Pattern<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22438,6 +22852,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action417<
     'input,
 >(
@@ -22445,8 +22860,8 @@ text: &'input str,
 ___0: (usize, &'input str, usize),
 ) -> Result<String,___lalrpop_util::ParseError<usize,Tok<'input>,tok::Error>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22461,6 +22876,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action418<
     'input,
 >(
@@ -22468,8 +22884,8 @@ text: &'input str,
 ___0: (usize, &'input str, usize),
 ) -> Result<Atom,___lalrpop_util::ParseError<usize,Tok<'input>,tok::Error>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22484,6 +22900,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action419<
     'input,
 >(
@@ -22497,10 +22914,10 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, usize, usize),
 ) -> Symbol
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
-let ___start1 = ___1.2.clone();
-let ___end1 = ___2.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
+let ___start1 = ___1.2;
+let ___end1 = ___2.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22528,6 +22945,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action420<
     'input,
 >(
@@ -22540,10 +22958,10 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, usize, usize),
 ) -> Symbol
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
-let ___start1 = ___0.2.clone();
-let ___end1 = ___1.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
+let ___start1 = ___0.2;
+let ___end1 = ___1.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22570,6 +22988,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action421<
     'input,
 >(
@@ -22580,8 +22999,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, usize, usize),
 ) -> Symbol
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22599,6 +23018,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action422<
     'input,
 >(
@@ -22607,8 +23027,8 @@ ___0: (usize, SymbolKind, usize),
 ___1: (usize, usize, usize),
 ) -> Symbol
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action186(
 text,
 &___start0,
@@ -22624,6 +23044,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action423<
     'input,
 >(
@@ -22635,8 +23056,8 @@ ___3: (usize, Condition, usize),
 ___4: (usize, core::option::Option<ActionKind>, usize),
 ) -> Alternative
 {
-let ___start0 = ___4.2.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.2;
+let ___end0 = ___4.2;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -22655,6 +23076,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action424<
     'input,
 >(
@@ -22664,8 +23086,8 @@ ___1: (usize, alloc::vec::Vec<Symbol>, usize),
 ___2: (usize, core::option::Option<ActionKind>, usize),
 ) -> Alternative
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___2.2;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -22682,6 +23104,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action425<
     'input,
 >(
@@ -22691,8 +23114,8 @@ ___1: (usize, Condition, usize),
 ___2: (usize, ActionKind, usize),
 ) -> Alternative
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___2.2;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -22709,6 +23132,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action426<
     'input,
 >(
@@ -22716,8 +23140,8 @@ text: &'input str,
 ___0: (usize, ActionKind, usize),
 ) -> Alternative
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -22732,6 +23156,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action427<
     'input,
 >(
@@ -22743,8 +23168,8 @@ ___3: (usize, core::option::Option<(Atom, String)>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Annotation
 {
-let ___start0 = ___3.2.clone();
-let ___end0 = ___4.0.clone();
+let ___start0 = ___3.2;
+let ___end0 = ___4.0;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -22763,6 +23188,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action428<
     'input,
 >(
@@ -22774,8 +23200,8 @@ ___3: (usize, TypeRef, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> AssociatedType
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___2.0.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___2.0;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -22794,6 +23220,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action429<
     'input,
 >(
@@ -22803,8 +23230,8 @@ ___1: (usize, ConditionOp, usize),
 ___2: (usize, Atom, usize),
 ) -> Condition
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___2.2;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -22821,6 +23248,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action430<
     'input,
 >(
@@ -22829,8 +23257,8 @@ ___0: (usize, TerminalString, usize),
 ___1: (usize, &'input str, usize),
 ) -> Result<Conversion,___lalrpop_util::ParseError<usize,Tok<'input>,tok::Error>>
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___1.2;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -22846,6 +23274,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action431<
     'input,
 >(
@@ -22857,8 +23286,8 @@ ___3: (usize, Vec<Conversion>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> EnumToken
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___2.0.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___2.0;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -22877,6 +23306,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action432<
     'input,
 >(
@@ -22889,8 +23319,8 @@ ___4: (usize, alloc::vec::Vec<AssociatedType>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -22910,6 +23340,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action433<
     'input,
 >(
@@ -22920,8 +23351,8 @@ ___2: (usize, alloc::vec::Vec<AssociatedType>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -22939,6 +23370,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action434<
     'input,
 >(
@@ -22948,8 +23380,8 @@ ___1: (usize, Tok<'input>, usize),
 ___2: (usize, Pattern<TypeRef>, usize),
 ) -> FieldPattern<TypeRef>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -22966,6 +23398,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action435<
     'input,
 >(
@@ -22981,8 +23414,8 @@ ___7: (usize, Tok<'input>, usize),
 ___8: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.2.clone();
-let ___end0 = ___4.0.clone();
+let ___start0 = ___3.2;
+let ___end0 = ___4.0;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -23005,6 +23438,7 @@ ___8,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action436<
     'input,
 >(
@@ -23012,8 +23446,8 @@ text: &'input str,
 ___0: (usize, Tok<'input>, usize),
 ) -> MatchItem
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -23028,6 +23462,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action437<
     'input,
 >(
@@ -23035,8 +23470,8 @@ text: &'input str,
 ___0: (usize, TerminalLiteral, usize),
 ) -> MatchItem
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -23051,6 +23486,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action438<
     'input,
 >(
@@ -23059,8 +23495,8 @@ ___0: (usize, TerminalLiteral, usize),
 ___1: (usize, &'input str, usize),
 ) -> Result<MatchItem,___lalrpop_util::ParseError<usize,Tok<'input>,tok::Error>>
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___1.2;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -23076,6 +23512,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action439<
     'input,
 >(
@@ -23086,8 +23523,8 @@ ___2: (usize, MatchContents, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> MatchToken
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -23105,6 +23542,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action440<
     'input,
 >(
@@ -23118,8 +23556,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, Vec<Alternative>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___3.0.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___3.0;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -23140,6 +23578,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action441<
     'input,
 >(
@@ -23151,8 +23590,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, Vec<Alternative>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___3.0.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___3.0;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -23171,6 +23610,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action442<
     'input,
 >(
@@ -23178,8 +23618,8 @@ text: &'input str,
 ___0: (usize, PatternKind<TypeRef>, usize),
 ) -> Pattern<TypeRef>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -23194,6 +23634,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action443<
     'input,
 >(
@@ -23206,8 +23647,8 @@ ___4: (usize, Symbol, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Symbol
 {
-let ___start0 = ___5.2.clone();
-let ___end0 = ___5.2.clone();
+let ___start0 = ___5.2;
+let ___end0 = ___5.2;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -23227,6 +23668,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action444<
     'input,
 >(
@@ -23238,8 +23680,8 @@ ___3: (usize, Symbol, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Symbol
 {
-let ___start0 = ___4.2.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.2;
+let ___end0 = ___4.2;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -23258,6 +23700,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action445<
     'input,
 >(
@@ -23267,8 +23710,8 @@ ___1: (usize, Symbol, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> Symbol
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___2.2;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -23285,6 +23728,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action446<
     'input,
 >(
@@ -23293,8 +23737,8 @@ ___0: (usize, Symbol, usize),
 ___1: (usize, RepeatOp, usize),
 ) -> Symbol
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___1.2;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -23310,6 +23754,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action447<
     'input,
 >(
@@ -23317,8 +23762,8 @@ text: &'input str,
 ___0: (usize, SymbolKind, usize),
 ) -> Symbol
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action185(
 text,
 &___start0,
@@ -23333,6 +23778,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action448<
     'input,
 >(
@@ -23344,8 +23790,8 @@ ___3: (usize, Condition, usize),
 ___4: (usize, ActionKind, usize),
 ) -> Alternative
 {
-let ___start0 = ___4.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action147(
 text,
 ___4,
@@ -23362,6 +23808,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action449<
     'input,
 >(
@@ -23372,8 +23819,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Condition, usize),
 ) -> Alternative
 {
-let ___start0 = ___3.2.clone();
-let ___end0 = ___3.2.clone();
+let ___start0 = ___3.2;
+let ___end0 = ___3.2;
 let ___temp0 = ___action148(
 text,
 &___start0,
@@ -23391,6 +23838,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action450<
     'input,
 >(
@@ -23400,8 +23848,8 @@ ___1: (usize, alloc::vec::Vec<Symbol>, usize),
 ___2: (usize, ActionKind, usize),
 ) -> Alternative
 {
-let ___start0 = ___2.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___2.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action147(
 text,
 ___2,
@@ -23416,6 +23864,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action451<
     'input,
 >(
@@ -23424,8 +23873,8 @@ ___0: (usize, alloc::vec::Vec<Annotation>, usize),
 ___1: (usize, alloc::vec::Vec<Symbol>, usize),
 ) -> Alternative
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___1.2;
 let ___temp0 = ___action148(
 text,
 &___start0,
@@ -23441,6 +23890,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action452<
     'input,
 >(
@@ -23448,8 +23898,8 @@ text: &'input str,
 ___0: (usize, Alternative, usize),
 ) -> Vec<Alternative>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action239(
 text,
 ___0,
@@ -23462,6 +23912,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action453<
     'input,
 >(
@@ -23470,8 +23921,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Vec<Alternative>
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action240(
 text,
 &___start0,
@@ -23485,6 +23936,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action454<
     'input,
 >(
@@ -23493,8 +23945,8 @@ ___0: (usize, alloc::vec::Vec<Alternative>, usize),
 ___1: (usize, Alternative, usize),
 ) -> Vec<Alternative>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action239(
 text,
 ___1,
@@ -23508,6 +23960,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action455<
     'input,
 >(
@@ -23515,8 +23968,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<Alternative>, usize),
 ) -> Vec<Alternative>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action240(
 text,
 &___start0,
@@ -23531,6 +23984,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action456<
     'input,
 >(
@@ -23541,8 +23995,8 @@ ___2: (usize, Condition, usize),
 ___3: (usize, ActionKind, usize),
 ) -> Alternative
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action187(
 text,
 &___start0,
@@ -23560,6 +24014,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action457<
     'input,
 >(
@@ -23571,8 +24026,8 @@ ___3: (usize, Condition, usize),
 ___4: (usize, ActionKind, usize),
 ) -> Alternative
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action188(
 text,
 ___0,
@@ -23589,6 +24044,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action458<
     'input,
 >(
@@ -23598,8 +24054,8 @@ ___1: (usize, Tok<'input>, usize),
 ___2: (usize, Condition, usize),
 ) -> Alternative
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action187(
 text,
 &___start0,
@@ -23616,6 +24072,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action459<
     'input,
 >(
@@ -23626,8 +24083,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Condition, usize),
 ) -> Alternative
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action188(
 text,
 ___0,
@@ -23643,6 +24100,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action460<
     'input,
 >(
@@ -23651,8 +24109,8 @@ ___0: (usize, alloc::vec::Vec<Symbol>, usize),
 ___1: (usize, ActionKind, usize),
 ) -> Alternative
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action187(
 text,
 &___start0,
@@ -23668,6 +24126,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action461<
     'input,
 >(
@@ -23677,8 +24136,8 @@ ___1: (usize, alloc::vec::Vec<Symbol>, usize),
 ___2: (usize, ActionKind, usize),
 ) -> Alternative
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action188(
 text,
 ___0,
@@ -23693,6 +24152,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action462<
     'input,
 >(
@@ -23700,8 +24160,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<Symbol>, usize),
 ) -> Alternative
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action187(
 text,
 &___start0,
@@ -23716,6 +24176,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action463<
     'input,
 >(
@@ -23724,8 +24185,8 @@ ___0: (usize, alloc::vec::Vec<Annotation>, usize),
 ___1: (usize, alloc::vec::Vec<Symbol>, usize),
 ) -> Alternative
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action188(
 text,
 ___0,
@@ -23739,6 +24200,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action464<
     'input,
 >(
@@ -23753,8 +24215,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___2.0.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___2.0;
 let ___temp0 = ___action187(
 text,
 &___start0,
@@ -23776,6 +24238,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action465<
     'input,
 >(
@@ -23791,8 +24254,8 @@ ___7: (usize, Tok<'input>, usize),
 ___8: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___2.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___2.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action188(
 text,
 ___2,
@@ -23813,6 +24276,7 @@ ___8,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action466<
     'input,
 >(
@@ -23825,8 +24289,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, Vec<Alternative>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action187(
 text,
 &___start0,
@@ -23846,6 +24310,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action467<
     'input,
 >(
@@ -23859,8 +24324,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, Vec<Alternative>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action188(
 text,
 ___0,
@@ -23879,6 +24344,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action468<
     'input,
 >(
@@ -23889,8 +24355,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Vec<Alternative>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action187(
 text,
 &___start0,
@@ -23908,6 +24374,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action469<
     'input,
 >(
@@ -23919,8 +24386,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, Vec<Alternative>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action188(
 text,
 ___0,
@@ -23937,6 +24404,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action470<
     'input,
 >(
@@ -23948,8 +24416,8 @@ ___3: (usize, (Atom, String), usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Annotation
 {
-let ___start0 = ___3.0.clone();
-let ___end0 = ___3.2.clone();
+let ___start0 = ___3.0;
+let ___end0 = ___3.2;
 let ___temp0 = ___action158(
 text,
 ___3,
@@ -23966,6 +24434,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action471<
     'input,
 >(
@@ -23976,8 +24445,8 @@ ___2: (usize, Atom, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Annotation
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___3.0.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___3.0;
 let ___temp0 = ___action159(
 text,
 &___start0,
@@ -23995,6 +24464,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action472<
     'input,
 >(
@@ -24005,10 +24475,10 @@ ___2: (usize, EnumToken, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___2.0.clone();
-let ___start1 = ___2.2.clone();
-let ___end1 = ___3.0.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___2.0;
+let ___start1 = ___2.2;
+let ___end1 = ___3.0;
 let ___temp0 = ___action132(
 text,
 &___start0,
@@ -24033,6 +24503,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action473<
     'input,
 >(
@@ -24044,10 +24515,10 @@ ___3: (usize, alloc::vec::Vec<AssociatedType>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___2.0.clone();
-let ___start1 = ___3.0.clone();
-let ___end1 = ___3.2.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___2.0;
+let ___start1 = ___3.0;
+let ___end1 = ___3.2;
 let ___temp0 = ___action132(
 text,
 &___start0,
@@ -24071,6 +24542,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action474<
     'input,
 >(
@@ -24082,10 +24554,10 @@ ___3: (usize, EnumToken, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___2.0.clone();
-let ___end0 = ___2.2.clone();
-let ___start1 = ___3.2.clone();
-let ___end1 = ___4.0.clone();
+let ___start0 = ___2.0;
+let ___end0 = ___2.2;
+let ___start1 = ___3.2;
+let ___end1 = ___4.0;
 let ___temp0 = ___action133(
 text,
 ___2,
@@ -24109,6 +24581,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action475<
     'input,
 >(
@@ -24121,10 +24594,10 @@ ___4: (usize, alloc::vec::Vec<AssociatedType>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___2.0.clone();
-let ___end0 = ___2.2.clone();
-let ___start1 = ___4.0.clone();
-let ___end1 = ___4.2.clone();
+let ___start0 = ___2.0;
+let ___end0 = ___2.2;
+let ___start1 = ___4.0;
+let ___end1 = ___4.2;
 let ___temp0 = ___action133(
 text,
 ___2,
@@ -24147,6 +24620,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action476<
     'input,
 >(
@@ -24156,8 +24630,8 @@ ___1: (usize, Tok<'input>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___2.0.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___2.0;
 let ___temp0 = ___action132(
 text,
 &___start0,
@@ -24174,6 +24648,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action477<
     'input,
 >(
@@ -24184,8 +24659,8 @@ ___2: (usize, alloc::vec::Vec<AssociatedType>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> GrammarItem
 {
-let ___start0 = ___2.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___2.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action133(
 text,
 ___2,
@@ -24201,6 +24676,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action478<
     'input,
 >(
@@ -24208,8 +24684,8 @@ text: &'input str,
 ___0: (usize, Conversion, usize),
 ) -> Vec<Conversion>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action263(
 text,
 ___0,
@@ -24222,6 +24698,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action479<
     'input,
 >(
@@ -24230,8 +24707,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Vec<Conversion>
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action264(
 text,
 &___start0,
@@ -24245,6 +24722,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action480<
     'input,
 >(
@@ -24253,8 +24731,8 @@ ___0: (usize, alloc::vec::Vec<Conversion>, usize),
 ___1: (usize, Conversion, usize),
 ) -> Vec<Conversion>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action263(
 text,
 ___1,
@@ -24268,6 +24746,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action481<
     'input,
 >(
@@ -24275,8 +24754,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<Conversion>, usize),
 ) -> Vec<Conversion>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action264(
 text,
 &___start0,
@@ -24291,6 +24770,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action482<
     'input,
 >(
@@ -24301,8 +24781,8 @@ ___2: (usize, FieldPattern<TypeRef>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> PatternKind<TypeRef>
 {
-let ___start0 = ___2.0.clone();
-let ___end0 = ___2.2.clone();
+let ___start0 = ___2.0;
+let ___end0 = ___2.2;
 let ___temp0 = ___action124(
 text,
 ___2,
@@ -24318,6 +24798,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action483<
     'input,
 >(
@@ -24327,8 +24808,8 @@ ___1: (usize, Tok<'input>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> PatternKind<TypeRef>
 {
-let ___start0 = ___1.2.clone();
-let ___end0 = ___2.0.clone();
+let ___start0 = ___1.2;
+let ___end0 = ___2.0;
 let ___temp0 = ___action125(
 text,
 &___start0,
@@ -24345,6 +24826,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action484<
     'input,
 >(
@@ -24356,8 +24838,8 @@ ___3: (usize, FieldPattern<TypeRef>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> PatternKind<TypeRef>
 {
-let ___start0 = ___3.0.clone();
-let ___end0 = ___3.2.clone();
+let ___start0 = ___3.0;
+let ___end0 = ___3.2;
 let ___temp0 = ___action124(
 text,
 ___3,
@@ -24374,6 +24856,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action485<
     'input,
 >(
@@ -24384,8 +24867,8 @@ ___2: (usize, alloc::vec::Vec<FieldPattern<TypeRef>>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> PatternKind<TypeRef>
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___3.0.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___3.0;
 let ___temp0 = ___action125(
 text,
 &___start0,
@@ -24403,6 +24886,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action486<
     'input,
 >(
@@ -24416,8 +24900,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, Vec<TypeBound<TypeRef>>, usize),
 ) -> WhereClause<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___3.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___3.2;
 let ___temp0 = ___action13(
 text,
 ___0,
@@ -24436,6 +24920,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action487<
     'input,
 >(
@@ -24445,8 +24930,8 @@ ___1: (usize, Tok<'input>, usize),
 ___2: (usize, Vec<TypeBound<TypeRef>>, usize),
 ) -> WhereClause<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action327(
 text,
 &___start0,
@@ -24463,6 +24948,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action488<
     'input,
 >(
@@ -24479,8 +24965,8 @@ ___8: (usize, Tok<'input>, usize),
 ___9: (usize, TypeRef, usize),
 ) -> TypeBound<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___3.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___3.2;
 let ___temp0 = ___action13(
 text,
 ___0,
@@ -24502,6 +24988,7 @@ ___9,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action489<
     'input,
 >(
@@ -24514,8 +25001,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, TypeRef, usize),
 ) -> TypeBound<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action327(
 text,
 &___start0,
@@ -24535,6 +25022,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action490<
     'input,
 >(
@@ -24549,8 +25037,8 @@ ___6: (usize, Vec<TypeRef>, usize),
 ___7: (usize, Tok<'input>, usize),
 ) -> TypeBound<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___3.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___3.2;
 let ___temp0 = ___action13(
 text,
 ___0,
@@ -24570,6 +25058,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action491<
     'input,
 >(
@@ -24580,8 +25069,8 @@ ___2: (usize, Vec<TypeRef>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> TypeBound<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action327(
 text,
 &___start0,
@@ -24599,6 +25088,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action492<
     'input,
 >(
@@ -24613,8 +25103,8 @@ ___6: (usize, Vec<TypeBoundParameter<TypeRef>>, usize),
 ___7: (usize, Tok<'input>, usize),
 ) -> TypeBound<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___3.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___3.2;
 let ___temp0 = ___action13(
 text,
 ___0,
@@ -24634,6 +25124,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action493<
     'input,
 >(
@@ -24644,8 +25135,8 @@ ___2: (usize, Vec<TypeBoundParameter<TypeRef>>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> TypeBound<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action327(
 text,
 &___start0,
@@ -24663,6 +25154,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action494<
     'input,
 >(
@@ -24674,8 +25166,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, Path, usize),
 ) -> TypeBound<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___3.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___3.2;
 let ___temp0 = ___action13(
 text,
 ___0,
@@ -24692,6 +25184,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action495<
     'input,
 >(
@@ -24699,8 +25192,8 @@ text: &'input str,
 ___0: (usize, Path, usize),
 ) -> TypeBound<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action327(
 text,
 &___start0,
@@ -24715,6 +25208,7 @@ ___0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action496<
     'input,
 >(
@@ -24732,8 +25226,8 @@ ___9: (usize, Tok<'input>, usize),
 ___10: (usize, TypeRef, usize),
 ) -> TypeRef
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action13(
 text,
 ___1,
@@ -24756,6 +25250,7 @@ ___10,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action497<
     'input,
 >(
@@ -24769,8 +25264,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, TypeRef, usize),
 ) -> TypeRef
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action327(
 text,
 &___start0,
@@ -24791,6 +25286,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action498<
     'input,
 >(
@@ -24806,8 +25302,8 @@ ___7: (usize, Vec<TypeRef>, usize),
 ___8: (usize, Tok<'input>, usize),
 ) -> TypeRef
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action13(
 text,
 ___1,
@@ -24828,6 +25324,7 @@ ___8,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action499<
     'input,
 >(
@@ -24839,8 +25336,8 @@ ___3: (usize, Vec<TypeRef>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> TypeRef
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action327(
 text,
 &___start0,
@@ -24859,6 +25356,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action500<
     'input,
 >(
@@ -24872,8 +25370,8 @@ ___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___6.2.clone();
-let ___end0 = ___6.2.clone();
+let ___start0 = ___6.2;
+let ___end0 = ___6.2;
 let ___temp0 = ___action177(
 text,
 &___start0,
@@ -24894,6 +25392,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action501<
     'input,
 >(
@@ -24908,8 +25407,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___7.0.clone();
-let ___end0 = ___7.2.clone();
+let ___start0 = ___7.0;
+let ___end0 = ___7.2;
 let ___temp0 = ___action178(
 text,
 ___7,
@@ -24929,6 +25428,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action502<
     'input,
 >(
@@ -24943,8 +25443,8 @@ ___6: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
 ___7: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___7.2.clone();
-let ___end0 = ___7.2.clone();
+let ___start0 = ___7.2;
+let ___end0 = ___7.2;
 let ___temp0 = ___action177(
 text,
 &___start0,
@@ -24966,6 +25466,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action503<
     'input,
 >(
@@ -24981,8 +25482,8 @@ ___7: (usize, Tok<'input>, usize),
 ___8: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___8.0.clone();
-let ___end0 = ___8.2.clone();
+let ___start0 = ___8.0;
+let ___end0 = ___8.2;
 let ___temp0 = ___action178(
 text,
 ___8,
@@ -25003,6 +25504,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action504<
     'input,
 >(
@@ -25010,8 +25512,8 @@ text: &'input str,
 ___0: (usize, Parameter, usize),
 ) -> Vec<Parameter>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action229(
 text,
 ___0,
@@ -25024,6 +25526,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action505<
     'input,
 >(
@@ -25032,8 +25535,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Vec<Parameter>
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action230(
 text,
 &___start0,
@@ -25047,6 +25550,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action506<
     'input,
 >(
@@ -25055,8 +25559,8 @@ ___0: (usize, alloc::vec::Vec<Parameter>, usize),
 ___1: (usize, Parameter, usize),
 ) -> Vec<Parameter>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action229(
 text,
 ___1,
@@ -25070,6 +25574,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action507<
     'input,
 >(
@@ -25077,8 +25582,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<Parameter>, usize),
 ) -> Vec<Parameter>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action230(
 text,
 &___start0,
@@ -25093,6 +25598,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action508<
     'input,
 >(
@@ -25106,8 +25612,8 @@ ___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action181(
 text,
 ___4,
@@ -25126,6 +25632,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action509<
     'input,
 >(
@@ -25138,8 +25645,8 @@ ___4: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.2.clone();
-let ___end0 = ___4.0.clone();
+let ___start0 = ___3.2;
+let ___end0 = ___4.0;
 let ___temp0 = ___action182(
 text,
 &___start0,
@@ -25159,6 +25666,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action510<
     'input,
 >(
@@ -25173,8 +25681,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action181(
 text,
 ___4,
@@ -25194,6 +25702,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action511<
     'input,
 >(
@@ -25207,8 +25716,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.2.clone();
-let ___end0 = ___4.0.clone();
+let ___start0 = ___3.2;
+let ___end0 = ___4.0;
 let ___temp0 = ___action182(
 text,
 &___start0,
@@ -25229,6 +25738,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action512<
     'input,
 >(
@@ -25243,8 +25753,8 @@ ___6: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
 ___7: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___5.0.clone();
-let ___end0 = ___5.2.clone();
+let ___start0 = ___5.0;
+let ___end0 = ___5.2;
 let ___temp0 = ___action181(
 text,
 ___5,
@@ -25264,6 +25774,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action513<
     'input,
 >(
@@ -25277,8 +25788,8 @@ ___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.2.clone();
-let ___end0 = ___5.0.clone();
+let ___start0 = ___4.2;
+let ___end0 = ___5.0;
 let ___temp0 = ___action182(
 text,
 &___start0,
@@ -25299,6 +25810,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action514<
     'input,
 >(
@@ -25314,8 +25826,8 @@ ___7: (usize, Tok<'input>, usize),
 ___8: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___5.0.clone();
-let ___end0 = ___5.2.clone();
+let ___start0 = ___5.0;
+let ___end0 = ___5.2;
 let ___temp0 = ___action181(
 text,
 ___5,
@@ -25336,6 +25848,7 @@ ___8,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action515<
     'input,
 >(
@@ -25350,8 +25863,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.2.clone();
-let ___end0 = ___5.0.clone();
+let ___start0 = ___4.2;
+let ___end0 = ___5.0;
 let ___temp0 = ___action182(
 text,
 &___start0,
@@ -25373,6 +25886,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action516<
     'input,
 >(
@@ -25386,8 +25900,8 @@ ___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.0.clone();
-let ___end0 = ___3.2.clone();
+let ___start0 = ___3.0;
+let ___end0 = ___3.2;
 let ___temp0 = ___action183(
 text,
 ___3,
@@ -25406,6 +25920,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action517<
     'input,
 >(
@@ -25418,8 +25933,8 @@ ___4: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___3.0.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___3.0;
 let ___temp0 = ___action184(
 text,
 &___start0,
@@ -25439,6 +25954,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action518<
     'input,
 >(
@@ -25451,8 +25967,8 @@ ___4: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.0.clone();
-let ___end0 = ___3.2.clone();
+let ___start0 = ___3.0;
+let ___end0 = ___3.2;
 let ___temp0 = ___action183(
 text,
 ___3,
@@ -25470,6 +25986,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action519<
     'input,
 >(
@@ -25481,8 +25998,8 @@ ___3: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___3.0.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___3.0;
 let ___temp0 = ___action184(
 text,
 &___start0,
@@ -25501,6 +26018,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action520<
     'input,
 >(
@@ -25515,8 +26033,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.0.clone();
-let ___end0 = ___3.2.clone();
+let ___start0 = ___3.0;
+let ___end0 = ___3.2;
 let ___temp0 = ___action183(
 text,
 ___3,
@@ -25536,6 +26054,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action521<
     'input,
 >(
@@ -25549,8 +26068,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___3.0.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___3.0;
 let ___temp0 = ___action184(
 text,
 &___start0,
@@ -25571,6 +26090,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action522<
     'input,
 >(
@@ -25584,8 +26104,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.0.clone();
-let ___end0 = ___3.2.clone();
+let ___start0 = ___3.0;
+let ___end0 = ___3.2;
 let ___temp0 = ___action183(
 text,
 ___3,
@@ -25604,6 +26124,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action523<
     'input,
 >(
@@ -25616,8 +26137,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___3.0.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___3.0;
 let ___temp0 = ___action184(
 text,
 &___start0,
@@ -25637,6 +26158,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action524<
     'input,
 >(
@@ -25651,8 +26173,8 @@ ___6: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
 ___7: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action183(
 text,
 ___4,
@@ -25672,6 +26194,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action525<
     'input,
 >(
@@ -25685,8 +26208,8 @@ ___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.2.clone();
-let ___end0 = ___4.0.clone();
+let ___start0 = ___3.2;
+let ___end0 = ___4.0;
 let ___temp0 = ___action184(
 text,
 &___start0,
@@ -25707,6 +26230,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action526<
     'input,
 >(
@@ -25720,8 +26244,8 @@ ___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action183(
 text,
 ___4,
@@ -25740,6 +26264,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action527<
     'input,
 >(
@@ -25752,8 +26277,8 @@ ___4: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.2.clone();
-let ___end0 = ___4.0.clone();
+let ___start0 = ___3.2;
+let ___end0 = ___4.0;
 let ___temp0 = ___action184(
 text,
 &___start0,
@@ -25773,6 +26298,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action528<
     'input,
 >(
@@ -25788,8 +26314,8 @@ ___7: (usize, Tok<'input>, usize),
 ___8: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action183(
 text,
 ___4,
@@ -25810,6 +26336,7 @@ ___8,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action529<
     'input,
 >(
@@ -25824,8 +26351,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.2.clone();
-let ___end0 = ___4.0.clone();
+let ___start0 = ___3.2;
+let ___end0 = ___4.0;
 let ___temp0 = ___action184(
 text,
 &___start0,
@@ -25847,6 +26374,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action530<
     'input,
 >(
@@ -25861,8 +26389,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action183(
 text,
 ___4,
@@ -25882,6 +26410,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action531<
     'input,
 >(
@@ -25895,8 +26424,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.2.clone();
-let ___end0 = ___4.0.clone();
+let ___start0 = ___3.2;
+let ___end0 = ___4.0;
 let ___temp0 = ___action184(
 text,
 &___start0,
@@ -25917,6 +26446,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action532<
     'input,
 >(
@@ -25924,8 +26454,8 @@ text: &'input str,
 ___0: (usize, WhereClause<TypeRef>, usize),
 ) -> Vec<WhereClause<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action206(
 text,
 ___0,
@@ -25938,6 +26468,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action533<
     'input,
 >(
@@ -25946,8 +26477,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Vec<WhereClause<TypeRef>>
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action207(
 text,
 &___start0,
@@ -25961,6 +26492,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action534<
     'input,
 >(
@@ -25969,8 +26501,8 @@ ___0: (usize, alloc::vec::Vec<WhereClause<TypeRef>>, usize),
 ___1: (usize, WhereClause<TypeRef>, usize),
 ) -> Vec<WhereClause<TypeRef>>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action206(
 text,
 ___1,
@@ -25984,6 +26516,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action535<
     'input,
 >(
@@ -25991,8 +26524,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<WhereClause<TypeRef>>, usize),
 ) -> Vec<WhereClause<TypeRef>>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action207(
 text,
 &___start0,
@@ -26007,6 +26540,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action536<
     'input,
 >(
@@ -26020,8 +26554,8 @@ ___5: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___5.0.clone();
-let ___end0 = ___5.2.clone();
+let ___start0 = ___5.0;
+let ___end0 = ___5.2;
 let ___temp0 = ___action179(
 text,
 ___5,
@@ -26040,6 +26574,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action537<
     'input,
 >(
@@ -26052,8 +26587,8 @@ ___4: (usize, Vec<Parameter>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.2.clone();
-let ___end0 = ___5.0.clone();
+let ___start0 = ___4.2;
+let ___end0 = ___5.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -26073,6 +26608,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action538<
     'input,
 >(
@@ -26085,8 +26621,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action179(
 text,
 ___4,
@@ -26104,6 +26640,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action539<
     'input,
 >(
@@ -26115,8 +26652,8 @@ ___3: (usize, Vec<Parameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.2.clone();
-let ___end0 = ___4.0.clone();
+let ___start0 = ___3.2;
+let ___end0 = ___4.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -26135,6 +26672,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action540<
     'input,
 >(
@@ -26147,8 +26685,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action179(
 text,
 ___4,
@@ -26166,6 +26704,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action541<
     'input,
 >(
@@ -26177,8 +26716,8 @@ ___3: (usize, Vec<TypeParameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.2.clone();
-let ___end0 = ___4.0.clone();
+let ___start0 = ___3.2;
+let ___end0 = ___4.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -26197,6 +26736,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action542<
     'input,
 >(
@@ -26208,8 +26748,8 @@ ___3: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.0.clone();
-let ___end0 = ___3.2.clone();
+let ___start0 = ___3.0;
+let ___end0 = ___3.2;
 let ___temp0 = ___action179(
 text,
 ___3,
@@ -26226,6 +26766,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action543<
     'input,
 >(
@@ -26236,8 +26777,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___3.0.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___3.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -26255,6 +26796,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action544<
     'input,
 >(
@@ -26269,8 +26811,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___5.0.clone();
-let ___end0 = ___5.2.clone();
+let ___start0 = ___5.0;
+let ___end0 = ___5.2;
 let ___temp0 = ___action179(
 text,
 ___5,
@@ -26290,6 +26832,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action545<
     'input,
 >(
@@ -26303,8 +26846,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.2.clone();
-let ___end0 = ___5.0.clone();
+let ___start0 = ___4.2;
+let ___end0 = ___5.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -26325,6 +26868,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action546<
     'input,
 >(
@@ -26338,8 +26882,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action179(
 text,
 ___4,
@@ -26358,6 +26902,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action547<
     'input,
 >(
@@ -26370,8 +26915,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.2.clone();
-let ___end0 = ___4.0.clone();
+let ___start0 = ___3.2;
+let ___end0 = ___4.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -26391,6 +26936,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action548<
     'input,
 >(
@@ -26404,8 +26950,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action179(
 text,
 ___4,
@@ -26424,6 +26970,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action549<
     'input,
 >(
@@ -26436,8 +26983,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.2.clone();
-let ___end0 = ___4.0.clone();
+let ___start0 = ___3.2;
+let ___end0 = ___4.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -26457,6 +27004,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action550<
     'input,
 >(
@@ -26469,8 +27017,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.0.clone();
-let ___end0 = ___3.2.clone();
+let ___start0 = ___3.0;
+let ___end0 = ___3.2;
 let ___temp0 = ___action179(
 text,
 ___3,
@@ -26488,6 +27036,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action551<
     'input,
 >(
@@ -26499,8 +27048,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___2.2.clone();
-let ___end0 = ___3.0.clone();
+let ___start0 = ___2.2;
+let ___end0 = ___3.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -26519,6 +27068,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action552<
     'input,
 >(
@@ -26533,8 +27083,8 @@ ___6: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___7: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___6.0.clone();
-let ___end0 = ___6.2.clone();
+let ___start0 = ___6.0;
+let ___end0 = ___6.2;
 let ___temp0 = ___action179(
 text,
 ___6,
@@ -26554,6 +27104,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action553<
     'input,
 >(
@@ -26567,8 +27118,8 @@ ___5: (usize, Vec<Parameter>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___5.2.clone();
-let ___end0 = ___6.0.clone();
+let ___start0 = ___5.2;
+let ___end0 = ___6.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -26589,6 +27140,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action554<
     'input,
 >(
@@ -26602,8 +27154,8 @@ ___5: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___5.0.clone();
-let ___end0 = ___5.2.clone();
+let ___start0 = ___5.0;
+let ___end0 = ___5.2;
 let ___temp0 = ___action179(
 text,
 ___5,
@@ -26622,6 +27174,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action555<
     'input,
 >(
@@ -26634,8 +27187,8 @@ ___4: (usize, Vec<Parameter>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.2.clone();
-let ___end0 = ___5.0.clone();
+let ___start0 = ___4.2;
+let ___end0 = ___5.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -26655,6 +27208,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action556<
     'input,
 >(
@@ -26668,8 +27222,8 @@ ___5: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___5.0.clone();
-let ___end0 = ___5.2.clone();
+let ___start0 = ___5.0;
+let ___end0 = ___5.2;
 let ___temp0 = ___action179(
 text,
 ___5,
@@ -26688,6 +27242,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action557<
     'input,
 >(
@@ -26700,8 +27255,8 @@ ___4: (usize, Vec<TypeParameter>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.2.clone();
-let ___end0 = ___5.0.clone();
+let ___start0 = ___4.2;
+let ___end0 = ___5.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -26721,6 +27276,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action558<
     'input,
 >(
@@ -26733,8 +27289,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action179(
 text,
 ___4,
@@ -26752,6 +27308,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action559<
     'input,
 >(
@@ -26763,8 +27320,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.2.clone();
-let ___end0 = ___4.0.clone();
+let ___start0 = ___3.2;
+let ___end0 = ___4.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -26783,6 +27340,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action560<
     'input,
 >(
@@ -26798,8 +27356,8 @@ ___7: (usize, Tok<'input>, usize),
 ___8: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___6.0.clone();
-let ___end0 = ___6.2.clone();
+let ___start0 = ___6.0;
+let ___end0 = ___6.2;
 let ___temp0 = ___action179(
 text,
 ___6,
@@ -26820,6 +27378,7 @@ ___8,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action561<
     'input,
 >(
@@ -26834,8 +27393,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___5.2.clone();
-let ___end0 = ___6.0.clone();
+let ___start0 = ___5.2;
+let ___end0 = ___6.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -26857,6 +27416,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action562<
     'input,
 >(
@@ -26871,8 +27431,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___5.0.clone();
-let ___end0 = ___5.2.clone();
+let ___start0 = ___5.0;
+let ___end0 = ___5.2;
 let ___temp0 = ___action179(
 text,
 ___5,
@@ -26892,6 +27452,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action563<
     'input,
 >(
@@ -26905,8 +27466,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.2.clone();
-let ___end0 = ___5.0.clone();
+let ___start0 = ___4.2;
+let ___end0 = ___5.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -26927,6 +27488,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action564<
     'input,
 >(
@@ -26941,8 +27503,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___5.0.clone();
-let ___end0 = ___5.2.clone();
+let ___start0 = ___5.0;
+let ___end0 = ___5.2;
 let ___temp0 = ___action179(
 text,
 ___5,
@@ -26962,6 +27524,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action565<
     'input,
 >(
@@ -26975,8 +27538,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.2.clone();
-let ___end0 = ___5.0.clone();
+let ___start0 = ___4.2;
+let ___end0 = ___5.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -26997,6 +27560,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action566<
     'input,
 >(
@@ -27010,8 +27574,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___4.0.clone();
-let ___end0 = ___4.2.clone();
+let ___start0 = ___4.0;
+let ___end0 = ___4.2;
 let ___temp0 = ___action179(
 text,
 ___4,
@@ -27030,6 +27594,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action567<
     'input,
 >(
@@ -27042,8 +27607,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___3.2.clone();
-let ___end0 = ___4.0.clone();
+let ___start0 = ___3.2;
+let ___end0 = ___4.0;
 let ___temp0 = ___action180(
 text,
 &___start0,
@@ -27063,6 +27628,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action568<
     'input,
 >(
@@ -27070,8 +27636,8 @@ text: &'input str,
 ___0: (usize, Lifetime, usize),
 ) -> Vec<Lifetime>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action140(
 text,
 ___0,
@@ -27084,6 +27650,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action569<
     'input,
 >(
@@ -27092,8 +27659,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Vec<Lifetime>
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action141(
 text,
 &___start0,
@@ -27107,6 +27674,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action570<
     'input,
 >(
@@ -27115,8 +27683,8 @@ ___0: (usize, alloc::vec::Vec<Lifetime>, usize),
 ___1: (usize, Lifetime, usize),
 ) -> Vec<Lifetime>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action140(
 text,
 ___1,
@@ -27130,6 +27698,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action571<
     'input,
 >(
@@ -27137,8 +27706,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<Lifetime>, usize),
 ) -> Vec<Lifetime>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action141(
 text,
 &___start0,
@@ -27153,6 +27722,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action572<
     'input,
 >(
@@ -27163,8 +27733,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, TypeRef, usize),
 ) -> TypeRef
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action140(
 text,
 ___1,
@@ -27180,6 +27750,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action573<
     'input,
 >(
@@ -27189,8 +27760,8 @@ ___1: (usize, Tok<'input>, usize),
 ___2: (usize, TypeRef, usize),
 ) -> TypeRef
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action141(
 text,
 &___start0,
@@ -27207,6 +27778,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action574<
     'input,
 >(
@@ -27216,8 +27788,8 @@ ___1: (usize, Lifetime, usize),
 ___2: (usize, TypeRef, usize),
 ) -> TypeRef
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action140(
 text,
 ___1,
@@ -27232,6 +27804,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action575<
     'input,
 >(
@@ -27240,8 +27813,8 @@ ___0: (usize, Tok<'input>, usize),
 ___1: (usize, TypeRef, usize),
 ) -> TypeRef
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action141(
 text,
 &___start0,
@@ -27257,6 +27830,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action576<
     'input,
 >(
@@ -27264,8 +27838,8 @@ text: &'input str,
 ___0: (usize, MatchItem, usize),
 ) -> Vec<MatchItem>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action258(
 text,
 ___0,
@@ -27278,6 +27852,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action577<
     'input,
 >(
@@ -27286,8 +27861,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Vec<MatchItem>
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action259(
 text,
 &___start0,
@@ -27301,6 +27876,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action578<
     'input,
 >(
@@ -27309,8 +27885,8 @@ ___0: (usize, alloc::vec::Vec<MatchItem>, usize),
 ___1: (usize, MatchItem, usize),
 ) -> Vec<MatchItem>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action258(
 text,
 ___1,
@@ -27324,6 +27900,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action579<
     'input,
 >(
@@ -27331,8 +27908,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<MatchItem>, usize),
 ) -> Vec<MatchItem>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action259(
 text,
 &___start0,
@@ -27347,6 +27924,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action580<
     'input,
 >(
@@ -27354,8 +27932,8 @@ text: &'input str,
 ___0: (usize, NonterminalString, usize),
 ) -> Vec<NonterminalString>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action234(
 text,
 ___0,
@@ -27368,6 +27946,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action581<
     'input,
 >(
@@ -27376,8 +27955,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Vec<NonterminalString>
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action235(
 text,
 &___start0,
@@ -27391,6 +27970,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action582<
     'input,
 >(
@@ -27399,8 +27979,8 @@ ___0: (usize, alloc::vec::Vec<NonterminalString>, usize),
 ___1: (usize, NonterminalString, usize),
 ) -> Vec<NonterminalString>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action234(
 text,
 ___1,
@@ -27414,6 +27994,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action583<
     'input,
 >(
@@ -27421,8 +28002,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<NonterminalString>, usize),
 ) -> Vec<NonterminalString>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action235(
 text,
 &___start0,
@@ -27437,6 +28018,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action584<
     'input,
 >(
@@ -27444,8 +28026,8 @@ text: &'input str,
 ___0: (usize, Pattern<TypeRef>, usize),
 ) -> Vec<Pattern<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action268(
 text,
 ___0,
@@ -27458,6 +28040,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action585<
     'input,
 >(
@@ -27466,8 +28049,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Vec<Pattern<TypeRef>>
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action269(
 text,
 &___start0,
@@ -27481,6 +28064,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action586<
     'input,
 >(
@@ -27489,8 +28073,8 @@ ___0: (usize, alloc::vec::Vec<Pattern<TypeRef>>, usize),
 ___1: (usize, Pattern<TypeRef>, usize),
 ) -> Vec<Pattern<TypeRef>>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action268(
 text,
 ___1,
@@ -27504,6 +28088,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action587<
     'input,
 >(
@@ -27511,8 +28096,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<Pattern<TypeRef>>, usize),
 ) -> Vec<Pattern<TypeRef>>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action269(
 text,
 &___start0,
@@ -27527,6 +28112,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action588<
     'input,
 >(
@@ -27539,8 +28125,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -27560,6 +28146,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action589<
     'input,
 >(
@@ -27573,8 +28160,8 @@ ___5: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -27593,6 +28180,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action590<
     'input,
 >(
@@ -27604,8 +28192,8 @@ ___3: (usize, Vec<Parameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -27624,6 +28212,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action591<
     'input,
 >(
@@ -27636,8 +28225,8 @@ ___4: (usize, Vec<Parameter>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -27655,6 +28244,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action592<
     'input,
 >(
@@ -27666,8 +28256,8 @@ ___3: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -27686,6 +28276,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action593<
     'input,
 >(
@@ -27698,8 +28289,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -27717,6 +28308,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action594<
     'input,
 >(
@@ -27727,8 +28319,8 @@ ___2: (usize, Vec<Parameter>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -27746,6 +28338,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action595<
     'input,
 >(
@@ -27757,8 +28350,8 @@ ___3: (usize, Vec<Parameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -27775,6 +28368,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action596<
     'input,
 >(
@@ -27786,8 +28380,8 @@ ___3: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -27806,6 +28400,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action597<
     'input,
 >(
@@ -27818,8 +28413,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -27837,6 +28432,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action598<
     'input,
 >(
@@ -27847,8 +28443,8 @@ ___2: (usize, Vec<TypeParameter>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -27866,6 +28462,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action599<
     'input,
 >(
@@ -27877,8 +28474,8 @@ ___3: (usize, Vec<TypeParameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -27895,6 +28492,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action600<
     'input,
 >(
@@ -27905,8 +28503,8 @@ ___2: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -27924,6 +28522,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action601<
     'input,
 >(
@@ -27935,8 +28534,8 @@ ___3: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -27953,6 +28552,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action602<
     'input,
 >(
@@ -27962,8 +28562,8 @@ ___1: (usize, Tok<'input>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -27980,6 +28580,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action603<
     'input,
 >(
@@ -27990,8 +28591,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28007,6 +28608,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action604<
     'input,
 >(
@@ -28020,8 +28622,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -28042,6 +28644,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action605<
     'input,
 >(
@@ -28056,8 +28659,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28077,6 +28680,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action606<
     'input,
 >(
@@ -28089,8 +28693,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -28110,6 +28714,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action607<
     'input,
 >(
@@ -28123,8 +28728,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28143,6 +28748,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action608<
     'input,
 >(
@@ -28155,8 +28761,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -28176,6 +28782,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action609<
     'input,
 >(
@@ -28189,8 +28796,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28209,6 +28816,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action610<
     'input,
 >(
@@ -28220,8 +28828,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -28240,6 +28848,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action611<
     'input,
 >(
@@ -28252,8 +28861,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28271,6 +28880,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action612<
     'input,
 >(
@@ -28283,8 +28893,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -28304,6 +28914,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action613<
     'input,
 >(
@@ -28317,8 +28928,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28337,6 +28948,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action614<
     'input,
 >(
@@ -28348,8 +28960,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -28368,6 +28980,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action615<
     'input,
 >(
@@ -28380,8 +28993,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28399,6 +29012,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action616<
     'input,
 >(
@@ -28410,8 +29024,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -28430,6 +29044,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action617<
     'input,
 >(
@@ -28442,8 +29057,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28461,6 +29076,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action618<
     'input,
 >(
@@ -28471,8 +29087,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -28490,6 +29106,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action619<
     'input,
 >(
@@ -28501,8 +29118,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28519,6 +29136,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action620<
     'input,
 >(
@@ -28532,8 +29150,8 @@ ___5: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -28554,6 +29172,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action621<
     'input,
 >(
@@ -28568,8 +29187,8 @@ ___6: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___7: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28589,6 +29208,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action622<
     'input,
 >(
@@ -28601,8 +29221,8 @@ ___4: (usize, Vec<Parameter>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -28622,6 +29242,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action623<
     'input,
 >(
@@ -28635,8 +29256,8 @@ ___5: (usize, Vec<Parameter>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28655,6 +29276,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action624<
     'input,
 >(
@@ -28667,8 +29289,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -28688,6 +29310,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action625<
     'input,
 >(
@@ -28701,8 +29324,8 @@ ___5: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28721,6 +29344,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action626<
     'input,
 >(
@@ -28732,8 +29356,8 @@ ___3: (usize, Vec<Parameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -28752,6 +29376,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action627<
     'input,
 >(
@@ -28764,8 +29389,8 @@ ___4: (usize, Vec<Parameter>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28783,6 +29408,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action628<
     'input,
 >(
@@ -28795,8 +29421,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -28816,6 +29442,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action629<
     'input,
 >(
@@ -28829,8 +29456,8 @@ ___5: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28849,6 +29476,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action630<
     'input,
 >(
@@ -28860,8 +29488,8 @@ ___3: (usize, Vec<TypeParameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -28880,6 +29508,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action631<
     'input,
 >(
@@ -28892,8 +29521,8 @@ ___4: (usize, Vec<TypeParameter>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28911,6 +29540,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action632<
     'input,
 >(
@@ -28922,8 +29552,8 @@ ___3: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -28942,6 +29572,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action633<
     'input,
 >(
@@ -28954,8 +29585,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -28973,6 +29604,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action634<
     'input,
 >(
@@ -28983,8 +29615,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -29002,6 +29634,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action635<
     'input,
 >(
@@ -29013,8 +29646,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -29031,6 +29664,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action636<
     'input,
 >(
@@ -29045,8 +29679,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -29068,6 +29702,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action637<
     'input,
 >(
@@ -29083,8 +29718,8 @@ ___7: (usize, Tok<'input>, usize),
 ___8: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -29105,6 +29740,7 @@ ___8,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action638<
     'input,
 >(
@@ -29118,8 +29754,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -29140,6 +29776,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action639<
     'input,
 >(
@@ -29154,8 +29791,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -29175,6 +29812,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action640<
     'input,
 >(
@@ -29188,8 +29826,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -29210,6 +29848,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action641<
     'input,
 >(
@@ -29224,8 +29863,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -29245,6 +29884,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action642<
     'input,
 >(
@@ -29257,8 +29897,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -29278,6 +29918,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action643<
     'input,
 >(
@@ -29291,8 +29932,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -29311,6 +29952,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action644<
     'input,
 >(
@@ -29324,8 +29966,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -29346,6 +29988,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action645<
     'input,
 >(
@@ -29360,8 +30003,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -29381,6 +30024,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action646<
     'input,
 >(
@@ -29393,8 +30037,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -29414,6 +30058,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action647<
     'input,
 >(
@@ -29427,8 +30072,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -29447,6 +30092,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action648<
     'input,
 >(
@@ -29459,8 +30105,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -29480,6 +30126,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action649<
     'input,
 >(
@@ -29493,8 +30140,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -29513,6 +30160,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action650<
     'input,
 >(
@@ -29524,8 +30172,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action191(
 text,
 &___start0,
@@ -29544,6 +30192,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action651<
     'input,
 >(
@@ -29556,8 +30205,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action192(
 text,
 ___0,
@@ -29575,6 +30224,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action652<
     'input,
 >(
@@ -29583,8 +30233,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> ExprSymbol
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action145(
 text,
 &___start0,
@@ -29598,6 +30248,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action653<
     'input,
 >(
@@ -29605,8 +30256,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<Symbol>, usize),
 ) -> ExprSymbol
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action146(
 text,
 ___0,
@@ -29619,6 +30270,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action654<
     'input,
 >(
@@ -29626,8 +30278,8 @@ text: &'input str,
 ___0: (usize, Symbol, usize),
 ) -> Vec<Symbol>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action244(
 text,
 ___0,
@@ -29640,6 +30292,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action655<
     'input,
 >(
@@ -29648,8 +30301,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Vec<Symbol>
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action245(
 text,
 &___start0,
@@ -29663,6 +30316,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action656<
     'input,
 >(
@@ -29671,8 +30325,8 @@ ___0: (usize, alloc::vec::Vec<Symbol>, usize),
 ___1: (usize, Symbol, usize),
 ) -> Vec<Symbol>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action244(
 text,
 ___1,
@@ -29686,6 +30340,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action657<
     'input,
 >(
@@ -29693,8 +30348,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<Symbol>, usize),
 ) -> Vec<Symbol>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action245(
 text,
 &___start0,
@@ -29709,6 +30364,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action658<
     'input,
 >(
@@ -29716,8 +30372,8 @@ text: &'input str,
 ___0: (usize, TypeBound<TypeRef>, usize),
 ) -> Vec<TypeBound<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action214(
 text,
 ___0,
@@ -29730,6 +30386,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action659<
     'input,
 >(
@@ -29738,8 +30395,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Vec<TypeBound<TypeRef>>
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action215(
 text,
 &___start0,
@@ -29753,6 +30410,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action660<
     'input,
 >(
@@ -29761,8 +30419,8 @@ ___0: (usize, alloc::vec::Vec<TypeBound<TypeRef>>, usize),
 ___1: (usize, TypeBound<TypeRef>, usize),
 ) -> Vec<TypeBound<TypeRef>>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action214(
 text,
 ___1,
@@ -29776,6 +30434,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action661<
     'input,
 >(
@@ -29783,8 +30442,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<TypeBound<TypeRef>>, usize),
 ) -> Vec<TypeBound<TypeRef>>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action215(
 text,
 &___start0,
@@ -29799,6 +30458,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action662<
     'input,
 >(
@@ -29806,8 +30466,8 @@ text: &'input str,
 ___0: (usize, TypeBoundParameter<TypeRef>, usize),
 ) -> Vec<TypeBoundParameter<TypeRef>>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action224(
 text,
 ___0,
@@ -29820,6 +30480,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action663<
     'input,
 >(
@@ -29828,8 +30489,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Vec<TypeBoundParameter<TypeRef>>
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action225(
 text,
 &___start0,
@@ -29843,6 +30504,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action664<
     'input,
 >(
@@ -29851,8 +30513,8 @@ ___0: (usize, alloc::vec::Vec<TypeBoundParameter<TypeRef>>, usize),
 ___1: (usize, TypeBoundParameter<TypeRef>, usize),
 ) -> Vec<TypeBoundParameter<TypeRef>>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action224(
 text,
 ___1,
@@ -29866,6 +30528,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action665<
     'input,
 >(
@@ -29873,8 +30536,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<TypeBoundParameter<TypeRef>>, usize),
 ) -> Vec<TypeBoundParameter<TypeRef>>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action225(
 text,
 &___start0,
@@ -29889,6 +30552,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action666<
     'input,
 >(
@@ -29896,8 +30560,8 @@ text: &'input str,
 ___0: (usize, TypeParameter, usize),
 ) -> Vec<TypeParameter>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action201(
 text,
 ___0,
@@ -29910,6 +30574,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action667<
     'input,
 >(
@@ -29918,8 +30583,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Vec<TypeParameter>
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action202(
 text,
 &___start0,
@@ -29933,6 +30598,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action668<
     'input,
 >(
@@ -29941,8 +30607,8 @@ ___0: (usize, alloc::vec::Vec<TypeParameter>, usize),
 ___1: (usize, TypeParameter, usize),
 ) -> Vec<TypeParameter>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action201(
 text,
 ___1,
@@ -29956,6 +30622,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action669<
     'input,
 >(
@@ -29963,8 +30630,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<TypeParameter>, usize),
 ) -> Vec<TypeParameter>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action202(
 text,
 &___start0,
@@ -29979,6 +30646,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action670<
     'input,
 >(
@@ -29986,8 +30654,8 @@ text: &'input str,
 ___0: (usize, TypeRef, usize),
 ) -> Vec<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action219(
 text,
 ___0,
@@ -30000,6 +30668,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action671<
     'input,
 >(
@@ -30008,8 +30677,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Vec<TypeRef>
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action220(
 text,
 &___start0,
@@ -30023,6 +30692,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action672<
     'input,
 >(
@@ -30031,8 +30701,8 @@ ___0: (usize, alloc::vec::Vec<TypeRef>, usize),
 ___1: (usize, TypeRef, usize),
 ) -> Vec<TypeRef>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action219(
 text,
 ___1,
@@ -30046,6 +30716,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action673<
     'input,
 >(
@@ -30053,8 +30724,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<TypeRef>, usize),
 ) -> Vec<TypeRef>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action220(
 text,
 &___start0,
@@ -30069,6 +30740,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action674<
     'input,
 >(
@@ -30076,8 +30748,8 @@ text: &'input str,
 ___0: (usize, TypeRef, usize),
 ) -> Vec<TypeRef>
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action249(
 text,
 ___0,
@@ -30090,6 +30762,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action675<
     'input,
 >(
@@ -30098,8 +30771,8 @@ ___lookbehind: &usize,
 ___lookahead: &usize,
 ) -> Vec<TypeRef>
 {
-let ___start0 = ___lookbehind.clone();
-let ___end0 = ___lookahead.clone();
+let ___start0 = *___lookbehind;
+let ___end0 = *___lookahead;
 let ___temp0 = ___action250(
 text,
 &___start0,
@@ -30113,6 +30786,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action676<
     'input,
 >(
@@ -30121,8 +30795,8 @@ ___0: (usize, alloc::vec::Vec<TypeRef>, usize),
 ___1: (usize, TypeRef, usize),
 ) -> Vec<TypeRef>
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action249(
 text,
 ___1,
@@ -30136,6 +30810,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action677<
     'input,
 >(
@@ -30143,8 +30818,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<TypeRef>, usize),
 ) -> Vec<TypeRef>
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___0.2;
 let ___temp0 = ___action250(
 text,
 &___start0,
@@ -30159,6 +30834,7 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action678<
     'input,
 >(
@@ -30170,8 +30846,8 @@ ___3: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -30190,6 +30866,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action679<
     'input,
 >(
@@ -30202,8 +30879,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -30221,6 +30898,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action680<
     'input,
 >(
@@ -30233,8 +30911,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -30254,6 +30932,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action681<
     'input,
 >(
@@ -30267,8 +30946,8 @@ ___5: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -30287,6 +30966,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action682<
     'input,
 >(
@@ -30297,8 +30977,8 @@ ___2: (usize, Vec<Parameter>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -30316,6 +30996,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action683<
     'input,
 >(
@@ -30327,8 +31008,8 @@ ___3: (usize, Vec<Parameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -30345,6 +31026,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action684<
     'input,
 >(
@@ -30356,8 +31038,8 @@ ___3: (usize, Vec<Parameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -30376,6 +31058,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action685<
     'input,
 >(
@@ -30388,8 +31071,8 @@ ___4: (usize, Vec<Parameter>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -30407,6 +31090,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action686<
     'input,
 >(
@@ -30417,8 +31101,8 @@ ___2: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -30436,6 +31120,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action687<
     'input,
 >(
@@ -30447,8 +31132,8 @@ ___3: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -30465,6 +31150,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action688<
     'input,
 >(
@@ -30476,8 +31162,8 @@ ___3: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -30496,6 +31182,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action689<
     'input,
 >(
@@ -30508,8 +31195,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -30527,6 +31214,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action690<
     'input,
 >(
@@ -30536,8 +31224,8 @@ ___1: (usize, Vec<Parameter>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -30554,6 +31242,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action691<
     'input,
 >(
@@ -30564,8 +31253,8 @@ ___2: (usize, Vec<Parameter>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -30581,6 +31270,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action692<
     'input,
 >(
@@ -30591,8 +31281,8 @@ ___2: (usize, Vec<Parameter>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -30610,6 +31300,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action693<
     'input,
 >(
@@ -30621,8 +31312,8 @@ ___3: (usize, Vec<Parameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -30639,6 +31330,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action694<
     'input,
 >(
@@ -30649,8 +31341,8 @@ ___2: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -30668,6 +31360,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action695<
     'input,
 >(
@@ -30679,8 +31372,8 @@ ___3: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -30697,6 +31390,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action696<
     'input,
 >(
@@ -30708,8 +31402,8 @@ ___3: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -30728,6 +31422,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action697<
     'input,
 >(
@@ -30740,8 +31435,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -30759,6 +31454,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action698<
     'input,
 >(
@@ -30768,8 +31464,8 @@ ___1: (usize, Vec<TypeParameter>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -30786,6 +31482,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action699<
     'input,
 >(
@@ -30796,8 +31493,8 @@ ___2: (usize, Vec<TypeParameter>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -30813,6 +31510,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action700<
     'input,
 >(
@@ -30823,8 +31521,8 @@ ___2: (usize, Vec<TypeParameter>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -30842,6 +31540,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action701<
     'input,
 >(
@@ -30853,8 +31552,8 @@ ___3: (usize, Vec<TypeParameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -30871,6 +31570,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action702<
     'input,
 >(
@@ -30880,8 +31580,8 @@ ___1: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -30898,6 +31598,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action703<
     'input,
 >(
@@ -30908,8 +31609,8 @@ ___2: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -30925,6 +31626,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action704<
     'input,
 >(
@@ -30935,8 +31637,8 @@ ___2: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -30954,6 +31656,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action705<
     'input,
 >(
@@ -30965,8 +31668,8 @@ ___3: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -30983,6 +31686,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action706<
     'input,
 >(
@@ -30991,8 +31695,8 @@ ___0: (usize, Tok<'input>, usize),
 ___1: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31008,6 +31712,7 @@ ___1,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action707<
     'input,
 >(
@@ -31017,8 +31722,8 @@ ___1: (usize, Tok<'input>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -31033,6 +31738,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action708<
     'input,
 >(
@@ -31042,8 +31748,8 @@ ___1: (usize, Tok<'input>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31060,6 +31766,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action709<
     'input,
 >(
@@ -31070,8 +31777,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -31087,6 +31794,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action710<
     'input,
 >(
@@ -31099,8 +31807,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31120,6 +31828,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action711<
     'input,
 >(
@@ -31133,8 +31842,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -31153,6 +31862,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action712<
     'input,
 >(
@@ -31166,8 +31876,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31188,6 +31898,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action713<
     'input,
 >(
@@ -31202,8 +31913,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -31223,6 +31934,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action714<
     'input,
 >(
@@ -31234,8 +31946,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31254,6 +31966,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action715<
     'input,
 >(
@@ -31266,8 +31979,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -31285,6 +31998,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action716<
     'input,
 >(
@@ -31297,8 +32011,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31318,6 +32032,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action717<
     'input,
 >(
@@ -31331,8 +32046,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -31351,6 +32066,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action718<
     'input,
 >(
@@ -31362,8 +32078,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31382,6 +32098,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action719<
     'input,
 >(
@@ -31394,8 +32111,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -31413,6 +32130,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action720<
     'input,
 >(
@@ -31425,8 +32143,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31446,6 +32164,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action721<
     'input,
 >(
@@ -31459,8 +32178,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -31479,6 +32198,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action722<
     'input,
 >(
@@ -31489,8 +32209,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31508,6 +32228,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action723<
     'input,
 >(
@@ -31519,8 +32240,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -31537,6 +32258,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action724<
     'input,
 >(
@@ -31548,8 +32270,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31568,6 +32290,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action725<
     'input,
 >(
@@ -31580,8 +32303,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -31599,6 +32322,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action726<
     'input,
 >(
@@ -31610,8 +32334,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31630,6 +32354,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action727<
     'input,
 >(
@@ -31642,8 +32367,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -31661,6 +32386,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action728<
     'input,
 >(
@@ -31673,8 +32399,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31694,6 +32420,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action729<
     'input,
 >(
@@ -31707,8 +32434,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -31727,6 +32454,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action730<
     'input,
 >(
@@ -31737,8 +32465,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31756,6 +32484,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action731<
     'input,
 >(
@@ -31767,8 +32496,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -31785,6 +32514,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action732<
     'input,
 >(
@@ -31796,8 +32526,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31816,6 +32546,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action733<
     'input,
 >(
@@ -31828,8 +32559,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -31847,6 +32578,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action734<
     'input,
 >(
@@ -31857,8 +32589,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31876,6 +32608,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action735<
     'input,
 >(
@@ -31887,8 +32620,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -31905,6 +32638,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action736<
     'input,
 >(
@@ -31916,8 +32650,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31936,6 +32670,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action737<
     'input,
 >(
@@ -31948,8 +32683,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -31967,6 +32702,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action738<
     'input,
 >(
@@ -31976,8 +32712,8 @@ ___1: (usize, Tok<'input>, usize),
 ___2: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -31994,6 +32730,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action739<
     'input,
 >(
@@ -32004,8 +32741,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -32021,6 +32758,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action740<
     'input,
 >(
@@ -32031,8 +32769,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32050,6 +32788,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action741<
     'input,
 >(
@@ -32061,8 +32800,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -32079,6 +32818,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action742<
     'input,
 >(
@@ -32091,8 +32831,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32112,6 +32852,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action743<
     'input,
 >(
@@ -32125,8 +32866,8 @@ ___5: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -32145,6 +32886,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action744<
     'input,
 >(
@@ -32158,8 +32900,8 @@ ___5: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32180,6 +32922,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action745<
     'input,
 >(
@@ -32194,8 +32937,8 @@ ___6: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___7: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -32215,6 +32958,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action746<
     'input,
 >(
@@ -32226,8 +32970,8 @@ ___3: (usize, Vec<Parameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32246,6 +32990,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action747<
     'input,
 >(
@@ -32258,8 +33003,8 @@ ___4: (usize, Vec<Parameter>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -32277,6 +33022,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action748<
     'input,
 >(
@@ -32289,8 +33035,8 @@ ___4: (usize, Vec<Parameter>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32310,6 +33056,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action749<
     'input,
 >(
@@ -32323,8 +33070,8 @@ ___5: (usize, Vec<Parameter>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -32343,6 +33090,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action750<
     'input,
 >(
@@ -32354,8 +33102,8 @@ ___3: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32374,6 +33122,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action751<
     'input,
 >(
@@ -32386,8 +33135,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -32405,6 +33154,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action752<
     'input,
 >(
@@ -32417,8 +33167,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32438,6 +33188,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action753<
     'input,
 >(
@@ -32451,8 +33202,8 @@ ___5: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -32471,6 +33222,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action754<
     'input,
 >(
@@ -32481,8 +33233,8 @@ ___2: (usize, Vec<Parameter>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32500,6 +33252,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action755<
     'input,
 >(
@@ -32511,8 +33264,8 @@ ___3: (usize, Vec<Parameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -32529,6 +33282,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action756<
     'input,
 >(
@@ -32540,8 +33294,8 @@ ___3: (usize, Vec<Parameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32560,6 +33314,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action757<
     'input,
 >(
@@ -32572,8 +33327,8 @@ ___4: (usize, Vec<Parameter>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -32591,6 +33346,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action758<
     'input,
 >(
@@ -32602,8 +33358,8 @@ ___3: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32622,6 +33378,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action759<
     'input,
 >(
@@ -32634,8 +33391,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -32653,6 +33410,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action760<
     'input,
 >(
@@ -32665,8 +33423,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32686,6 +33444,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action761<
     'input,
 >(
@@ -32699,8 +33458,8 @@ ___5: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -32719,6 +33478,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action762<
     'input,
 >(
@@ -32729,8 +33489,8 @@ ___2: (usize, Vec<TypeParameter>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32748,6 +33508,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action763<
     'input,
 >(
@@ -32759,8 +33520,8 @@ ___3: (usize, Vec<TypeParameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -32777,6 +33538,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action764<
     'input,
 >(
@@ -32788,8 +33550,8 @@ ___3: (usize, Vec<TypeParameter>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32808,6 +33570,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action765<
     'input,
 >(
@@ -32820,8 +33583,8 @@ ___4: (usize, Vec<TypeParameter>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -32839,6 +33602,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action766<
     'input,
 >(
@@ -32849,8 +33613,8 @@ ___2: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32868,6 +33632,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action767<
     'input,
 >(
@@ -32879,8 +33644,8 @@ ___3: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -32897,6 +33662,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action768<
     'input,
 >(
@@ -32908,8 +33674,8 @@ ___3: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32928,6 +33694,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action769<
     'input,
 >(
@@ -32940,8 +33707,8 @@ ___4: (usize, Vec<WhereClause<TypeRef>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -32959,6 +33726,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action770<
     'input,
 >(
@@ -32968,8 +33736,8 @@ ___1: (usize, Tok<'input>, usize),
 ___2: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -32986,6 +33754,7 @@ ___2,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action771<
     'input,
 >(
@@ -32996,8 +33765,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -33013,6 +33782,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action772<
     'input,
 >(
@@ -33023,8 +33793,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -33042,6 +33812,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action773<
     'input,
 >(
@@ -33053,8 +33824,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -33071,6 +33842,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action774<
     'input,
 >(
@@ -33084,8 +33856,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -33106,6 +33878,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action775<
     'input,
 >(
@@ -33120,8 +33893,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -33141,6 +33914,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action776<
     'input,
 >(
@@ -33155,8 +33929,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -33178,6 +33952,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action777<
     'input,
 >(
@@ -33193,8 +33968,8 @@ ___7: (usize, Tok<'input>, usize),
 ___8: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -33215,6 +33990,7 @@ ___8,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action778<
     'input,
 >(
@@ -33227,8 +34003,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -33248,6 +34024,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action779<
     'input,
 >(
@@ -33261,8 +34038,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -33281,6 +34058,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action780<
     'input,
 >(
@@ -33294,8 +34072,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -33316,6 +34094,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action781<
     'input,
 >(
@@ -33330,8 +34109,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -33351,6 +34130,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action782<
     'input,
 >(
@@ -33363,8 +34143,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -33384,6 +34164,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action783<
     'input,
 >(
@@ -33397,8 +34178,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -33417,6 +34198,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action784<
     'input,
 >(
@@ -33430,8 +34212,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -33452,6 +34234,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action785<
     'input,
 >(
@@ -33466,8 +34249,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -33487,6 +34270,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action786<
     'input,
 >(
@@ -33498,8 +34282,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -33518,6 +34302,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action787<
     'input,
 >(
@@ -33530,8 +34315,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -33549,6 +34334,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action788<
     'input,
 >(
@@ -33561,8 +34347,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -33582,6 +34368,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action789<
     'input,
 >(
@@ -33595,8 +34382,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -33615,6 +34402,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action790<
     'input,
 >(
@@ -33627,8 +34415,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -33648,6 +34436,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action791<
     'input,
 >(
@@ -33661,8 +34450,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -33681,6 +34470,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action792<
     'input,
 >(
@@ -33694,8 +34484,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -33716,6 +34506,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action793<
     'input,
 >(
@@ -33730,8 +34521,8 @@ ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -33751,6 +34542,7 @@ ___7,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action794<
     'input,
 >(
@@ -33762,8 +34554,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -33782,6 +34574,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action795<
     'input,
 >(
@@ -33794,8 +34587,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -33813,6 +34606,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action796<
     'input,
 >(
@@ -33825,8 +34619,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -33846,6 +34640,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action797<
     'input,
 >(
@@ -33859,8 +34654,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -33879,6 +34674,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action798<
     'input,
 >(
@@ -33890,8 +34686,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -33910,6 +34706,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action799<
     'input,
 >(
@@ -33922,8 +34719,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -33941,6 +34738,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action800<
     'input,
 >(
@@ -33953,8 +34751,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -33974,6 +34772,7 @@ ___5,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action801<
     'input,
 >(
@@ -33987,8 +34786,8 @@ ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -34007,6 +34806,7 @@ ___6,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action802<
     'input,
 >(
@@ -34017,8 +34817,8 @@ ___2: (usize, Tok<'input>, usize),
 ___3: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.0.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -34036,6 +34836,7 @@ ___3,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action803<
     'input,
 >(
@@ -34047,8 +34848,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.0.clone();
-let ___end0 = ___0.2.clone();
+let ___start0 = ___0.0;
+let ___end0 = ___0.2;
 let ___temp0 = ___action190(
 text,
 ___0,
@@ -34065,6 +34866,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action804<
     'input,
 >(
@@ -34076,8 +34878,8 @@ ___3: (usize, Tok<'input>, usize),
 ___4: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___0.2.clone();
-let ___end0 = ___1.0.clone();
+let ___start0 = ___0.2;
+let ___end0 = ___1.0;
 let ___temp0 = ___action189(
 text,
 &___start0,
@@ -34096,6 +34898,7 @@ ___4,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn ___action805<
     'input,
 >(
@@ -34108,8 +34911,8 @@ ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
 {
-let ___start0 = ___1.0.clone();
-let ___end0 = ___1.2.clone();
+let ___start0 = ___1.0;
+let ___end0 = ___1.2;
 let ___temp0 = ___action190(
 text,
 ___1,
@@ -34125,6 +34928,7 @@ ___4,
 ___5,
 )
 }
+#[allow(clippy::type_complexity)]
 
 pub trait ___ToTriple<'input, >
 {


### PR DESCRIPTION
This fixes two errors with the test cases.
First a compilation error:
```
error[E0308]: mismatched types
   --> lalrpop/src/main.rs:183:20
    |
183 |         parse_args(Arguments::from_vec(os_vec(args))).unwrap()
    |         ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&[&str]`, found `Arguments`
    |         |
    |         arguments to this function are incorrect
    |
note: function defined here
   --> lalrpop/src/main.rs:182:8
    |
182 |     fn parse_args(args: &[&str]) -> Args {
    |        ^^^^^^^^^^ -------------
```

And after I fixed that, I got a failing test case:
```
---- verify_lalrpop_generates_itself stdout ----
... more
thread 'verify_lalrpop_generates_itself' panicked at 'The snapshot does not match what lalrpop generates now.
Use ./snap.sh to generate a new snapshot of the lrgrammar', lalrpop-test/src/util/mod.rs:108:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    verify_lalrpop_generates_itself
```

This two errors are fixed by the two commits in this pull request.