### PR TITLE
Fix dependency on is-terminal on specific version 0.4.7

### DIFF
--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -23,7 +23,7 @@ ascii-canvas = { version = "3.0", default_features = false }
 bit-set = { version = "0.5.2", default_features = false }
 diff = { workspace = true }
 ena = { version = "0.14", default_features = false }
-is-terminal = "0.4.2"
+is-terminal = "=0.4.7"
 itertools = { version = "0.10", default_features = false, features = ["use_std"] }
 petgraph = { version = "0.6", default_features = false }
 regex = { workspace = true }


### PR DESCRIPTION
With is-terminal 0.4.8, the MSRV was changed from 1.48 to 1.63. This implicitly affects the MSRV of lalrpop, breaking existing builds.

I think a MSRV change should be considered a breaking change according to semver rules. But even with a less strict interpretation of semver, it's probably a bad idea to change MSRV without a version update at all, breaking existing build setups.
(Example:
https://github.com/rp-rs/rp-hal/actions/runs/5458734797/jobs/9934102344?pr=642)

As is-terminal has a policy of changing MSRV in a minor release, and actively suggests to pin a specific version to avoid that, I think lalrpop should do that and use exactly version 0.4.7. (https://github.com/sunfishcode/is-terminal/blob/v0.4.7/README.md?plain=1#L97-L99)