### PR TITLE
Run cargo update before tests in CI

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -2,6 +2,7 @@ export RUST_BACKTRACE=1
 export CARGO_INCREMENTAL=0
 export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
+cargo update
 cargo build -p lalrpop
 cargo test --all --all-features
 # Check the documentation examples separately so that the `lexer` feature specified in tests do not


### PR DESCRIPTION
Lalrpop is usually used as a dependency of some other crate. In that situation, the Cargo.lock of lalrpop would not be used.

But tests run in CI do consider the existing Cargo.lock file and will therefore run the tests against older versions of its dependencies.

If there are new breakages causes by more recent versions of lalrpop's dependencies, the CI script would not flag them.

Therefore, I propose to add a call to `cargo update` at the beginning of tools/ci.sh.

It might be worthwhile to do both: First test against the versions in Cargo.lock, then run `cargo update`, and then re-run the tests. However, that would double the CI runtime, so I didn't do that in this PR.