### PR TITLE
Fix issue #775

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -225,7 +225,7 @@ dependencies = [
  "pico-args",
  "rand",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.6.29",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -396,13 +396,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -410,6 +410,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ edition = "2021"
 
 [workspace.dependencies]
 diff = { version = "0.1.12", default_features = false }
-regex = { version = "1", default_features = false }
-regex-syntax = { version = "0.6", default_features = false }
+regex = { version = "1.8", default_features = false, features = ["std"] }
+regex-syntax = { version = "0.6", default_features = false, features = ["unicode"] }

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -25,8 +25,8 @@ ena = { version = "0.14", default_features = false }
 is-terminal = "0.4.2"
 itertools = { version = "0.10", default_features = false, features = ["use_std"] }
 petgraph = { version = "0.6", default_features = false }
-regex = { workspace = true, features = ["std"] }
-regex-syntax = { workspace = true, features = ["unicode"] }
+regex = { workspace = true }
+regex-syntax = { workspace = true }
 string_cache = { version = "0.8", default_features = false }
 term = { version = "0.7", default_features = false }
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }


### PR DESCRIPTION
#775 has a good example of how to replicate this issue though I wasn't sure how to turn that into a test case.

I'm also trying to keep the feature sets for each dependency consistent. At the top level, we should also explicitly set the version of Regex to 1.8.

Personally, this aggressive use of `default_features = false` doesn't seem worth it but eh.