### PR TITLE
Modernize extern crate

### DIFF
--- a/doc/calculator/Cargo.toml
+++ b/doc/calculator/Cargo.toml
@@ -2,8 +2,7 @@
 name = "calculator"
 version = "0.20.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
-build = "build.rs" # <-- We added this and everything after!
-workspace = "../.."
+workspace = "../.." # <-- We added this and everything after!
 edition = "2021"
 
 [build-dependencies]

--- a/doc/calculator/build.rs
+++ b/doc/calculator/build.rs
@@ -1,5 +1,3 @@
-extern crate lalrpop;
-
 fn main() {
     lalrpop::process_root().unwrap();
 }

--- a/doc/nobol/Cargo.toml
+++ b/doc/nobol/Cargo.toml
@@ -3,8 +3,7 @@ name = "nobol"
 version = "0.1.0"
 edition = "2021"
 authors = ["Felix S Klock II <pnkfelix@pnkfx.org>"]
-build = "build.rs" # <-- We added this and everything after!
-workspace = "../.."
+workspace = "../.." # <-- We added this and everything after!
 
 [build-dependencies]
 lalrpop = { version = "0.20.0", path = "../../lalrpop" }

--- a/doc/nobol/build.rs
+++ b/doc/nobol/build.rs
@@ -1,5 +1,3 @@
-extern crate lalrpop;
-
 fn main() {
     lalrpop::process_root().unwrap();
 }

--- a/doc/nobol/src/main.rs
+++ b/doc/nobol/src/main.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
-#[macro_use]
-extern crate lalrpop_util;
+use lalrpop_util::lalrpop_mod;
 
 lalrpop_mod!(pub nobol1); // syntesized by LALRPOP
 

--- a/doc/pascal/lalrpop/Cargo.toml
+++ b/doc/pascal/lalrpop/Cargo.toml
@@ -2,7 +2,6 @@
 name = "pascal"
 version = "0.11.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
-build = "build.rs"
 edition = "2021"
 
 [build-dependencies]

--- a/doc/pascal/lalrpop/build.rs
+++ b/doc/pascal/lalrpop/build.rs
@@ -1,5 +1,3 @@
-extern crate lalrpop;
-
 fn main() {
     lalrpop::Configuration::new()
         .emit_comments(true)

--- a/doc/pascal/lalrpop/src/main.rs
+++ b/doc/pascal/lalrpop/src/main.rs
@@ -1,6 +1,4 @@
-#[macro_use]
-extern crate lalrpop_util;
-extern crate pico_args;
+use lalrpop_util::lalrpop_mod;
 
 use std::ffi::OsString;
 use std::fs::File;

--- a/doc/src/advanced_setup.md
+++ b/doc/src/advanced_setup.md
@@ -4,8 +4,6 @@ When you setup LALRPOP, you create a `build.rs` file that looks something
 like this:
 
 ```rust
-extern crate lalrpop;
-
 fn main() {
     lalrpop::process_root().unwrap();
 }
@@ -23,8 +21,6 @@ For example, to **force** the use of colors in the output (ignoring
 the TTY settings), you might make your `build.rs` file look like so:
 
 ```rust
-extern crate lalrpop;
-
 fn main() {
     lalrpop::Configuration::new()
         .always_use_colors()

--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -7,10 +7,6 @@ here is a quick 'cheat sheet' for setting up your project.  First, add
 the following lines to your `Cargo.toml`:
 
 ```toml
-[package]
-...
-build = "build.rs" # LALRPOP preprocessing
-
 # The generated code depends on lalrpop-util.
 [dependencies]
 lalrpop-util = "0.20.0"
@@ -27,8 +23,6 @@ Next create a [`build.rs`](https://doc.rust-lang.org/cargo/reference/build-scrip
 that looks like:
 
 ```rust
-extern crate lalrpop;
-
 fn main() {
     lalrpop::process_root().unwrap();
 }

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -63,8 +63,6 @@ your Rust code. This should just look like the following:
 [this feature]: https://doc.rust-lang.org/cargo/reference/build-scripts.html
 
 ```rust
-extern crate lalrpop;
-
 fn main() {
     lalrpop::process_root().unwrap();
 }

--- a/doc/src/tutorial/002_paren_numbers.md
+++ b/doc/src/tutorial/002_paren_numbers.md
@@ -96,12 +96,12 @@ number; so `22` is a term. The second alternative is `"(" <t:Term>
 **Invoking the parser.** OK, so we wrote our parser, how do we use it?
 For every nonterminal `Foo` declared as `pub`, LALRPOP will export a
 `FooParser` struct with a `parse` method that you can call to parse a
-string as that nonterminal. Here is a simple test that we've added to 
+string as that nonterminal. Here is a simple test that we've added to
 our [`main.rs`][main] file which uses this struct to test our `Term`
 nonterminal:
 
 ```rust
-#[macro_use] extern crate lalrpop_util;
+use lalrpop_util::lalrpop_mod;
 
 lalrpop_mod!(pub calculator1); // synthesized by LALRPOP
 

--- a/doc/src/tutorial/006_macros.md
+++ b/doc/src/tutorial/006_macros.md
@@ -103,7 +103,7 @@ FactorOp: Opcode = {
 And, of course, we have to add some tests to [main.rs file][main]:
 
 ```rust
-#[macro_use] extern crate lalrpop_util;
+use lalrpop_util::lalrpop_mod;
 
 lalrpop_mod!(pub calculator5);
 

--- a/doc/src/tutorial/007_fallible_actions.md
+++ b/doc/src/tutorial/007_fallible_actions.md
@@ -37,7 +37,7 @@ source as [`calculator6.lalrpop`][calculator6]. This allows you to nicely
 handle the errors:
 
 ```rust
-#[macro_use] extern crate lalrpop_util;
+use lalrpop_util::lalrpop_mod;
 
 lalrpop_mod!(pub calculator6);
 
@@ -109,7 +109,7 @@ Num: i32 = {
 And finally we can see if it works:
 
 ```rust
-#[macro_use] extern crate lalrpop_util;
+use lalrpop_util::lalrpop_mod;
 
 lalrpop_mod!(pub calculator6b);
 

--- a/doc/whitespace/Cargo.toml
+++ b/doc/whitespace/Cargo.toml
@@ -2,7 +2,6 @@
 name = "whitespace"
 version = "0.20.0"
 authors = ["Mako <jlauve@rsmw.net>"]
-build = "build.rs"
 edition = "2021"
 
 [build-dependencies.lalrpop]

--- a/doc/whitespace/build.rs
+++ b/doc/whitespace/build.rs
@@ -1,5 +1,3 @@
-extern crate lalrpop;
-
 fn main() {
     lalrpop::process_root().unwrap();
 }

--- a/doc/whitespace/src/lib.rs
+++ b/doc/whitespace/src/lib.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate lalrpop_util;
+use lalrpop_util::lalrpop_mod;
 
 pub mod ast;
 pub mod eval;

--- a/doc/whitespace/src/main.rs
+++ b/doc/whitespace/src/main.rs
@@ -1,5 +1,3 @@
-extern crate whitespace;
-
 fn main() {
     use std::io::*;
 

--- a/lalrpop-test/Cargo.toml
+++ b/lalrpop-test/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "lalrpop-test"
-build = "build.rs"
 workspace = ".."
 
 repository.workspace = true

--- a/lalrpop-test/build.rs
+++ b/lalrpop-test/build.rs
@@ -1,5 +1,3 @@
-extern crate lalrpop;
-
 fn main() {
     lalrpop::Configuration::new()
         .emit_comments(true)

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -6,9 +6,7 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-extern crate diff;
-#[macro_use]
-extern crate lalrpop_util;
+use lalrpop_util::lalrpop_mod;
 
 use lalrpop_util::{ErrorRecovery, ParseError};
 

--- a/lalrpop-test/src/pub_in.rs
+++ b/lalrpop-test/src/pub_in.rs
@@ -3,7 +3,8 @@
 
 mod outer {
     pub(crate) mod inner {
-        lalrpop_util::lalrpop_mod!(pub(crate) pub_in);
+        use crate::lalrpop_mod;
+        lalrpop_mod!(pub(crate) pub_in);
     }
 
     #[test]

--- a/lalrpop-test/src/user_defined_error_visibility.rs
+++ b/lalrpop-test/src/user_defined_error_visibility.rs
@@ -5,7 +5,9 @@ pub(crate) struct UserErrorCrate;
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UserErrorPublic;
 
-lalrpop_util::lalrpop_mod!(
+use lalrpop_util::lalrpop_mod;
+
+lalrpop_mod!(
     #[allow(unused)]
     user_defined_error_private
 );

--- a/lalrpop/src/lib.rs
+++ b/lalrpop/src/lib.rs
@@ -8,25 +8,6 @@
 // ε shows up in lalrpop/src/lr1/example/test.rs
 #![cfg_attr(test, allow(dead_code, mixed_script_confusables))]
 
-extern crate ascii_canvas;
-extern crate bit_set;
-extern crate ena;
-extern crate is_terminal;
-extern crate itertools;
-extern crate petgraph;
-extern crate regex;
-extern crate regex_syntax;
-extern crate string_cache;
-extern crate term;
-extern crate tiny_keccak;
-extern crate unicode_xid;
-
-#[cfg_attr(feature = "test", macro_use)]
-extern crate lalrpop_util;
-
-#[cfg(test)]
-extern crate rand;
-
 // hoist the modules that define macros up earlier
 #[macro_use]
 mod rust;

--- a/lalrpop/src/main.rs
+++ b/lalrpop/src/main.rs
@@ -1,6 +1,3 @@
-extern crate lalrpop;
-extern crate pico_args;
-
 use std::ffi::OsString;
 use std::io::Write;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

Hello, I was looking through the docs again to write a parser and I realized they have some excess code in the form of `extern crate lalrpop;` and setting the build file to `build.rs` which is the default.

I've gone through and done my best to remove these throughout the code base.