### PR TITLE
Move cargo hack to it's own workflow and cleanup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,6 +68,8 @@ jobs:
       - name: Update
         run: cargo update
       - run: cargo build --bin lalrpop --features pico-args
+      - name: Build feature powerset
+        run: cargo hack build --workspace --feature-powerset --exclude-features pico-args,default --optional-deps
       - name: Run feature powerset check
         # test with minimal amount of features plus a few extra on regex/regex-syntax
         run: cargo hack test --workspace --feature-powerset --exclude-features pico-args,default --optional-deps

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,9 +30,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          components: rustfmt
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
       - name: Update
         if: matrix.cargo-update
         run: cargo update
@@ -59,3 +56,18 @@ jobs:
           toolchain: nightly
       - name: Check the minimum possible crate versions
         run: rm Cargo.lock && cargo +nightly build -Zdirect-minimal-versions
+  feature_powerset:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+            toolchain: stable
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - name: Update
+        run: cargo update
+      - run: cargo build --bin lalrpop --features pico-args
+      - name: Run feature powerset check
+        # test with minimal amount of features plus a few extra on regex/regex-syntax
+        run: cargo hack test --workspace --feature-powerset --exclude-features pico-args --optional-deps

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,6 +58,8 @@ jobs:
         run: rm Cargo.lock && cargo +nightly build -Zdirect-minimal-versions
   feature_powerset:
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: 1
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
@@ -68,8 +70,6 @@ jobs:
       - name: Update
         run: cargo update
       - run: cargo build --bin lalrpop --features pico-args
-      - name: Build feature powerset
-        run: cargo hack build --workspace --feature-powerset --exclude-features pico-args,default --optional-deps
       - name: Run feature powerset check
         # test with minimal amount of features plus a few extra on regex/regex-syntax
         run: cargo hack test --workspace --feature-powerset --exclude-features pico-args,default --optional-deps

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,9 +7,6 @@ on:
     branches: ["master"]
   merge_group:
 
-env:
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-
 permissions:
   contents: read
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,4 +70,4 @@ jobs:
       - run: cargo build --bin lalrpop --features pico-args
       - name: Run feature powerset check
         # test with minimal amount of features plus a few extra on regex/regex-syntax
-        run: cargo hack test --workspace --feature-powerset --exclude-features pico-args --optional-deps
+        run: cargo hack test --workspace --feature-powerset --exclude-features pico-args,default --optional-deps

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -7,9 +7,9 @@ export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 cargo build --bin lalrpop --features pico-args
 # build with minimal amount of features to make sure dependencies can build too.
-cargo hack build --workspace --feature-powerset --optional-deps
+cargo hack build --workspace --feature-powerset --exclude-features pico-args --optional-deps
 # test with minimal amount of features plus a few extra on regex/regex-syntax
-cargo hack test --workspace --feature-powerset --optional-deps
+cargo hack test --workspace --feature-powerset --exclude-features pico-args --optional-deps
 # Check the documentation examples separately so that the `lexer` feature specified in tests do not
 # leak into them
 cargo check -p calculator

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -6,8 +6,7 @@ export CARGO_INCREMENTAL=0
 export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 cargo build --bin lalrpop --features pico-args
-# test with minimal amount of features plus a few extra on regex/regex-syntax
-cargo hack test --workspace --feature-powerset --exclude-features pico-args --optional-deps
+cargo test --workspace
 # Check the documentation examples separately so that the `lexer` feature specified in tests do not
 # leak into them
 cargo check -p calculator

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -6,8 +6,6 @@ export CARGO_INCREMENTAL=0
 export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 cargo build --bin lalrpop --features pico-args
-# build with minimal amount of features to make sure dependencies can build too.
-cargo hack build --workspace --feature-powerset --exclude-features pico-args --optional-deps
 # test with minimal amount of features plus a few extra on regex/regex-syntax
 cargo hack test --workspace --feature-powerset --exclude-features pico-args --optional-deps
 # Check the documentation examples separately so that the `lexer` feature specified in tests do not


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

With the addition of `cargo hack` into the `ci.sh` script, the github workflows run has significantly slowed down. This also makes it more inconvenient to add further things to the workflow like #790. I think the workflow should prioritize failing fast and speed.

To this end, I've moved the `cargo hack test` call out of the `ci.sh` script into it's own workflow. This invocation is a bit heavy weight to be the first thing a contributor runs and can be better parallelized on it's own. Maybe something like https://github.com/taiki-e/cargo-hack/pull/180.

Note I've ignore two features from the `cargo hack` invocation: `pico-args` and `default`. `pico-args` is only needed for the cli so it's unnecessary to include with the tests.`default` is excluded because it added an extra unnecessary dimension to the features being run(as all default does is enable other features, it is not used in the code itself). Add the `--print-command-list` flag to your cargo hack call to see all of the commands that will be run and with what features.