### PR TITLE
Upgrade regex-syntax to 0.7 #757

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ dependencies = [
  "pico-args",
  "rand",
  "regex",
- "regex-syntax 0.6.29",
+ "regex-syntax",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -430,14 +430,8 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
- "regex-syntax 0.7.1",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ rust-version = "1.64"
 [workspace.dependencies]
 diff = { version = "0.1.12", default_features = false }
 regex = { version = "1.8", default_features = false, features = ["std"] }
-regex-syntax = { version = "0.6", default_features = false }
+regex-syntax = { version = "0.7", default_features = false }

--- a/lalrpop/src/lexer/nfa/mod.rs
+++ b/lalrpop/src/lexer/nfa/mod.rs
@@ -225,28 +225,12 @@ impl Nfa {
         match expr.kind() {
             HirKind::Empty => Ok(accept),
 
-            HirKind::Literal(Literal(l)) => {
-                /* // [s0] -otherwise-> [accept]
-                Literal::Unicode(c) => {
-                    let s0 = self.new_state(StateKind::Neither);
-                    self.push_edge(s0, Test::char(c), accept);
-                    self.push_edge(s0, Other, reject);
-                    Ok(s0)
-                } */
-                //// Bytes are not supported
-
-                if l.len() == 1 {
-                    let s0 = self.new_state(StateKind::Neither);
-                    self.push_edge(s0, Test::byte(l[0]), accept);
-                    self.push_edge(s0, Other, reject);
-                    Ok(s0)
-                } else {
-                    let s0 = self.new_state(StateKind::Neither);
-                    self.push_edge(s0, Test::byte(*l.last().unwrap()), accept);
-                    self.push_edge(s0, Other, reject);
-                    self.expr(&Hir::literal(&l[..l.len() - 1]), s0, reject)
-                }
-            }
+            HirKind::Literal(Literal(l)) => Ok(l.iter().rev().fold(accept, |accept, &b| {
+                let s0 = self.new_state(StateKind::Neither);
+                self.push_edge(s0, Test::byte(b), accept);
+                self.push_edge(s0, Other, reject);
+                s0
+            })),
 
             HirKind::Class(ref class) => {
                 match *class {

--- a/lalrpop/src/lexer/nfa/mod.rs
+++ b/lalrpop/src/lexer/nfa/mod.rs
@@ -4,8 +4,7 @@
 
 use crate::lexer::re::Regex;
 use regex_syntax::hir::{
-    Anchor, Class, ClassBytesRange, ClassUnicodeRange, GroupKind, Hir, HirKind, Literal,
-    RepetitionKind, RepetitionRange,
+    Class, ClassBytesRange, ClassUnicodeRange, Hir, HirKind, Literal, Repetition,
 };
 use std::char;
 use std::fmt::{Debug, Error as FmtError, Formatter};
@@ -117,9 +116,7 @@ pub const START: NfaStateIndex = NfaStateIndex(2);
 pub enum NfaConstructionError {
     NamedCaptures,
     NonGreedy,
-    WordBoundary,
-    LineBoundary,
-    TextBoundary,
+    LookAround,
     ByteRegex,
 }
 
@@ -225,25 +222,29 @@ impl Nfa {
         accept: NfaStateIndex,
         reject: NfaStateIndex,
     ) -> Result<NfaStateIndex, NfaConstructionError> {
-        match *expr.kind() {
+        match expr.kind() {
             HirKind::Empty => Ok(accept),
 
-            HirKind::Literal(ref l) => {
-                match *l {
-                    // [s0] -otherwise-> [accept]
-                    Literal::Unicode(c) => {
-                        let s0 = self.new_state(StateKind::Neither);
-                        self.push_edge(s0, Test::char(c), accept);
-                        self.push_edge(s0, Other, reject);
-                        Ok(s0)
-                    }
-                    //// Bytes are not supported
-                    Literal::Byte(b) => {
-                        let s0 = self.new_state(StateKind::Neither);
-                        self.push_edge(s0, Test::byte(b), accept);
-                        self.push_edge(s0, Other, reject);
-                        Ok(s0)
-                    }
+            HirKind::Literal(Literal(l)) => {
+                /* // [s0] -otherwise-> [accept]
+                Literal::Unicode(c) => {
+                    let s0 = self.new_state(StateKind::Neither);
+                    self.push_edge(s0, Test::char(c), accept);
+                    self.push_edge(s0, Other, reject);
+                    Ok(s0)
+                } */
+                //// Bytes are not supported
+
+                if l.len() == 1 {
+                    let s0 = self.new_state(StateKind::Neither);
+                    self.push_edge(s0, Test::byte(l[0]), accept);
+                    self.push_edge(s0, Other, reject);
+                    Ok(s0)
+                } else {
+                    let s0 = self.new_state(StateKind::Neither);
+                    self.push_edge(s0, Test::byte(*l.last().unwrap()), accept);
+                    self.push_edge(s0, Other, reject);
+                    self.expr(&Hir::literal(&l[..l.len() - 1]), s0, reject)
                 }
             }
 
@@ -280,65 +281,61 @@ impl Nfa {
 
             // currently we don't support any boundaries because
             // I was too lazy to code them up or think about them
-            HirKind::WordBoundary(_) => Err(NfaConstructionError::WordBoundary),
-            HirKind::Anchor(ref a) => match a {
-                Anchor::StartLine | Anchor::EndLine => Err(NfaConstructionError::LineBoundary),
-                Anchor::StartText | Anchor::EndText => Err(NfaConstructionError::TextBoundary),
-            },
+            // Akin to anchors or wordboundaries
+            HirKind::Look(_) => Err(NfaConstructionError::LookAround),
 
-            // currently we treat all groups the same, whether they
+            // currently we treat all capture groups the same, whether they
             // capture or not; but we don't permit named groups,
             // in case we want to give them significance in the future
-            HirKind::Group(ref g) => match g.kind {
-                GroupKind::CaptureName { .. } => Err(NfaConstructionError::NamedCaptures),
-                GroupKind::CaptureIndex(_) | GroupKind::NonCapturing => {
-                    self.expr(&g.hir, accept, reject)
-                }
+            HirKind::Capture(c) => match c.name {
+                Some(_) => Err(NfaConstructionError::NamedCaptures),
+                None => self.expr(&c.sub, accept, reject),
             },
 
-            HirKind::Repetition(ref r) => {
-                if !r.greedy {
+            HirKind::Repetition(Repetition {
+                min,
+                max,
+                greedy,
+                sub,
+            }) => {
+                if !greedy {
                     // currently we always report the longest match possible
                     Err(NfaConstructionError::NonGreedy)
                 } else {
-                    match r.kind {
-                        RepetitionKind::ZeroOrOne => self.optional_expr(&r.hir, accept, reject),
-                        RepetitionKind::ZeroOrMore => self.star_expr(&r.hir, accept, reject),
-                        RepetitionKind::OneOrMore => self.plus_expr(&r.hir, accept, reject),
-                        RepetitionKind::Range(ref range) => {
-                            match *range {
-                                RepetitionRange::Exactly(c) => {
-                                    let mut s = accept;
-                                    for _ in 0..c {
-                                        s = self.expr(&r.hir, s, reject)?;
-                                    }
-                                    Ok(s)
-                                }
-                                RepetitionRange::AtLeast(min) => {
-                                    // +---min times----+
-                                    // |                |
-                                    //
-                                    // [s0] --..e..-- [s1] --..e*..--> [accept]
-                                    //          |      |
-                                    //          |      v
-                                    //          +-> [reject]
-                                    let mut s = self.star_expr(&r.hir, accept, reject)?;
-                                    for _ in 0..min {
-                                        s = self.expr(&r.hir, s, reject)?;
-                                    }
-                                    Ok(s)
-                                }
-                                RepetitionRange::Bounded(min, max) => {
-                                    let mut s = accept;
-                                    for _ in min..max {
-                                        s = self.optional_expr(&r.hir, s, reject)?;
-                                    }
-                                    for _ in 0..min {
-                                        s = self.expr(&r.hir, s, reject)?;
-                                    }
-                                    Ok(s)
-                                }
+                    match (min, max) {
+                        (0, Some(1)) => self.optional_expr(sub, accept, reject),
+                        (0, None) => self.star_expr(sub, accept, reject),
+                        (1, None) => self.plus_expr(sub, accept, reject),
+                        (_, Some(max)) if min == max => {
+                            let mut s = accept;
+                            for _ in 0..*max {
+                                s = self.expr(sub, s, reject)?;
                             }
+                            Ok(s)
+                        }
+                        (_, Some(max)) => {
+                            let mut s = accept;
+                            for _ in *min..*max {
+                                s = self.optional_expr(sub, s, reject)?;
+                            }
+                            for _ in 0..*min {
+                                s = self.expr(sub, s, reject)?;
+                            }
+                            Ok(s)
+                        }
+                        (_, None) => {
+                            // +---min times----+
+                            // |                |
+                            //
+                            // [s0] --..e..-- [s1] --..e*..--> [accept]
+                            //          |      |
+                            //          |      v
+                            //          +-> [reject]
+                            let mut s = self.star_expr(sub, accept, reject)?;
+                            for _ in 0..*min {
+                                s = self.expr(sub, s, reject)?;
+                            }
+                            Ok(s)
                         }
                     }
                 }

--- a/lalrpop/src/lexer/nfa/test.rs
+++ b/lalrpop/src/lexer/nfa/test.rs
@@ -114,13 +114,13 @@ fn line_boundaries() {
     let num = re::parse_regex(r#"^aBCdeF"#).unwrap();
     assert_eq!(
         Nfa::from_re(&num).unwrap_err(),
-        NfaConstructionError::TextBoundary
+        NfaConstructionError::LookAround
     );
 
     let num = re::parse_regex(r#"aBCdeF$"#).unwrap();
     assert_eq!(
         Nfa::from_re(&num).unwrap_err(),
-        NfaConstructionError::TextBoundary
+        NfaConstructionError::LookAround
     );
 }
 
@@ -129,13 +129,13 @@ fn text_boundaries() {
     let num = re::parse_regex(r#"(?m)^aBCdeF"#).unwrap();
     assert_eq!(
         Nfa::from_re(&num).unwrap_err(),
-        NfaConstructionError::LineBoundary
+        NfaConstructionError::LookAround
     );
 
     let num = re::parse_regex(r#"(?m)aBCdeF$"#).unwrap();
     assert_eq!(
         Nfa::from_re(&num).unwrap_err(),
-        NfaConstructionError::LineBoundary
+        NfaConstructionError::LookAround
     );
 }
 
@@ -144,13 +144,13 @@ fn word_boundaries() {
     let num = re::parse_regex(r#"\baBCdeF"#).unwrap();
     assert_eq!(
         Nfa::from_re(&num).unwrap_err(),
-        NfaConstructionError::WordBoundary
+        NfaConstructionError::LookAround
     );
 
     let num = re::parse_regex(r#"aBCdeF\B"#).unwrap();
     assert_eq!(
         Nfa::from_re(&num).unwrap_err(),
-        NfaConstructionError::WordBoundary
+        NfaConstructionError::LookAround
     );
 }
 

--- a/lalrpop/src/normalize/token_check/mod.rs
+++ b/lalrpop/src/normalize/token_check/mod.rs
@@ -351,9 +351,7 @@ fn construct(grammar: &mut Grammar, match_block: MatchBlock) -> NormResult<()> {
             let feature = match error {
                 NamedCaptures => r#"named captures (`(?P<foo>...)`)"#,
                 NonGreedy => r#""non-greedy" repetitions (`*?` or `+?`)"#,
-                WordBoundary => r#"word boundaries (`\b` or `\B`)"#,
-                LineBoundary => r#"line boundaries (`^` or `$`)"#,
-                TextBoundary => r#"text boundaries (`^` or `$`)"#,
+                LookAround => r#"All boundaries like `\b` or `\B` or `^` or `$`"#,
                 ByteRegex => r#"byte-based matches"#,
             };
             let literal = &match_entries[index.index()].match_literal;

--- a/lalrpop/src/normalize/token_check/mod.rs
+++ b/lalrpop/src/normalize/token_check/mod.rs
@@ -351,7 +351,7 @@ fn construct(grammar: &mut Grammar, match_block: MatchBlock) -> NormResult<()> {
             let feature = match error {
                 NamedCaptures => r#"named captures (`(?P<foo>...)`)"#,
                 NonGreedy => r#""non-greedy" repetitions (`*?` or `+?`)"#,
-                LookAround => r#"All boundaries like `\b` or `\B` or `^` or `$`"#,
+                LookAround => r#"all boundaries like `\b` or `\B` or `^` or `$`"#,
                 ByteRegex => r#"byte-based matches"#,
             };
             let literal = &match_entries[index.index()].match_literal;


### PR DESCRIPTION
Taking a crack at upgrading regex-syntax.

Some of the non-trivial changes that could use a second look are with the new handling of Literal and all of the Anchor/Boundary stuff being converted into this Look(with the corresponding change to the error handling).