### PR TITLE
tutorial code will not comppile w/o unicode

### DIFF
--- a/tutorial/001_adding_lalrpop.html
+++ b/tutorial/001_adding_lalrpop.html
@@ -195,7 +195,7 @@ edition = &quot;2021&quot;
 lalrpop = &quot;0.20.0&quot;
 
 [dependencies]
-lalrpop-util = { version = &quot;0.20.0&quot;, features = [&quot;lexer&quot;] }
+lalrpop-util = { version = &quot;0.20.0&quot;, features = [&quot;lexer&quot;, &quot;unicode&quot;] }
 </code></pre>
 <p>Cargo can run <a href="https://doc.rust-lang.org/cargo/reference/build-scripts.html">build scripts</a> as a pre-processing step,
 named <code>build.rs</code> by default. The <code>[build-dependencies]</code>


### PR DESCRIPTION
trivial correction adding unicode to features in the tutorial doc to align tutorial with the working code linked to in the text.  (you can't compile the code from the tutorial otherwise)