### PR TITLE
Allow unused imports in nested test

### DIFF
--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -173,7 +173,12 @@ lalrpop_mod_test!(comments);
 
 lalrpop_mod_test!(sp_from_optional);
 
-lalrpop_mod_test!(nested);
+// The allow is to work around issue with imports used only in externs
+// https://github.com/lalrpop/lalrpop/issues/675
+lalrpop_mod_test!(
+    #[allow(unused_imports)]
+    nested
+);
 
 pub fn use_cfg_created_parser() {
     cfg::CreatedParser::new();


### PR DESCRIPTION
https://github.com/lalrpop/lalrpop/issues/675

Imports in extern blocks are only needed in modules, but lalrpop can't currently differentiate that to avoid importing them globally.  Use the workaround suggested in the above linked issue to silence the warning when running test cases