### PR TITLE
Drop mention of adding regex dependencies from book.

### DIFF
--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -46,15 +46,7 @@ case, just LALRPOP.
 
 The `[dependencies]` section describes the dependencies that LALRPOP
 needs at runtime. All LALRPOP parsers require at least the
-`lalrpop-util` crate. In addition, if you don't want to write the
-lexer by hand, you need to add a dependency on the regex crate. (If
-you don't know what a lexer is, don't worry, it's not important just
-now, though we will cover it in [the next section]; if you *do*
-know what a lexer is, and you want to know how to write a lexer by
-hand and use it with LALRPOP, then check out the [lexer tutorial].)
-
-[the next section]: 002_paren_numbers.md
-[lexer tutorial]: ../lexer_tutorial/index.md
+`lalrpop-util` crate.
 
 Next we have to add `build.rs` itself. For those unfamiliar with [this feature], the `build.rs` file
 should be placed next to your `Cargo.toml` file and not inside the `src` folder with the rest of


### PR DESCRIPTION
The regex dependency is not and should not be a dependency of crates depending on lalrpop (unless they need regex directly).  This was presumably added to work around lalrpop's previous feature underspecification, but is no longer needed.  Using the built-in lexer works just fine with the normal dependencies, indirectly pulling lalrpop's regex dependency.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->