### PR TITLE
[RFC] Don't run feature-powerset test until after linting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,6 +58,8 @@ jobs:
         run: rm Cargo.lock && cargo +nightly build -Zdirect-minimal-versions
   feature_powerset:
     runs-on: ubuntu-latest
+    # Don't do expensive test if we're just going to fail on linting
+    needs: lint
     env:
       CARGO_INCREMENTAL: 1
     steps:


### PR DESCRIPTION
This is so that we don't waste resources on the heaviest test if we're just going to fail on format or similar.

It does lengthen the CI runtime by a little bit, but that's async anyways.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->