### PR TITLE
Fix building issues when not all features are enabled at once.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           components: rustfmt
+      - name: Install cargo-hack
+        run: cargo install cargo-hack --locked
       - name: Run tests
         run: ./ci.sh
 

--- a/ci.sh
+++ b/ci.sh
@@ -1,7 +1,10 @@
+# Exis on error
+set -ex
+
 export RUST_BACKTRACE=1
 export CARGO_INCREMENTAL=0
-cargo build -p lalrpop
-cargo test --all --all-features
+cargo build --bin lalrpop --features pico-args
+cargo hack test --workspace --each-feature
 # Check the documentation examples separately so that the `lexer` feature specified in tests do not
 # leak into them
 cargo check -p calculator

--- a/lalrpop-test/src/cfg.lalrpop
+++ b/lalrpop-test/src/cfg.lalrpop
@@ -1,5 +1,8 @@
 grammar;
 
+pub AlwaysCreated: () = {
+};
+
 #[cfg(feature = "test-not-set")]
 pub NotCreated: () = {
 };

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -164,7 +164,9 @@ lalrpop_mod!(sp_from_optional);
 lalrpop_mod!(nested);
 
 pub fn use_cfg_created_parser() {
+    #[cfg(feature = "test-set")]
     cfg::CreatedParser::new();
+    cfg::AlwaysCreatedParser::new();
 }
 
 /// This constant is here so that some of the generator parsers can

--- a/lalrpop-util/Cargo.toml
+++ b/lalrpop-util/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 regex = { version = "1", optional = true }
 
 [features]
-lexer = ["regex"]
+lexer = ["regex/std", "std"]
 std = []
 default = ["std"]
 

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -197,6 +197,7 @@ macro_rules! lalrpop_mod {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{format, vec, string::ToString};
 
     #[test]
     fn test() {

--- a/lalrpop-util/src/state_machine.rs
+++ b/lalrpop-util/src/state_machine.rs
@@ -3,6 +3,7 @@
 use alloc::{string::String, vec, vec::Vec};
 use core::fmt::Debug;
 
+#[cfg(feature = "std")]
 const DEBUG_ENABLED: bool = false;
 
 macro_rules! debug {

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -30,10 +30,7 @@ term = { version = "0.7", default_features = false }
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 unicode-xid = { version = "0.2", default_features = false }
 
-# This dependency is only needed for binary builds, if you use LALRPOP as
-# library, disable it in your project by setting default_features = false.
 pico-args = { version = "0.4", default_features = false, optional = true }
-
 
 [dev-dependencies]
 regex = { version = "1", default-features = false, features = ["std", "unicode-case", "unicode-perl"] }

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -43,7 +43,7 @@ path = "../lalrpop-util"
 version = "0.19.9" # LALRPOP
 
 [features]
-default=["lexer", "pico-args"]
+default=["lexer"]
 
 # Feature used when developing LALRPOP. Tells the build script to use an existing lalrpop binary to
 # generate LALRPOPs own parser instead of using the saved parser.
@@ -53,3 +53,7 @@ lexer = ["lalrpop-util/lexer"]
 
 [package.metadata.docs.rs]
 features = ["lexer"]
+
+[[bin]]
+name = "lalrpop"
+required-features = ["pico-args"]

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -36,6 +36,8 @@ pico-args = { version = "0.4", default_features = false, optional = true }
 
 
 [dev-dependencies]
+regex = { version = "1", default-features = false, features = ["std", "unicode-case", "unicode-perl"] }
+regex-syntax = { version = "0.6", default-features = false, features = ["unicode-case", "unicode-perl"] }
 rand = "0.8"
 
 [dependencies.lalrpop-util]

--- a/lalrpop/src/normalize/token_check/mod.rs
+++ b/lalrpop/src/normalize/token_check/mod.rs
@@ -34,12 +34,6 @@ pub fn validate(mut grammar: Grammar) -> NormResult<Grammar> {
                     .collect(),
             }
         } else {
-            if cfg!(not(feature = "lexer")) {
-                return_err!(
-                    Span::default(),
-                    "The `lexer` feature must be specified unless an `extern` lexer is defined"
-                );
-            }
             TokenMode::Internal {
                 match_block: MatchBlock::new(grammar.match_token())?,
             }

--- a/lalrpop/src/test_util.rs
+++ b/lalrpop/src/test_util.rs
@@ -64,12 +64,12 @@ pub fn check_norm_err(expected_err: &str, span: &str, err: NormError) {
     let expected_err = Regex::new(expected_err).unwrap();
     let start_index = span.find('~').unwrap();
     let end_index = span.rfind('~').unwrap() + 1;
-    assert!(start_index <= end_index);
-    assert_eq!(err.span, pt::Span(start_index, end_index));
     assert!(
         expected_err.is_match(&err.message),
         "unexpected error text `{}`, which did not match regular expression `{}`",
         err.message,
         expected_err
     );
+    assert!(start_index <= end_index);
+    assert_eq!(err.span, pt::Span(start_index, end_index));
 }


### PR DESCRIPTION
The tests are currently run with all features enables which hides breakage when some are note defined.

This should help capture future issues.

**Note 1:** this PR removes a check in `normalize::token_check` that prevented most tests from running.
I am not sure about the extent of that change but all the tests now build & pass success-fully regardless of the enabled features.

**Note 2:** The subtlety of enabling the regex's and regex-syntax unicode feature for the specific needs of the grammar used, while totally sensible, is a bit unintuitive.
That's mostly because it is a transitive dependency and one does not expect it to break in such a way.
This might be worth stressing in the documentation.