### PR TITLE
Release 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "calculator"
-version = "0.19.10"
+version = "0.20.0"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.10"
+version = "0.20.0"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-test"
-version = "0.19.10"
+version = "0.20.0"
 dependencies = [
  "diff",
  "lalrpop",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.10"
+version = "0.20.0"
 dependencies = [
  "regex",
 ]
@@ -561,7 +561,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "whitespace"
-version = "0.19.10"
+version = "0.20.0"
 dependencies = [
  "lalrpop",
  "lalrpop-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 repository = "https://github.com/lalrpop/lalrpop"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0 OR MIT"
-version = "0.19.10" # LALRPOP
+version = "0.20.0" # LALRPOP
 edition = "2021"
 # This is (very) soft limit of the minimum supported version.
 # Please update it when lalrpop requires a new feature.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,10 +1,35 @@
+<a name="0.20.0"></a>
+## 0.20.0 (2023-05-02)
+
+Bringing back 0.19.10 patches and further enhancement.
+
+#### Breaking changes
+
+* Types and enums name with capitalized acronyms are renamed to camelCase
+* Minimum rust supported version is now 1.64
+* New `unicode` feature is added to enable `regex/unicode` and `regex-syntax/unicode`. Building lalrpop with --no-default-features may be broken without adding it.
+
+#### Features
+
+* faster compilation time by up to 2x
+* expected tokens in failed parses are more accurate
+* support for unicode when using builtin tokenizer
+
+#### Bug fixes and other changes
+
+* fewer warnings about clippy/unused imports in generated code
+* updated to edition 2021
+* updated mdbook
+* Use inclusive ranges for DFA/NFA
+* A new document "Lexing raw delimited content"
+
 <a name="0.19.12"></a>
 ## 0.19.12 (2023-04-28)
 
 * Add `unicode` feature to `regex-syntax` (thanks to Jan Niehusmann!)
 
 #### Compatibility note
-This is actually not fixing a `lalrpop` bug but fixing user side bugs.
+This is actually not fixing a `lalrpop` bug but fixing user side missing dependency.
 `lalrpop` doesn't directly depend on the feature. But regex from user code probably contains it.
 We will drop this dependency again in the next release.
 

--- a/doc/calculator/Cargo.toml
+++ b/doc/calculator/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "calculator"
-version = "0.19.10"
+version = "0.20.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 build = "build.rs" # <-- We added this and everything after!
 workspace = "../.."
 edition = "2021"
 
 [build-dependencies]
-lalrpop = { version = "0.19.10", path = "../../lalrpop" }
+lalrpop = { version = "0.20.0", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.19.10", path = "../../lalrpop-util", features = ["lexer", "unicode"] }
+lalrpop-util = { version = "0.20.0", path = "../../lalrpop-util", features = ["lexer", "unicode"] }

--- a/doc/nobol/Cargo.toml
+++ b/doc/nobol/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs" # <-- We added this and everything after!
 workspace = "../.."
 
 [build-dependencies]
-lalrpop = { version = "0.19.7", path = "../../lalrpop" }
+lalrpop = { version = "0.20.0", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.19.7", path = "../../lalrpop-util", features = ["lexer", "unicode"] }
+lalrpop-util = { version = "0.20.0", path = "../../lalrpop-util", features = ["lexer", "unicode"] }

--- a/doc/pascal/lalrpop/Cargo.toml
+++ b/doc/pascal/lalrpop/Cargo.toml
@@ -6,12 +6,12 @@ build = "build.rs"
 edition = "2021"
 
 [build-dependencies]
-lalrpop = { version = "0.19.7", path = "../../../lalrpop" }
+lalrpop = { version = "0.20.0", path = "../../../lalrpop" }
 
 [dependencies]
 pico-args = "0.5"
 
 [dependencies.lalrpop-util]
-version = "0.19.10"
+version = "0.20.0"
 path = "../../../lalrpop-util"
 features = ["lexer"]

--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -13,11 +13,11 @@ build = "build.rs" # LALRPOP preprocessing
 
 # The generated code depends on lalrpop-util.
 [dependencies]
-lalrpop-util = "0.19.10"
+lalrpop-util = "0.20.0"
 
 # Add a build-time dependency on the lalrpop library:
 [build-dependencies]
-lalrpop = "0.19.10"
+lalrpop = "0.20.0"
 # If you are supplying your own external lexer you can disable default features so that the
 # built-in lexer feature is not included
 # lalrpop = { version = "0.19.1", default-features = false }

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -30,10 +30,10 @@ version = "0.1.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 
 [build-dependencies] # <-- We added this and everything after!
-lalrpop = "0.19.10"
+lalrpop = "0.20.0"
 
 [dependencies]
-lalrpop-util = "0.19.10"
+lalrpop-util = "0.20.0"
 ```
 
 Cargo can run [build scripts] as a pre-processing step,

--- a/doc/whitespace/Cargo.toml
+++ b/doc/whitespace/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "whitespace"
-version = "0.19.10"
+version = "0.20.0"
 authors = ["Mako <jlauve@rsmw.net>"]
 build = "build.rs"
 edition = "2021"
 
 [build-dependencies.lalrpop]
-version = "0.19.10"
+version = "0.20.0"
 path = "../../lalrpop"
 
 [dependencies.lalrpop-util]
-version = "0.19.10"
+version = "0.20.0"
 path = "../../lalrpop-util"

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -37,7 +37,7 @@ unicode-xid = { version = "0.2", default_features = false }
 # library, disable it in your project by setting default_features = false.
 pico-args = { version = "0.5", default_features = false, optional = true }
 
-lalrpop-util = { path = "../lalrpop-util", version = "0.19.10" }
+lalrpop-util = { path = "../lalrpop-util", version = "0.20.0" }
 
 [dev-dependencies]
 rand = "0.8"

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -1,4 +1,4 @@
-// auto-generated: "lalrpop 0.19.10"
+// auto-generated: "lalrpop 0.20.0"
 // sha3: 41f98a6a8c1305d7ef67ac81e1eb4a8b9450d8a01a72a06b1fc8bb7900055a0b
 use string_cache::DefaultAtom as Atom;
 use crate::grammar::parse_tree::*;


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

closes #778 