### PR TITLE
Remove some debugging statements

### DIFF
--- a/lalrpop-test/src/lexer_generic_lib.rs
+++ b/lalrpop-test/src/lexer_generic_lib.rs
@@ -77,8 +77,6 @@ impl<'i> Iterator for Lexer<'i> {
                 // SAFETY: the indices where returned by char_indices
                 let slice = unsafe { self.source.get_unchecked(start..end) };
 
-                eprintln!("{:?}", slice);
-
                 return if slice == "+" {
                     Some(Ok((start, Token::Plus, end)))
                 } else if slice.is_empty() {

--- a/lalrpop/src/lexer/dfa/overlap.rs
+++ b/lalrpop/src/lexer/dfa/overlap.rs
@@ -49,9 +49,6 @@ fn add_range(range: Test, start_index: usize, disjoint_ranges: &mut Vec<Test>) {
         return;
     }
 
-    dbg!(&range);
-    dbg!(&disjoint_ranges);
-
     // Find first overlapping range in `disjoint_ranges`, if any.
     match disjoint_ranges[start_index..]
         .iter()


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

I was poking around at the compile times and I realized there was an incredible amount of error printing going on. Seems like some debugging code got merged, whoops. Removing these saves at least a minute in `cargo hack test`.