### PR TITLE
release 0.19.10 (take 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "calculator"
-version = "0.19.9"
+version = "0.19.10"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.9"
+version = "0.19.10"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-test"
-version = "0.19.9"
+version = "0.19.10"
 dependencies = [
  "diff",
  "lalrpop",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.9"
+version = "0.19.10"
 dependencies = [
  "regex",
 ]
@@ -483,7 +483,7 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "whitespace"
-version = "0.19.9"
+version = "0.19.10"
 dependencies = [
  "lalrpop",
  "lalrpop-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 repository = "https://github.com/lalrpop/lalrpop"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0 OR MIT"
-version = "0.19.9" # LALRPOP
+version = "0.19.10" # LALRPOP
 edition = "2021"
 
 [workspace.dependencies]

--- a/doc/calculator/Cargo.toml
+++ b/doc/calculator/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "calculator"
-version = "0.19.9"
+version = "0.19.10"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 build = "build.rs" # <-- We added this and everything after!
 workspace = "../.."
 edition = "2021"
 
 [build-dependencies.lalrpop]
-version = "0.19.9"
+version = "0.19.10"
 path = "../../lalrpop"
 features = ["lexer"]
 
@@ -15,5 +15,5 @@ features = ["lexer"]
 regex = "1"
 
 [dependencies.lalrpop-util]
-version = "0.19.9"
+version = "0.19.10"
 path = "../../lalrpop-util"

--- a/doc/pascal/lalrpop/Cargo.toml
+++ b/doc/pascal/lalrpop/Cargo.toml
@@ -14,5 +14,5 @@ regex = "1"
 pico-args = "0.5"
 
 [dependencies.lalrpop-util]
-version = "0.19.9"
+version = "0.19.10"
 path = "../../../lalrpop-util"

--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -18,12 +18,12 @@ build = "build.rs" # LALRPOP preprocessing
 # (If you write your own tokenizer, or already have the regex
 # crate, you can skip this dependency.)
 [dependencies]
-lalrpop-util = "0.19.9"
+lalrpop-util = "0.19.10"
 regex = "1"
 
 # Add a build-time dependency on the lalrpop library:
 [build-dependencies]
-lalrpop = "0.19.9"
+lalrpop = "0.19.10"
 # If you are supplying your own external lexer you can disable default features so that the
 # built-in lexer feature is not included
 # lalrpop = { version = "0.19.1", default-features = false }

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -30,10 +30,10 @@ version = "0.1.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 
 [build-dependencies] # <-- We added this and everything after!
-lalrpop = "0.19.9"
+lalrpop = "0.19.10"
 
 [dependencies]
-lalrpop-util = "0.19.9"
+lalrpop-util = "0.19.10"
 regex = "1"
 ```
 

--- a/doc/whitespace/Cargo.toml
+++ b/doc/whitespace/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "whitespace"
-version = "0.19.9"
+version = "0.19.10"
 authors = ["Mako <jlauve@rsmw.net>"]
 build = "build.rs"
 edition = "2021"
 
 [build-dependencies.lalrpop]
-version = "0.19.9"
+version = "0.19.10"
 path = "../../lalrpop"
 
 [dependencies.lalrpop-util]
-version = "0.19.9"
+version = "0.19.10"
 path = "../../lalrpop-util"

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -42,7 +42,7 @@ rand = "0.8"
 
 [dependencies.lalrpop-util]
 path = "../lalrpop-util"
-version = "0.19.9" # LALRPOP
+version = "0.19.10" # LALRPOP
 
 [features]
 default=["lexer", "pico-args"]

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -1,4 +1,4 @@
-// auto-generated: "lalrpop 0.19.9"
+// auto-generated: "lalrpop 0.19.10"
 // sha3: 41f98a6a8c1305d7ef67ac81e1eb4a8b9450d8a01a72a06b1fc8bb7900055a0b
 use string_cache::DefaultAtom as Atom;
 use crate::grammar::parse_tree::*;

--- a/version.sh
+++ b/version.sh
@@ -9,7 +9,7 @@ if [ "$1" == "" ]; then
 fi
 
 VERSION=$(
-    ls lalrpop*/Cargo.toml | \
+    ls Cargo.toml lalrpop*/Cargo.toml | \
         xargs grep "# LALRPOP" | \
         perl -p -e 's/.*version = "([0-9.]+)" # LALRPOP/$1/' |
         sort |
@@ -26,7 +26,7 @@ echo "Found consistent version $VERSION"
 clog --setversion $1
 
 perl -p -i -e 's/version *= *"[0-9.]+" # LALRPOP/version = "'$1'" # LALRPOP/' \
-     $(ls lalrpop*/Cargo.toml)
+     $(ls Cargo.toml lalrpop*/Cargo.toml)
 
 perl -p -i -e 's/version *= *"'$VERSION'"/version = "'$1'"/' \
      $(find doc -name Cargo.toml)


### PR DESCRIPTION
OK, in my previous PR I failed to update the version number, regenerate the snapshot, etc.

We need to document / streamline this release process.