### PR TITLE
Add a matrix to run all tests both with and without cargo update

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,9 @@ jobs:
           - nightly
         cargo-update:
           - true
-          - false
+        include:
+          - rust: stable
+            cargo-update: false
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,9 @@ jobs:
           - stable
           - beta
           - nightly
+        cargo-update:
+          - true
+          - false
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
@@ -31,6 +34,9 @@ jobs:
           components: rustfmt
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
+      - name: Update
+        if: matrix.cargo-update
+        run: cargo update
       - name: Run tests
         run: ./tools/ci.sh
   lint:


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

An alternative option to #755.  This pulls cargo update out of ci.sh into the test.yaml, and uses a matrix strategy to run all tests with both the existing Cargo.lock and cargo update run, for each toolchain version.