### PR TITLE
Filter out NotFound errors

### DIFF
--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -186,16 +186,17 @@ fn lalrpop_files<P: AsRef<Path>>(root_dir: P) -> io::Result<Vec<PathBuf>> {
             result.extend(lalrpop_files(&path)?);
         }
 
-        let is_symlink_file = || -> io::Result<bool> {
+        let is_symlink_file = || -> bool {
             if !file_type.is_symlink() {
-                Ok(false)
+                false
             } else {
-                // Ensure all symlinks are resolved
-                Ok(fs::metadata(&path)?.is_file())
+                // Ensure all symlinks are resolved to a file
+                // Or ignore eronious ones https://github.com/lalrpop/lalrpop/issues/808
+                fs::metadata(&path).map_or(false, |m| m.is_file())
             }
         };
 
-        if (file_type.is_file() || is_symlink_file()?)
+        if (file_type.is_file() || is_symlink_file())
             && path.extension().is_some()
             && path.extension().unwrap() == "lalrpop"
         {


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->
Closes #808 

This pr will ignore any erroneous symlinks when looking for lalrpop files and will not propagate up the error.

The related issue also mentions adding some kind of warning message. I'm not sure how/if such a thing should be added especially since we are otherwise skipping over this error(So it would mean using `eprintln` I guess?).

Better error messages would certainly be more helpful but in this case lalrpop is just propagating up whatever https://doc.rust-lang.org/std/io/type.Result.html gives us so poor error messages seem like a libs team issue https://github.com/rust-lang/rfcs/issues/2885.