### PR TITLE
Small Clippy nits

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,4 +42,4 @@ jobs:
       - name: Run rustfmt check
         run: cargo fmt --all -- --check
       - name: Run clippy
-        run: cargo clippy --all -- -D warnings
+        run: cargo clippy --all --all-targets -- -D warnings

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -152,7 +152,6 @@ lalrpop_mod_test!(error_issue_278);
 lalrpop_mod_test!(generics_issue_417);
 
 lalrpop_mod_test!(
-    #[deny(overflowing_literals)]
     #[allow(unused)]
     issue_394
 );
@@ -164,7 +163,6 @@ lalrpop_mod_test!(
 );
 
 lalrpop_mod_test!(
-    #[deny(bare_trait_objects)]
     #[allow(unused)]
     dyn_argument
 );

--- a/lalrpop-util/src/state_machine.rs
+++ b/lalrpop-util/src/state_machine.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use alloc::{string::String, vec, vec::Vec};
 use core::fmt::Debug;
 

--- a/lalrpop/src/normalize/inline/graph/mod.rs
+++ b/lalrpop/src/normalize/inline/graph/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::collections::{map, Map};
 use crate::grammar::consts::INLINE;
 use crate::grammar::repr::*;


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.
-->

Two `#[deny(...)]` attributes are for things that were promoted to deny over the edition boundary so these are no longer needed.

In two parts, there is an `#[allow(deadcode]` when there isn't anything unused. Probably best to remove these so new unused code isn't added.

In ci, `clippy` should be run with `--all-targets` to cover more of the repository.