### PR TITLE
Add deprecation notice for process_root_unconditionally

### DIFF
--- a/lalrpop/src/api/mod.rs
+++ b/lalrpop/src/api/mod.rs
@@ -253,6 +253,10 @@ pub fn process_root() -> Result<(), Box<dyn Error>> {
 /// Configuration::new().force_build(true).process_current_dir()
 /// ```
 ///
+#[deprecated(
+    since = "1.0.0",
+    note = "use `Configuration::new().force_build(true).process_current_dir()` instead"
+)]
 pub fn process_root_unconditionally() -> Result<(), Box<dyn Error>> {
     Configuration::new().force_build(true).process_current_dir()
 }

--- a/lalrpop/src/lib.rs
+++ b/lalrpop/src/lib.rs
@@ -56,6 +56,7 @@ mod generate;
 mod test_util;
 
 pub use crate::api::process_root;
+#[allow(deprecated)]
 pub use crate::api::process_root_unconditionally;
 pub use crate::api::Configuration;
 use ascii_canvas::style;


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

Given the comment on process_root_unconditionally, seems like there could be an additional annotation to help elevate this.