### PR TITLE
patch #811

### DIFF
--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -378,7 +378,9 @@ impl<'grammar> Validator<'grammar> {
                 }
             }
             SymbolKind::Macro(ref msym) => {
-                debug_assert!(!msym.args.is_empty());
+                if msym.args.is_empty() {
+                    return_err!(symbol.span, "macros must have atleast one argument")
+                }
                 for arg in &msym.args {
                     self.validate_symbol(arg)?;
                 }

--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -379,7 +379,7 @@ impl<'grammar> Validator<'grammar> {
             }
             SymbolKind::Macro(ref msym) => {
                 if msym.args.is_empty() {
-                    return_err!(symbol.span, "macros must have atleast one argument")
+                    return_err!(symbol.span, "macros must have at least one argument")
                 }
                 for arg in &msym.args {
                     self.validate_symbol(arg)?;

--- a/lalrpop/src/normalize/prevalidate/test.rs
+++ b/lalrpop/src/normalize/prevalidate/test.rs
@@ -231,3 +231,12 @@ fn first_level_assoc() {
         r#"                                             ~~~~~~~~~~~~~~~~~~             "#,
     );
 }
+
+#[test]
+fn missing_macro_arg() {
+    check_err(
+        r#"macros must have at least one argument"#,
+        r#"grammar; Macro<Smth>: String = { Smth => <>.to_string() } pub Root: String = { Macro<>}"#,
+        r#"                                                                               ~~~~~~~"#,
+    )
+}


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

Convert trigger-able assertion to error. See https://github.com/lalrpop/lalrpop/issues/811

I'm not sure if there are tests for grammar files that are intended to error. Let me know if something like that should be added. 