### PR TITLE
miscellaneous clippy/cfg_attr rustfmt deprecations

### DIFF
--- a/lalrpop/src/build/action.rs
+++ b/lalrpop/src/build/action.rs
@@ -120,7 +120,7 @@ fn emit_user_action_code<W: Write>(
         ]);
     }
 
-    rust!(rust, "#[allow(clippy::too_many_arguments)]");
+    rust!(rust, "#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]");
     rust.fn_header(
         &r::Visibility::Priv,
         format!("{}action{}", grammar.prefix, index),
@@ -234,7 +234,11 @@ fn emit_inline_action_code<W: Write>(
         ]);
     }
 
-    rust!(rust, "#[allow(clippy::too_many_arguments)]");
+    rust!(
+        rust,
+        "#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]"
+    );
     rust.fn_header(
         &r::Visibility::Priv,
         format!("{}action{}", grammar.prefix, index),

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -13,7 +13,7 @@ pub fn compile<W: Write>(
 ) -> io::Result<()> {
     let prefix = &grammar.prefix;
 
-    rust!(out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
+    rust!(out, "#[rustfmt::skip]");
     rust!(out, "mod {}intern_token {{", prefix);
     rust!(out, "#![allow(unused_imports)]");
     out.write_uses("super::", grammar)?;

--- a/lalrpop/src/lr1/codegen/ascent.rs
+++ b/lalrpop/src/lr1/codegen/ascent.rs
@@ -404,7 +404,7 @@ impl<'ascent, 'grammar, W: Write>
         if fixed > 0 {
             rust!(
                 self.out,
-                "let {}location = {}sym{}.2.clone();",
+                "let {}location = {}sym{}.2;",
                 self.prefix,
                 self.prefix,
                 stack_suffix.len() - 1
@@ -414,7 +414,7 @@ impl<'ascent, 'grammar, W: Write>
             for index in (0..optional).rev() {
                 rust!(
                     self.out,
-                    "{}sym{}.as_ref().map(|sym| sym.2.clone()).unwrap_or_else(|| {{",
+                    "{}sym{}.as_ref().map(|sym| sym.2).unwrap_or_else(|| {{",
                     self.prefix,
                     index
                 );
@@ -855,7 +855,7 @@ impl<'ascent, 'grammar, W: Write>
             if !stack_suffix.fixed().is_empty() {
                 rust!(
                     self.out,
-                    "let {p}start = {p}lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| {p}sym{top}.2.clone());",
+                    "let {p}start = {p}lookahead.as_ref().map(|o| o.0).unwrap_or_else(|| {p}sym{top}.2);",
                     p = self.prefix,
                     top = top
                 );

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -162,7 +162,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         rust!(
             self.out,
             "#[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, \
-             unused_imports, unused_parens, clippy::all)]"
+             unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding)]"
         );
         rust!(self.out, "mod {}parse{} {{", self.prefix, self.start_symbol);
         rust!(self.out, "");
@@ -251,6 +251,14 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         rust!(self.out, "}}");
         rust!(self.out, "");
 
+        // Start default impl
+        rust!(
+            self.out,
+            "impl Default for {}Parser {{ fn default() -> Self {{ Self::new() }} }}",
+            self.user_start_symbol
+        );
+
+        // Start parser impl
         rust!(self.out, "impl {}Parser {{", self.user_start_symbol);
         rust!(
             self.out,

--- a/lalrpop/src/lr1/codegen/test_all.rs
+++ b/lalrpop/src/lr1/codegen/test_all.rs
@@ -48,7 +48,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TestAll> {
         self.write_parse_mod(|this| {
             this.write_parser_fn()?;
 
-            rust!(this.out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
+            rust!(this.out, "#[rustfmt::skip]");
             rust!(this.out, "mod {}ascent {{", this.prefix);
             super::ascent::compile(
                 this.grammar,
@@ -68,7 +68,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TestAll> {
             rust!(this.out, "{}", pub_use);
             rust!(this.out, "}}");
 
-            rust!(this.out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
+            rust!(this.out, "#[rustfmt::skip]");
             rust!(this.out, "mod {}parse_table {{", this.prefix);
             super::parse_table::compile(
                 this.grammar,

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -16,7 +16,7 @@ extern crate core;
 extern crate alloc;
 
 #[rustfmt::skip]
-#[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::all)]
+#[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding)]
 mod ___parse___Top {
 
 use string_cache::DefaultAtom as Atom;
@@ -6337,6 +6337,7 @@ pub struct TopParser {
 _priv: (),
 }
 
+impl Default for TopParser { fn default() -> Self { Self::new() } }
 impl TopParser {
 pub fn new() -> TopParser {
 TopParser {
@@ -9085,8 +9086,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // "::"? =  => ActionFn(138);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action138::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant2(___nt), ___end));
 (0, 0)
@@ -9118,8 +9119,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // ";"? =  => ActionFn(155);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action155::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant2(___nt), ___end));
 (0, 1)
@@ -9151,8 +9152,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // "mut"? =  => ActionFn(144);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action144::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant2(___nt), ___end));
 (0, 2)
@@ -9205,8 +9206,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // ("->" <TypeRef>)? =  => ActionFn(169);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action169::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant4(___nt), ___end));
 (0, 4)
@@ -9259,8 +9260,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (":" <TypeRef>)? =  => ActionFn(161);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action161::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant4(___nt), ___end));
 (0, 6)
@@ -9315,8 +9316,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // ("<" <Comma<TypeBoundParameter>> ">")? =  => ActionFn(165);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action165::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant6(___nt), ___end));
 (0, 8)
@@ -9369,8 +9370,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // ("if" <Cond>)? =  => ActionFn(150);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action150::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant8(___nt), ___end));
 (0, 10)
@@ -9385,8 +9386,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // () =  => ActionFn(173);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action173::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant9(___nt), ___end));
 (0, 11)
@@ -9420,8 +9421,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<Alternative> ",")* =  => ActionFn(241);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action241::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant11(___nt), ___end));
 (0, 13)
@@ -9511,8 +9512,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<Conversion> ",")* =  => ActionFn(265);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action265::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant13(___nt), ___end));
 (0, 16)
@@ -9602,8 +9603,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<FieldPattern> ",")* =  => ActionFn(126);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action126::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant15(___nt), ___end));
 (0, 19)
@@ -9693,8 +9694,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<GrammarParameter> ",")* =  => ActionFn(231);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action231::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant17(___nt), ___end));
 (0, 22)
@@ -9784,8 +9785,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<GrammarWhereClause> ",")* =  => ActionFn(208);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action208::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant19(___nt), ___end));
 (0, 25)
@@ -9875,8 +9876,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<Id> "::")* =  => ActionFn(134);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action134::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant21(___nt), ___end));
 (0, 28)
@@ -9966,8 +9967,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<Lifetime> "+")* =  => ActionFn(211);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action211::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant23(___nt), ___end));
 (0, 31)
@@ -10057,8 +10058,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<MatchItem> ",")* =  => ActionFn(260);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action260::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant25(___nt), ___end));
 (0, 34)
@@ -10148,8 +10149,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<NotMacroId> ",")* =  => ActionFn(236);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action236::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant27(___nt), ___end));
 (0, 37)
@@ -10239,8 +10240,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<Pattern> ",")* =  => ActionFn(270);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action270::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant29(___nt), ___end));
 (0, 40)
@@ -10330,8 +10331,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<Symbol> ",")* =  => ActionFn(246);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action246::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant31(___nt), ___end));
 (0, 43)
@@ -10421,8 +10422,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<TypeBound> "+")* =  => ActionFn(216);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action216::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant33(___nt), ___end));
 (0, 46)
@@ -10512,8 +10513,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<TypeBoundParameter> ",")* =  => ActionFn(226);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action226::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant35(___nt), ___end));
 (0, 49)
@@ -10603,8 +10604,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<TypeParameter> ",")* =  => ActionFn(203);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action203::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant37(___nt), ___end));
 (0, 52)
@@ -10694,8 +10695,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<TypeRef> ",")* =  => ActionFn(221);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action221::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant38(___nt), ___end));
 (0, 55)
@@ -10785,8 +10786,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // (<TypeRefOrLifetime> ",")* =  => ActionFn(251);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action251::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant38(___nt), ___end));
 (0, 58)
@@ -10857,8 +10858,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // @L =  => ActionFn(186);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action186::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant39(___nt), ___end));
 (0, 60)
@@ -10873,8 +10874,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // @R =  => ActionFn(185);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action185::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant39(___nt), ___end));
 (0, 61)
@@ -10974,8 +10975,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Action? =  => ActionFn(148);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action148::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant41(___nt), ___end));
 (0, 63)
@@ -11203,8 +11204,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Alternative? =  => ActionFn(240);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action240::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant42(___nt), ___end));
 (0, 65)
@@ -11322,8 +11323,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Annotation* =  => ActionFn(187);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action187::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant45(___nt), ___end));
 (0, 68)
@@ -11430,8 +11431,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // AnnotationArg? =  => ActionFn(159);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action159::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant47(___nt), ___end));
 (0, 71)
@@ -11468,8 +11469,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // AssociatedType* =  => ActionFn(132);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action132::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant49(___nt), ___end));
 (0, 73)
@@ -11554,8 +11555,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<Alternative> =  => ActionFn(453);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action453::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant43(___nt), ___end));
 (0, 75)
@@ -11623,8 +11624,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<Conversion> =  => ActionFn(479);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action479::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant50(___nt), ___end));
 (0, 76)
@@ -11692,8 +11693,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<GrammarParameter> =  => ActionFn(505);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action505::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant51(___nt), ___end));
 (0, 77)
@@ -11761,8 +11762,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<GrammarWhereClause> =  => ActionFn(533);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action533::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant52(___nt), ___end));
 (0, 78)
@@ -11830,8 +11831,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<MatchItem> =  => ActionFn(577);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action577::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant53(___nt), ___end));
 (0, 79)
@@ -11899,8 +11900,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<NotMacroId> =  => ActionFn(581);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action581::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant54(___nt), ___end));
 (0, 80)
@@ -11968,8 +11969,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<Pattern> =  => ActionFn(585);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action585::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant55(___nt), ___end));
 (0, 81)
@@ -12037,8 +12038,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<Symbol> =  => ActionFn(655);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action655::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant56(___nt), ___end));
 (0, 82)
@@ -12106,8 +12107,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<TypeBoundParameter> =  => ActionFn(663);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action663::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant5(___nt), ___end));
 (0, 83)
@@ -12175,8 +12176,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<TypeParameter> =  => ActionFn(667);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action667::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant57(___nt), ___end));
 (0, 84)
@@ -12244,8 +12245,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<TypeRef> =  => ActionFn(671);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action671::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant58(___nt), ___end));
 (0, 85)
@@ -12313,8 +12314,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Comma<TypeRefOrLifetime> =  => ActionFn(675);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action675::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant58(___nt), ___end));
 (0, 86)
@@ -12470,8 +12471,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Conversion? =  => ActionFn(264);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action264::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant60(___nt), ___end));
 (0, 90)
@@ -12525,8 +12526,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // ExprSymbol =  => ActionFn(652);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action652::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant62(___nt), ___end));
 (0, 93)
@@ -12724,8 +12725,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // FieldPattern? =  => ActionFn(125);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action125::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant64(___nt), ___end));
 (0, 96)
@@ -12761,8 +12762,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // ForAll =  => ActionFn(327);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action327::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant57(___nt), ___end));
 (0, 97)
@@ -15725,8 +15726,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // GrammarItem* =  => ActionFn(177);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action177::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant66(___nt), ___end));
 (0, 100)
@@ -15831,8 +15832,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // GrammarParameter? =  => ActionFn(230);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action230::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant67(___nt), ___end));
 (0, 103)
@@ -15884,8 +15885,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // GrammarParameters? =  => ActionFn(182);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action182::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant68(___nt), ___end));
 (0, 105)
@@ -15937,8 +15938,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // GrammarTypeParameters? =  => ActionFn(184);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action184::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant69(___nt), ___end));
 (0, 107)
@@ -16034,8 +16035,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // GrammarWhereClause? =  => ActionFn(207);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action207::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant70(___nt), ___end));
 (0, 109)
@@ -16086,8 +16087,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // GrammarWhereClauses? =  => ActionFn(180);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action180::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant71(___nt), ___end));
 (0, 111)
@@ -16170,8 +16171,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Lifetime? =  => ActionFn(141);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action141::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant72(___nt), ___end));
 (0, 114)
@@ -16271,8 +16272,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // MatchItem? =  => ActionFn(259);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action259::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant74(___nt), ___end));
 (0, 118)
@@ -16579,8 +16580,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // NotMacroId? =  => ActionFn(235);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action235::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant79(___nt), ___end));
 (0, 126)
@@ -16704,8 +16705,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Pattern? =  => ActionFn(269);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action269::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant81(___nt), ___end));
 (0, 129)
@@ -17010,8 +17011,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Plus<Lifetime> =  => ActionFn(569);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action569::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant83(___nt), ___end));
 (0, 131)
@@ -17079,8 +17080,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Plus<TypeBound> =  => ActionFn(659);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action659::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant84(___nt), ___end));
 (0, 132)
@@ -17267,8 +17268,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // ShebangAttribute* =  => ActionFn(191);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action191::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant88(___nt), ___end));
 (0, 138)
@@ -17418,8 +17419,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Symbol* =  => ActionFn(145);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action145::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant31(___nt), ___end));
 (0, 143)
@@ -17557,8 +17558,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Symbol? =  => ActionFn(245);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action245::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant89(___nt), ___end));
 (0, 147)
@@ -18060,8 +18061,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // TypeBound? =  => ActionFn(215);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action215::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant92(___nt), ___end));
 (0, 152)
@@ -18147,8 +18148,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // TypeBoundParameter? =  => ActionFn(225);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action225::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant93(___nt), ___end));
 (0, 154)
@@ -18231,8 +18232,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // TypeParameter? =  => ActionFn(202);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action202::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant94(___nt), ___end));
 (0, 157)
@@ -18583,8 +18584,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // TypeRef? =  => ActionFn(220);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action220::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant4(___nt), ___end));
 (0, 159)
@@ -18650,8 +18651,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // TypeRefOrLifetime? =  => ActionFn(250);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action250::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant4(___nt), ___end));
 (0, 161)
@@ -18685,8 +18686,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Use* =  => ActionFn(189);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action189::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant66(___nt), ___end));
 (0, 163)
@@ -18814,8 +18815,8 @@ _: core::marker::PhantomData<(&'input ())>,
 ) -> (usize, usize)
 {
 // Visibility =  => ActionFn(328);
-let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2.clone())).unwrap_or_default();
-let ___end = ___start.clone();
+let ___start = ___lookahead_start.cloned().or_else(|| ___symbols.last().map(|s| s.2)).unwrap_or_default();
+let ___end = ___start;
 let ___nt = super::___action328::<>(text, &___start, &___end);
 ___symbols.push((___start, ___Symbol::Variant95(___nt), ___end));
 (0, 165)
@@ -18824,7 +18825,7 @@ ___symbols.push((___start, ___Symbol::Variant95(___nt), ___end));
 pub use self::___parse___Top::TopParser;
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action0<
     'input,
 >(
@@ -18836,7 +18837,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action1<
     'input,
 >(
@@ -18849,7 +18850,7 @@ Top::Grammar(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action2<
     'input,
 >(
@@ -18862,7 +18863,7 @@ Top::Pattern(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action3<
     'input,
 >(
@@ -18875,7 +18876,7 @@ Top::MatchMapping(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action4<
     'input,
 >(
@@ -18888,7 +18889,7 @@ Top::TypeRef(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action5<
     'input,
 >(
@@ -18901,7 +18902,7 @@ Top::GrammarWhereClauses(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action6<
     'input,
 >(
@@ -18932,7 +18933,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action7<
     'input,
 >(
@@ -18946,7 +18947,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action8<
     'input,
 >(
@@ -18958,7 +18959,7 @@ TypeParameter::Lifetime(l)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action9<
     'input,
 >(
@@ -18970,7 +18971,7 @@ TypeParameter::Id(l)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action10<
     'input,
 >(
@@ -18983,7 +18984,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action11<
     'input,
 >(
@@ -18997,7 +18998,7 @@ WhereClause::Lifetime { lifetime: l, bounds }
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action12<
     'input,
 >(
@@ -19012,7 +19013,7 @@ WhereClause::Type { forall: f, ty, bounds }
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action13<
     'input,
 >(
@@ -19027,7 +19028,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action14<
     'input,
 >(
@@ -19039,7 +19040,7 @@ vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action15<
     'input,
 >(
@@ -19051,7 +19052,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action16<
     'input,
 >(
@@ -19063,7 +19064,7 @@ TypeBound::Lifetime(l)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action17<
     'input,
 >(
@@ -19080,7 +19081,7 @@ TypeBound::Fn { forall: f, path: p, parameters: params, ret }
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action18<
     'input,
 >(
@@ -19094,7 +19095,7 @@ TypeBound::Trait { forall: f, path: p, parameters: params.unwrap_or(vec![]) }
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action19<
     'input,
 >(
@@ -19106,7 +19107,7 @@ TypeBoundParameter::Lifetime(l)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action20<
     'input,
 >(
@@ -19118,7 +19119,7 @@ TypeBoundParameter::TypeParameter(ty)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action21<
     'input,
 >(
@@ -19132,7 +19133,7 @@ TypeBoundParameter::Associated(id, ty)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action22<
     'input,
 >(
@@ -19146,7 +19147,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action23<
     'input,
 >(
@@ -19160,7 +19161,7 @@ Parameter { name: id, ty }
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action24<
     'input,
 >(
@@ -19172,7 +19173,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action25<
     'input,
 >(
@@ -19184,7 +19185,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action26<
     'input,
 >(
@@ -19196,7 +19197,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action27<
     'input,
 >(
@@ -19208,7 +19209,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action28<
     'input,
 >(
@@ -19221,7 +19222,7 @@ GrammarItem::Use(strip(u).to_string())
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action29<
     'input,
 >(
@@ -19236,7 +19237,7 @@ Visibility::Pub(Some(p))
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action30<
     'input,
 >(
@@ -19252,7 +19253,7 @@ Visibility::PubIn(p)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action31<
     'input,
 >(
@@ -19264,7 +19265,7 @@ Visibility::Pub(None)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action32<
     'input,
 >(
@@ -19276,7 +19277,7 @@ Visibility::Priv
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action33<
     'input,
 >(
@@ -19303,7 +19304,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action34<
     'input,
 >(
@@ -19319,7 +19320,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action35<
     'input,
 >(
@@ -19339,7 +19340,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action36<
     'input,
 >(
@@ -19354,7 +19355,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action37<
     'input,
 >(
@@ -19366,7 +19367,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action38<
     'input,
 >(
@@ -19378,7 +19379,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action39<
     'input,
 >(
@@ -19391,7 +19392,7 @@ vec![a]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action40<
     'input,
 >(
@@ -19406,7 +19407,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action41<
     'input,
 >(
@@ -19431,7 +19432,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action42<
     'input,
 >(
@@ -19454,7 +19455,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action43<
     'input,
 >(
@@ -19466,7 +19467,7 @@ ActionKind::Lookahead
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action44<
     'input,
 >(
@@ -19478,7 +19479,7 @@ ActionKind::Lookbehind
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action45<
     'input,
 >(
@@ -19490,7 +19491,7 @@ ActionKind::User(strip(c).to_string())
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action46<
     'input,
 >(
@@ -19502,7 +19503,7 @@ ActionKind::Fallible(strip(c).to_string())
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action47<
     'input,
 >(
@@ -19520,7 +19521,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action48<
     'input,
 >(
@@ -19532,7 +19533,7 @@ ConditionOp::Equals
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action49<
     'input,
 >(
@@ -19544,7 +19545,7 @@ ConditionOp::NotEquals
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action50<
     'input,
 >(
@@ -19556,7 +19557,7 @@ ConditionOp::Match
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action51<
     'input,
 >(
@@ -19568,7 +19569,7 @@ ConditionOp::NotMatch
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action52<
     'input,
 >(
@@ -19580,7 +19581,7 @@ ExprSymbol { symbols: ___0 }
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action53<
     'input,
 >(
@@ -19600,7 +19601,7 @@ Symbol::new(Span(lo, hi), SymbolKind::Name(Name::new(m.is_some(), l), Box::new(s
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action54<
     'input,
 >(
@@ -19616,7 +19617,7 @@ Symbol::new(Span(lo, hi), SymbolKind::Choose(Box::new(s)))
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action55<
     'input,
 >(
@@ -19628,7 +19629,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action56<
     'input,
 >(
@@ -19640,7 +19641,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action57<
     'input,
 >(
@@ -19655,7 +19656,7 @@ Symbol::new(Span(lhs.span.0, hi),
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action58<
     'input,
 >(
@@ -19667,7 +19668,7 @@ RepeatOp::Plus
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action59<
     'input,
 >(
@@ -19679,7 +19680,7 @@ RepeatOp::Star
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action60<
     'input,
 >(
@@ -19691,7 +19692,7 @@ RepeatOp::Question
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action61<
     'input,
 >(
@@ -19705,7 +19706,7 @@ Symbol::new(Span(lo, hi), sk)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action62<
     'input,
 >(
@@ -19720,7 +19721,7 @@ SymbolKind::Macro(MacroSymbol { name, args })
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action63<
     'input,
 >(
@@ -19732,7 +19733,7 @@ SymbolKind::Terminal(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action64<
     'input,
 >(
@@ -19744,7 +19745,7 @@ SymbolKind::AmbiguousId(Atom::from(___0))
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action65<
     'input,
 >(
@@ -19756,7 +19757,7 @@ SymbolKind::Nonterminal(NonterminalString(___0))
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action66<
     'input,
 >(
@@ -19770,7 +19771,7 @@ SymbolKind::Expr(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action67<
     'input,
 >(
@@ -19782,7 +19783,7 @@ SymbolKind::Lookahead
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action68<
     'input,
 >(
@@ -19794,7 +19795,7 @@ SymbolKind::Lookbehind
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action69<
     'input,
 >(
@@ -19806,7 +19807,7 @@ SymbolKind::Error
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action70<
     'input,
 >(
@@ -19820,7 +19821,7 @@ TypeRef::Tuple(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action71<
     'input,
 >(
@@ -19834,7 +19835,7 @@ TypeRef::Slice(Box::new(___0))
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action72<
     'input,
 >(
@@ -19850,7 +19851,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action73<
     'input,
 >(
@@ -19867,7 +19868,7 @@ TypeRef::Ref { lifetime: l,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action74<
     'input,
 >(
@@ -19882,7 +19883,7 @@ TypeRef::Nominal { path, types }
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action75<
     'input,
 >(
@@ -19897,7 +19898,7 @@ match p.as_id() {
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action76<
     'input,
 >(
@@ -19913,7 +19914,7 @@ TypeRef::TraitObject { path, types }
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action77<
     'input,
 >(
@@ -19926,7 +19927,7 @@ TypeRef::TraitObject { path, types: vec![] }
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action78<
     'input,
 >(
@@ -19944,7 +19945,7 @@ TypeRef::Fn { forall, path, parameters, ret: ret.map(Box::new) }
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action79<
     'input,
 >(
@@ -19956,7 +19957,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action80<
     'input,
 >(
@@ -19968,7 +19969,7 @@ TypeRef::Lifetime(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action81<
     'input,
 >(
@@ -19985,7 +19986,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action82<
     'input,
 >(
@@ -20010,7 +20011,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action83<
     'input,
 >(
@@ -20033,7 +20034,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action84<
     'input,
 >(
@@ -20045,7 +20046,7 @@ GrammarItem::MatchToken(t)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action85<
     'input,
 >(
@@ -20061,7 +20062,7 @@ t.add(c)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action86<
     'input,
 >(
@@ -20078,7 +20079,7 @@ MatchToken::new(c, Span(lo, hi))
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action87<
     'input,
 >(
@@ -20090,7 +20091,7 @@ MatchContents { items }
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action88<
     'input,
 >(
@@ -20104,7 +20105,7 @@ MatchItem::CatchAll(Span(lo, hi))
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action89<
     'input,
 >(
@@ -20118,7 +20119,7 @@ MatchItem::Unmapped(s, Span(lo, hi))
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action90<
     'input,
 >(
@@ -20137,7 +20138,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action91<
     'input,
 >(
@@ -20149,7 +20150,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action92<
     'input,
 >(
@@ -20161,7 +20162,7 @@ MatchMapping::Terminal(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action93<
     'input,
 >(
@@ -20174,7 +20175,7 @@ MatchMapping::Skip
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action94<
     'input,
 >(
@@ -20198,7 +20199,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action95<
     'input,
 >(
@@ -20220,7 +20221,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action96<
     'input,
 >(
@@ -20241,7 +20242,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action97<
     'input,
 >(
@@ -20255,7 +20256,7 @@ Pattern { span: Span(lo, hi), kind: k }
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action98<
     'input,
 >(
@@ -20270,7 +20271,7 @@ PatternKind::Enum(___0, ___1)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action99<
     'input,
 >(
@@ -20286,7 +20287,7 @@ PatternKind::Struct(p, a0.into_iter().chain(a1).collect(), false)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action100<
     'input,
 >(
@@ -20302,7 +20303,7 @@ PatternKind::Struct(p, a0, true)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action101<
     'input,
 >(
@@ -20314,7 +20315,7 @@ PatternKind::Underscore
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action102<
     'input,
 >(
@@ -20326,7 +20327,7 @@ PatternKind::DotDot
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action103<
     'input,
 >(
@@ -20340,7 +20341,7 @@ PatternKind::Choose(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action104<
     'input,
 >(
@@ -20354,7 +20355,7 @@ PatternKind::Tuple(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action105<
     'input,
 >(
@@ -20366,7 +20367,7 @@ PatternKind::CharLiteral(Atom::from(c))
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action106<
     'input,
 >(
@@ -20378,7 +20379,7 @@ PatternKind::Path(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action107<
     'input,
 >(
@@ -20390,7 +20391,7 @@ PatternKind::String(s)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action108<
     'input,
 >(
@@ -20410,7 +20411,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action109<
     'input,
 >(
@@ -20422,7 +20423,7 @@ NonterminalString(Atom::from(i))
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action110<
     'input,
 >(
@@ -20434,7 +20435,7 @@ NonterminalString(Atom::from(i))
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action111<
     'input,
 >(
@@ -20446,7 +20447,7 @@ Atom::from(i)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action112<
     'input,
 >(
@@ -20458,7 +20459,7 @@ Atom::from(i)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action113<
     'input,
 >(
@@ -20470,7 +20471,7 @@ Atom::from(i)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action114<
     'input,
 >(
@@ -20482,7 +20483,7 @@ Lifetime(Atom::from(i))
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action115<
     'input,
 >(
@@ -20494,7 +20495,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action116<
     'input,
 >(
@@ -20506,7 +20507,7 @@ TerminalString::Bare(Atom::from(i))
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action117<
     'input,
 >(
@@ -20518,7 +20519,7 @@ TerminalString::Literal(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action118<
     'input,
 >(
@@ -20530,7 +20531,7 @@ TerminalLiteral::Quoted(s)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action119<
     'input,
 >(
@@ -20542,7 +20543,7 @@ TerminalLiteral::Regex(s)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action120<
     'input,
 >(
@@ -20559,7 +20560,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action121<
     'input,
 >(
@@ -20576,7 +20577,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action122<
     'input,
 >(
@@ -20588,7 +20589,7 @@ Atom::from(s)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action123<
     'input,
 >(
@@ -20600,7 +20601,7 @@ s.to_string()
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action124<
     'input,
 >(
@@ -20612,7 +20613,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action125<
     'input,
 >(
@@ -20625,7 +20626,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action126<
     'input,
 >(
@@ -20638,7 +20639,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action127<
     'input,
 >(
@@ -20650,7 +20651,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action128<
     'input,
 >(
@@ -20663,7 +20664,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action129<
     'input,
 >(
@@ -20676,7 +20677,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action130<
     'input,
 >(
@@ -20689,7 +20690,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action131<
     'input,
 >(
@@ -20702,7 +20703,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action132<
     'input,
 >(
@@ -20715,7 +20716,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action133<
     'input,
 >(
@@ -20727,7 +20728,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action134<
     'input,
 >(
@@ -20740,7 +20741,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action135<
     'input,
 >(
@@ -20752,7 +20753,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action136<
     'input,
 >(
@@ -20765,7 +20766,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action137<
     'input,
 >(
@@ -20777,7 +20778,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action138<
     'input,
 >(
@@ -20790,7 +20791,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action139<
     'input,
 >(
@@ -20803,7 +20804,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action140<
     'input,
 >(
@@ -20815,7 +20816,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action141<
     'input,
 >(
@@ -20828,7 +20829,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action142<
     'input,
 >(
@@ -20841,7 +20842,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action143<
     'input,
 >(
@@ -20853,7 +20854,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action144<
     'input,
 >(
@@ -20866,7 +20867,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action145<
     'input,
 >(
@@ -20879,7 +20880,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action146<
     'input,
 >(
@@ -20891,7 +20892,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action147<
     'input,
 >(
@@ -20903,7 +20904,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action148<
     'input,
 >(
@@ -20916,7 +20917,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action149<
     'input,
 >(
@@ -20928,7 +20929,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action150<
     'input,
 >(
@@ -20941,7 +20942,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action151<
     'input,
 >(
@@ -20954,7 +20955,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action152<
     'input,
 >(
@@ -20966,7 +20967,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action153<
     'input,
 >(
@@ -20979,7 +20980,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action154<
     'input,
 >(
@@ -20991,7 +20992,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action155<
     'input,
 >(
@@ -21004,7 +21005,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action156<
     'input,
 >(
@@ -21017,7 +21018,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action157<
     'input,
 >(
@@ -21030,7 +21031,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action158<
     'input,
 >(
@@ -21042,7 +21043,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action159<
     'input,
 >(
@@ -21055,7 +21056,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action160<
     'input,
 >(
@@ -21067,7 +21068,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action161<
     'input,
 >(
@@ -21080,7 +21081,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action162<
     'input,
 >(
@@ -21093,7 +21094,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action163<
     'input,
 >(
@@ -21106,7 +21107,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action164<
     'input,
 >(
@@ -21118,7 +21119,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action165<
     'input,
 >(
@@ -21131,7 +21132,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action166<
     'input,
 >(
@@ -21145,7 +21146,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action167<
     'input,
 >(
@@ -21158,7 +21159,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action168<
     'input,
 >(
@@ -21170,7 +21171,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action169<
     'input,
 >(
@@ -21183,7 +21184,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action170<
     'input,
 >(
@@ -21196,7 +21197,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action171<
     'input,
 >(
@@ -21209,7 +21210,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action172<
     'input,
 >(
@@ -21225,7 +21226,7 @@ match e {
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action173<
     'input,
 >(
@@ -21237,7 +21238,7 @@ ___lookahead: &usize,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action174<
     'input,
 >(
@@ -21253,7 +21254,7 @@ match e {
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action175<
     'input,
 >(
@@ -21266,7 +21267,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action176<
     'input,
 >(
@@ -21279,7 +21280,7 @@ v0.into_iter().chain(e1).collect()
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action177<
     'input,
 >(
@@ -21292,7 +21293,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action178<
     'input,
 >(
@@ -21304,7 +21305,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action179<
     'input,
 >(
@@ -21316,7 +21317,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action180<
     'input,
 >(
@@ -21329,7 +21330,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action181<
     'input,
 >(
@@ -21341,7 +21342,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action182<
     'input,
 >(
@@ -21354,7 +21355,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action183<
     'input,
 >(
@@ -21366,7 +21367,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action184<
     'input,
 >(
@@ -21403,7 +21404,7 @@ ___lookahead: &usize,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action187<
     'input,
 >(
@@ -21416,7 +21417,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action188<
     'input,
 >(
@@ -21428,7 +21429,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action189<
     'input,
 >(
@@ -21441,7 +21442,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action190<
     'input,
 >(
@@ -21453,7 +21454,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action191<
     'input,
 >(
@@ -21466,7 +21467,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action192<
     'input,
 >(
@@ -21478,7 +21479,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action193<
     'input,
 >(
@@ -21490,7 +21491,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action194<
     'input,
 >(
@@ -21503,7 +21504,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action195<
     'input,
 >(
@@ -21515,7 +21516,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action196<
     'input,
 >(
@@ -21528,7 +21529,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action197<
     'input,
 >(
@@ -21540,7 +21541,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action198<
     'input,
 >(
@@ -21553,7 +21554,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action199<
     'input,
 >(
@@ -21565,7 +21566,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action200<
     'input,
 >(
@@ -21578,7 +21579,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action201<
     'input,
 >(
@@ -21590,7 +21591,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action202<
     'input,
 >(
@@ -21603,7 +21604,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action203<
     'input,
 >(
@@ -21616,7 +21617,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action204<
     'input,
 >(
@@ -21628,7 +21629,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action205<
     'input,
 >(
@@ -21641,7 +21642,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action206<
     'input,
 >(
@@ -21653,7 +21654,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action207<
     'input,
 >(
@@ -21666,7 +21667,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action208<
     'input,
 >(
@@ -21679,7 +21680,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action209<
     'input,
 >(
@@ -21691,7 +21692,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action210<
     'input,
 >(
@@ -21704,7 +21705,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action211<
     'input,
 >(
@@ -21717,7 +21718,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action212<
     'input,
 >(
@@ -21729,7 +21730,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action213<
     'input,
 >(
@@ -21742,7 +21743,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action214<
     'input,
 >(
@@ -21754,7 +21755,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action215<
     'input,
 >(
@@ -21767,7 +21768,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action216<
     'input,
 >(
@@ -21780,7 +21781,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action217<
     'input,
 >(
@@ -21792,7 +21793,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action218<
     'input,
 >(
@@ -21805,7 +21806,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action219<
     'input,
 >(
@@ -21817,7 +21818,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action220<
     'input,
 >(
@@ -21830,7 +21831,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action221<
     'input,
 >(
@@ -21843,7 +21844,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action222<
     'input,
 >(
@@ -21855,7 +21856,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action223<
     'input,
 >(
@@ -21868,7 +21869,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action224<
     'input,
 >(
@@ -21880,7 +21881,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action225<
     'input,
 >(
@@ -21893,7 +21894,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action226<
     'input,
 >(
@@ -21906,7 +21907,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action227<
     'input,
 >(
@@ -21918,7 +21919,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action228<
     'input,
 >(
@@ -21931,7 +21932,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action229<
     'input,
 >(
@@ -21943,7 +21944,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action230<
     'input,
 >(
@@ -21956,7 +21957,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action231<
     'input,
 >(
@@ -21969,7 +21970,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action232<
     'input,
 >(
@@ -21981,7 +21982,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action233<
     'input,
 >(
@@ -21994,7 +21995,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action234<
     'input,
 >(
@@ -22006,7 +22007,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action235<
     'input,
 >(
@@ -22019,7 +22020,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action236<
     'input,
 >(
@@ -22032,7 +22033,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action237<
     'input,
 >(
@@ -22044,7 +22045,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action238<
     'input,
 >(
@@ -22057,7 +22058,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action239<
     'input,
 >(
@@ -22069,7 +22070,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action240<
     'input,
 >(
@@ -22082,7 +22083,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action241<
     'input,
 >(
@@ -22095,7 +22096,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action242<
     'input,
 >(
@@ -22107,7 +22108,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action243<
     'input,
 >(
@@ -22120,7 +22121,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action244<
     'input,
 >(
@@ -22132,7 +22133,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action245<
     'input,
 >(
@@ -22145,7 +22146,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action246<
     'input,
 >(
@@ -22158,7 +22159,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action247<
     'input,
 >(
@@ -22170,7 +22171,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action248<
     'input,
 >(
@@ -22183,7 +22184,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action249<
     'input,
 >(
@@ -22195,7 +22196,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action250<
     'input,
 >(
@@ -22208,7 +22209,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action251<
     'input,
 >(
@@ -22221,7 +22222,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action252<
     'input,
 >(
@@ -22233,7 +22234,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action253<
     'input,
 >(
@@ -22246,7 +22247,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action254<
     'input,
 >(
@@ -22258,7 +22259,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action255<
     'input,
 >(
@@ -22271,7 +22272,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action256<
     'input,
 >(
@@ -22283,7 +22284,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action257<
     'input,
 >(
@@ -22296,7 +22297,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action258<
     'input,
 >(
@@ -22308,7 +22309,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action259<
     'input,
 >(
@@ -22321,7 +22322,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action260<
     'input,
 >(
@@ -22334,7 +22335,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action261<
     'input,
 >(
@@ -22346,7 +22347,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action262<
     'input,
 >(
@@ -22359,7 +22360,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action263<
     'input,
 >(
@@ -22371,7 +22372,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action264<
     'input,
 >(
@@ -22384,7 +22385,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action265<
     'input,
 >(
@@ -22397,7 +22398,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action266<
     'input,
 >(
@@ -22409,7 +22410,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action267<
     'input,
 >(
@@ -22422,7 +22423,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action268<
     'input,
 >(
@@ -22434,7 +22435,7 @@ Some(___0)
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action269<
     'input,
 >(
@@ -22447,7 +22448,7 @@ None
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action270<
     'input,
 >(
@@ -22460,7 +22461,7 @@ alloc::vec![]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action271<
     'input,
 >(
@@ -22472,7 +22473,7 @@ v
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action272<
     'input,
 >(
@@ -22485,7 +22486,7 @@ ___0
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action273<
     'input,
 >(
@@ -22497,7 +22498,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action274<
     'input,
 >(
@@ -22510,7 +22511,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action275<
     'input,
 >(
@@ -22522,7 +22523,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action276<
     'input,
 >(
@@ -22535,7 +22536,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action277<
     'input,
 >(
@@ -22547,7 +22548,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action278<
     'input,
 >(
@@ -22560,7 +22561,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action279<
     'input,
 >(
@@ -22572,7 +22573,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action280<
     'input,
 >(
@@ -22585,7 +22586,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action281<
     'input,
 >(
@@ -22597,7 +22598,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action282<
     'input,
 >(
@@ -22610,7 +22611,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action283<
     'input,
 >(
@@ -22622,7 +22623,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action284<
     'input,
 >(
@@ -22635,7 +22636,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action285<
     'input,
 >(
@@ -22647,7 +22648,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action286<
     'input,
 >(
@@ -22660,7 +22661,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action287<
     'input,
 >(
@@ -22672,7 +22673,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action288<
     'input,
 >(
@@ -22685,7 +22686,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action289<
     'input,
 >(
@@ -22697,7 +22698,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action290<
     'input,
 >(
@@ -22710,7 +22711,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action291<
     'input,
 >(
@@ -22722,7 +22723,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action292<
     'input,
 >(
@@ -22735,7 +22736,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action293<
     'input,
 >(
@@ -22747,7 +22748,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action294<
     'input,
 >(
@@ -22760,7 +22761,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action295<
     'input,
 >(
@@ -22772,7 +22773,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action296<
     'input,
 >(
@@ -22785,7 +22786,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action297<
     'input,
 >(
@@ -22797,7 +22798,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action298<
     'input,
 >(
@@ -22810,7 +22811,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action299<
     'input,
 >(
@@ -22822,7 +22823,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action300<
     'input,
 >(
@@ -22835,7 +22836,7 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action301<
     'input,
 >(
@@ -22847,7 +22848,7 @@ alloc::vec![___0]
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes, clippy::just_underscores_and_digits)]
 fn ___action302<
     'input,
 >(
@@ -22860,7 +22861,8 @@ text: &'input str,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action303<
     'input,
 >(
@@ -22886,7 +22888,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action304<
     'input,
 >(
@@ -22912,7 +22915,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action305<
     'input,
 >(
@@ -22940,7 +22944,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action306<
     'input,
 >(
@@ -22968,7 +22973,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action307<
     'input,
 >(
@@ -23006,7 +23012,8 @@ ___8,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action308<
     'input,
 >(
@@ -23044,7 +23051,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action309<
     'input,
 >(
@@ -23072,7 +23080,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action310<
     'input,
 >(
@@ -23100,7 +23109,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action311<
     'input,
 >(
@@ -23124,7 +23134,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action312<
     'input,
 >(
@@ -23158,7 +23169,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action313<
     'input,
 >(
@@ -23190,7 +23202,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action314<
     'input,
 >(
@@ -23226,7 +23239,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action315<
     'input,
 >(
@@ -23260,7 +23274,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action316<
     'input,
 >(
@@ -23284,7 +23299,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action317<
     'input,
 >(
@@ -23322,7 +23338,8 @@ ___8,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action318<
     'input,
 >(
@@ -23358,7 +23375,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action319<
     'input,
 >(
@@ -23384,7 +23402,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action320<
     'input,
 >(
@@ -23414,7 +23433,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action321<
     'input,
 >(
@@ -23440,7 +23460,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action322<
     'input,
 >(
@@ -23464,7 +23485,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action323<
     'input,
 >(
@@ -23498,7 +23520,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action324<
     'input,
 >(
@@ -23530,7 +23553,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action325<
     'input,
 >(
@@ -23560,7 +23584,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action326<
     'input,
 >(
@@ -23588,7 +23613,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action327<
     'input,
 >(
@@ -23612,7 +23638,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action328<
     'input,
 >(
@@ -23636,7 +23663,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action329<
     'input,
 >(
@@ -23660,7 +23688,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action330<
     'input,
 >(
@@ -23686,7 +23715,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action331<
     'input,
 >(
@@ -23710,7 +23740,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action332<
     'input,
 >(
@@ -23734,7 +23765,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action333<
     'input,
 >(
@@ -23758,7 +23790,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action334<
     'input,
 >(
@@ -23784,7 +23817,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action335<
     'input,
 >(
@@ -23808,7 +23842,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action336<
     'input,
 >(
@@ -23832,7 +23867,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action337<
     'input,
 >(
@@ -23856,7 +23892,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action338<
     'input,
 >(
@@ -23882,7 +23919,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action339<
     'input,
 >(
@@ -23912,7 +23950,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action340<
     'input,
 >(
@@ -23942,7 +23981,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action341<
     'input,
 >(
@@ -23972,7 +24012,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action342<
     'input,
 >(
@@ -24002,7 +24043,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action343<
     'input,
 >(
@@ -24026,7 +24068,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action344<
     'input,
 >(
@@ -24052,7 +24095,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action345<
     'input,
 >(
@@ -24076,7 +24120,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action346<
     'input,
 >(
@@ -24100,7 +24145,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action347<
     'input,
 >(
@@ -24124,7 +24170,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action348<
     'input,
 >(
@@ -24150,7 +24197,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action349<
     'input,
 >(
@@ -24174,7 +24222,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action350<
     'input,
 >(
@@ -24198,7 +24247,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action351<
     'input,
 >(
@@ -24222,7 +24272,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action352<
     'input,
 >(
@@ -24248,7 +24299,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action353<
     'input,
 >(
@@ -24274,7 +24326,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action354<
     'input,
 >(
@@ -24300,7 +24353,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action355<
     'input,
 >(
@@ -24324,7 +24378,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action356<
     'input,
 >(
@@ -24348,7 +24403,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action357<
     'input,
 >(
@@ -24372,7 +24428,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action358<
     'input,
 >(
@@ -24398,7 +24455,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action359<
     'input,
 >(
@@ -24422,7 +24480,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action360<
     'input,
 >(
@@ -24446,7 +24505,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action361<
     'input,
 >(
@@ -24470,7 +24530,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action362<
     'input,
 >(
@@ -24496,7 +24557,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action363<
     'input,
 >(
@@ -24520,7 +24582,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action364<
     'input,
 >(
@@ -24544,7 +24607,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action365<
     'input,
 >(
@@ -24568,7 +24632,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action366<
     'input,
 >(
@@ -24594,7 +24659,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action367<
     'input,
 >(
@@ -24618,7 +24684,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action368<
     'input,
 >(
@@ -24642,7 +24709,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action369<
     'input,
 >(
@@ -24666,7 +24734,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action370<
     'input,
 >(
@@ -24692,7 +24761,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action371<
     'input,
 >(
@@ -24716,7 +24786,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action372<
     'input,
 >(
@@ -24740,7 +24811,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action373<
     'input,
 >(
@@ -24764,7 +24836,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action374<
     'input,
 >(
@@ -24790,7 +24863,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action375<
     'input,
 >(
@@ -24814,7 +24888,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action376<
     'input,
 >(
@@ -24838,7 +24913,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action377<
     'input,
 >(
@@ -24862,7 +24938,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action378<
     'input,
 >(
@@ -24888,7 +24965,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action379<
     'input,
 >(
@@ -24912,7 +24990,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action380<
     'input,
 >(
@@ -24936,7 +25015,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action381<
     'input,
 >(
@@ -24960,7 +25040,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action382<
     'input,
 >(
@@ -24986,7 +25067,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action383<
     'input,
 >(
@@ -25010,7 +25092,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action384<
     'input,
 >(
@@ -25034,7 +25117,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action385<
     'input,
 >(
@@ -25058,7 +25142,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action386<
     'input,
 >(
@@ -25084,7 +25169,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action387<
     'input,
 >(
@@ -25108,7 +25194,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action388<
     'input,
 >(
@@ -25132,7 +25219,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action389<
     'input,
 >(
@@ -25156,7 +25244,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action390<
     'input,
 >(
@@ -25182,7 +25271,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action391<
     'input,
 >(
@@ -25206,7 +25296,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action392<
     'input,
 >(
@@ -25230,7 +25321,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action393<
     'input,
 >(
@@ -25254,7 +25346,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action394<
     'input,
 >(
@@ -25280,7 +25373,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action395<
     'input,
 >(
@@ -25304,7 +25398,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action396<
     'input,
 >(
@@ -25328,7 +25423,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action397<
     'input,
 >(
@@ -25362,7 +25458,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action398<
     'input,
 >(
@@ -25392,7 +25489,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action399<
     'input,
 >(
@@ -25422,7 +25520,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action400<
     'input,
 >(
@@ -25448,7 +25547,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action401<
     'input,
 >(
@@ -25482,7 +25582,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action402<
     'input,
 >(
@@ -25516,7 +25617,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action403<
     'input,
 >(
@@ -25546,7 +25648,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action404<
     'input,
 >(
@@ -25583,7 +25686,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action405<
     'input,
 >(
@@ -25617,7 +25721,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action406<
     'input,
 >(
@@ -25653,7 +25758,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action407<
     'input,
 >(
@@ -25685,7 +25791,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action408<
     'input,
 >(
@@ -25715,7 +25822,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action409<
     'input,
 >(
@@ -25757,7 +25865,8 @@ ___9,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action410<
     'input,
 >(
@@ -25783,7 +25892,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action411<
     'input,
 >(
@@ -25809,7 +25919,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action412<
     'input,
 >(
@@ -25846,7 +25957,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action413<
     'input,
 >(
@@ -25878,7 +25990,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action414<
     'input,
 >(
@@ -25916,7 +26029,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action415<
     'input,
 >(
@@ -25950,7 +26064,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action416<
     'input,
 >(
@@ -25976,7 +26091,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action417<
     'input,
 >(
@@ -26000,7 +26116,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action418<
     'input,
 >(
@@ -26024,7 +26141,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action419<
     'input,
 >(
@@ -26069,7 +26187,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action420<
     'input,
 >(
@@ -26112,7 +26231,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action421<
     'input,
 >(
@@ -26142,7 +26262,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action422<
     'input,
 >(
@@ -26168,7 +26289,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action423<
     'input,
 >(
@@ -26200,7 +26322,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action424<
     'input,
 >(
@@ -26228,7 +26351,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action425<
     'input,
 >(
@@ -26256,7 +26380,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action426<
     'input,
 >(
@@ -26280,7 +26405,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action427<
     'input,
 >(
@@ -26312,7 +26438,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action428<
     'input,
 >(
@@ -26344,7 +26471,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action429<
     'input,
 >(
@@ -26372,7 +26500,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action430<
     'input,
 >(
@@ -26398,7 +26527,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action431<
     'input,
 >(
@@ -26430,7 +26560,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action432<
     'input,
 >(
@@ -26464,7 +26595,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action433<
     'input,
 >(
@@ -26494,7 +26626,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action434<
     'input,
 >(
@@ -26522,7 +26655,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action435<
     'input,
 >(
@@ -26562,7 +26696,8 @@ ___8,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action436<
     'input,
 >(
@@ -26586,7 +26721,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action437<
     'input,
 >(
@@ -26610,7 +26746,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action438<
     'input,
 >(
@@ -26636,7 +26773,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action439<
     'input,
 >(
@@ -26666,7 +26804,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action440<
     'input,
 >(
@@ -26702,7 +26841,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action441<
     'input,
 >(
@@ -26734,7 +26874,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action442<
     'input,
 >(
@@ -26758,7 +26899,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action443<
     'input,
 >(
@@ -26792,7 +26934,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action444<
     'input,
 >(
@@ -26824,7 +26967,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action445<
     'input,
 >(
@@ -26852,7 +26996,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action446<
     'input,
 >(
@@ -26878,7 +27023,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action447<
     'input,
 >(
@@ -26902,7 +27048,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action448<
     'input,
 >(
@@ -26932,7 +27079,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action449<
     'input,
 >(
@@ -26962,7 +27110,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action450<
     'input,
 >(
@@ -26988,7 +27137,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action451<
     'input,
 >(
@@ -27014,7 +27164,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action452<
     'input,
 >(
@@ -27036,7 +27187,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action453<
     'input,
 >(
@@ -27060,7 +27212,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action454<
     'input,
 >(
@@ -27084,7 +27237,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action455<
     'input,
 >(
@@ -27108,7 +27262,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action456<
     'input,
 >(
@@ -27138,7 +27293,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action457<
     'input,
 >(
@@ -27168,7 +27324,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action458<
     'input,
 >(
@@ -27196,7 +27353,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action459<
     'input,
 >(
@@ -27224,7 +27382,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action460<
     'input,
 >(
@@ -27250,7 +27409,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action461<
     'input,
 >(
@@ -27276,7 +27436,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action462<
     'input,
 >(
@@ -27300,7 +27461,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action463<
     'input,
 >(
@@ -27324,7 +27486,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action464<
     'input,
 >(
@@ -27362,7 +27525,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action465<
     'input,
 >(
@@ -27400,7 +27564,8 @@ ___8,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action466<
     'input,
 >(
@@ -27434,7 +27599,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action467<
     'input,
 >(
@@ -27468,7 +27634,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action468<
     'input,
 >(
@@ -27498,7 +27665,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action469<
     'input,
 >(
@@ -27528,7 +27696,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action470<
     'input,
 >(
@@ -27558,7 +27727,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action471<
     'input,
 >(
@@ -27588,7 +27758,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action472<
     'input,
 >(
@@ -27627,7 +27798,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action473<
     'input,
 >(
@@ -27666,7 +27838,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action474<
     'input,
 >(
@@ -27705,7 +27878,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action475<
     'input,
 >(
@@ -27744,7 +27918,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action476<
     'input,
 >(
@@ -27772,7 +27947,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action477<
     'input,
 >(
@@ -27800,7 +27976,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action478<
     'input,
 >(
@@ -27822,7 +27999,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action479<
     'input,
 >(
@@ -27846,7 +28024,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action480<
     'input,
 >(
@@ -27870,7 +28049,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action481<
     'input,
 >(
@@ -27894,7 +28074,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action482<
     'input,
 >(
@@ -27922,7 +28103,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action483<
     'input,
 >(
@@ -27950,7 +28132,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action484<
     'input,
 >(
@@ -27980,7 +28163,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action485<
     'input,
 >(
@@ -28010,7 +28194,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action486<
     'input,
 >(
@@ -28044,7 +28229,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action487<
     'input,
 >(
@@ -28072,7 +28258,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action488<
     'input,
 >(
@@ -28112,7 +28299,8 @@ ___9,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action489<
     'input,
 >(
@@ -28146,7 +28334,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action490<
     'input,
 >(
@@ -28182,7 +28371,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action491<
     'input,
 >(
@@ -28212,7 +28402,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action492<
     'input,
 >(
@@ -28248,7 +28439,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action493<
     'input,
 >(
@@ -28278,7 +28470,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action494<
     'input,
 >(
@@ -28308,7 +28501,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action495<
     'input,
 >(
@@ -28332,7 +28526,8 @@ ___0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action496<
     'input,
 >(
@@ -28374,7 +28569,8 @@ ___10,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action497<
     'input,
 >(
@@ -28410,7 +28606,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action498<
     'input,
 >(
@@ -28448,7 +28645,8 @@ ___8,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action499<
     'input,
 >(
@@ -28480,7 +28678,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action500<
     'input,
 >(
@@ -28516,7 +28715,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action501<
     'input,
 >(
@@ -28552,7 +28752,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action502<
     'input,
 >(
@@ -28590,7 +28791,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action503<
     'input,
 >(
@@ -28628,7 +28830,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action504<
     'input,
 >(
@@ -28650,7 +28853,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action505<
     'input,
 >(
@@ -28674,7 +28878,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action506<
     'input,
 >(
@@ -28698,7 +28903,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action507<
     'input,
 >(
@@ -28722,7 +28928,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action508<
     'input,
 >(
@@ -28756,7 +28963,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action509<
     'input,
 >(
@@ -28790,7 +28998,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action510<
     'input,
 >(
@@ -28826,7 +29035,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action511<
     'input,
 >(
@@ -28862,7 +29072,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action512<
     'input,
 >(
@@ -28898,7 +29109,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action513<
     'input,
 >(
@@ -28934,7 +29146,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action514<
     'input,
 >(
@@ -28972,7 +29185,8 @@ ___8,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action515<
     'input,
 >(
@@ -29010,7 +29224,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action516<
     'input,
 >(
@@ -29044,7 +29259,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action517<
     'input,
 >(
@@ -29078,7 +29294,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action518<
     'input,
 >(
@@ -29110,7 +29327,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action519<
     'input,
 >(
@@ -29142,7 +29360,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action520<
     'input,
 >(
@@ -29178,7 +29397,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action521<
     'input,
 >(
@@ -29214,7 +29434,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action522<
     'input,
 >(
@@ -29248,7 +29469,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action523<
     'input,
 >(
@@ -29282,7 +29504,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action524<
     'input,
 >(
@@ -29318,7 +29541,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action525<
     'input,
 >(
@@ -29354,7 +29578,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action526<
     'input,
 >(
@@ -29388,7 +29613,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action527<
     'input,
 >(
@@ -29422,7 +29648,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action528<
     'input,
 >(
@@ -29460,7 +29687,8 @@ ___8,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action529<
     'input,
 >(
@@ -29498,7 +29726,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action530<
     'input,
 >(
@@ -29534,7 +29763,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action531<
     'input,
 >(
@@ -29570,7 +29800,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action532<
     'input,
 >(
@@ -29592,7 +29823,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action533<
     'input,
 >(
@@ -29616,7 +29848,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action534<
     'input,
 >(
@@ -29640,7 +29873,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action535<
     'input,
 >(
@@ -29664,7 +29898,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action536<
     'input,
 >(
@@ -29698,7 +29933,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action537<
     'input,
 >(
@@ -29732,7 +29968,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action538<
     'input,
 >(
@@ -29764,7 +30001,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action539<
     'input,
 >(
@@ -29796,7 +30034,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action540<
     'input,
 >(
@@ -29828,7 +30067,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action541<
     'input,
 >(
@@ -29860,7 +30100,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action542<
     'input,
 >(
@@ -29890,7 +30131,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action543<
     'input,
 >(
@@ -29920,7 +30162,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action544<
     'input,
 >(
@@ -29956,7 +30199,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action545<
     'input,
 >(
@@ -29992,7 +30236,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action546<
     'input,
 >(
@@ -30026,7 +30271,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action547<
     'input,
 >(
@@ -30060,7 +30306,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action548<
     'input,
 >(
@@ -30094,7 +30341,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action549<
     'input,
 >(
@@ -30128,7 +30376,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action550<
     'input,
 >(
@@ -30160,7 +30409,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action551<
     'input,
 >(
@@ -30192,7 +30442,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action552<
     'input,
 >(
@@ -30228,7 +30479,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action553<
     'input,
 >(
@@ -30264,7 +30516,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action554<
     'input,
 >(
@@ -30298,7 +30551,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action555<
     'input,
 >(
@@ -30332,7 +30586,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action556<
     'input,
 >(
@@ -30366,7 +30621,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action557<
     'input,
 >(
@@ -30400,7 +30656,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action558<
     'input,
 >(
@@ -30432,7 +30689,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action559<
     'input,
 >(
@@ -30464,7 +30722,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action560<
     'input,
 >(
@@ -30502,7 +30761,8 @@ ___8,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action561<
     'input,
 >(
@@ -30540,7 +30800,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action562<
     'input,
 >(
@@ -30576,7 +30837,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action563<
     'input,
 >(
@@ -30612,7 +30874,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action564<
     'input,
 >(
@@ -30648,7 +30911,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action565<
     'input,
 >(
@@ -30684,7 +30948,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action566<
     'input,
 >(
@@ -30718,7 +30983,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action567<
     'input,
 >(
@@ -30752,7 +31018,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action568<
     'input,
 >(
@@ -30774,7 +31041,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action569<
     'input,
 >(
@@ -30798,7 +31066,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action570<
     'input,
 >(
@@ -30822,7 +31091,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action571<
     'input,
 >(
@@ -30846,7 +31116,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action572<
     'input,
 >(
@@ -30874,7 +31145,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action573<
     'input,
 >(
@@ -30902,7 +31174,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action574<
     'input,
 >(
@@ -30928,7 +31201,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action575<
     'input,
 >(
@@ -30954,7 +31228,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action576<
     'input,
 >(
@@ -30976,7 +31251,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action577<
     'input,
 >(
@@ -31000,7 +31276,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action578<
     'input,
 >(
@@ -31024,7 +31301,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action579<
     'input,
 >(
@@ -31048,7 +31326,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action580<
     'input,
 >(
@@ -31070,7 +31349,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action581<
     'input,
 >(
@@ -31094,7 +31374,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action582<
     'input,
 >(
@@ -31118,7 +31399,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action583<
     'input,
 >(
@@ -31142,7 +31424,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action584<
     'input,
 >(
@@ -31164,7 +31447,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action585<
     'input,
 >(
@@ -31188,7 +31472,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action586<
     'input,
 >(
@@ -31212,7 +31497,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action587<
     'input,
 >(
@@ -31236,7 +31522,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action588<
     'input,
 >(
@@ -31270,7 +31557,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action589<
     'input,
 >(
@@ -31304,7 +31592,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action590<
     'input,
 >(
@@ -31336,7 +31625,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action591<
     'input,
 >(
@@ -31368,7 +31658,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action592<
     'input,
 >(
@@ -31400,7 +31691,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action593<
     'input,
 >(
@@ -31432,7 +31724,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action594<
     'input,
 >(
@@ -31462,7 +31755,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action595<
     'input,
 >(
@@ -31492,7 +31786,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action596<
     'input,
 >(
@@ -31524,7 +31819,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action597<
     'input,
 >(
@@ -31556,7 +31852,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action598<
     'input,
 >(
@@ -31586,7 +31883,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action599<
     'input,
 >(
@@ -31616,7 +31914,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action600<
     'input,
 >(
@@ -31646,7 +31945,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action601<
     'input,
 >(
@@ -31676,7 +31976,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action602<
     'input,
 >(
@@ -31704,7 +32005,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action603<
     'input,
 >(
@@ -31732,7 +32034,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action604<
     'input,
 >(
@@ -31768,7 +32071,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action605<
     'input,
 >(
@@ -31804,7 +32108,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action606<
     'input,
 >(
@@ -31838,7 +32143,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action607<
     'input,
 >(
@@ -31872,7 +32178,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action608<
     'input,
 >(
@@ -31906,7 +32213,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action609<
     'input,
 >(
@@ -31940,7 +32248,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action610<
     'input,
 >(
@@ -31972,7 +32281,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action611<
     'input,
 >(
@@ -32004,7 +32314,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action612<
     'input,
 >(
@@ -32038,7 +32349,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action613<
     'input,
 >(
@@ -32072,7 +32384,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action614<
     'input,
 >(
@@ -32104,7 +32417,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action615<
     'input,
 >(
@@ -32136,7 +32450,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action616<
     'input,
 >(
@@ -32168,7 +32483,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action617<
     'input,
 >(
@@ -32200,7 +32516,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action618<
     'input,
 >(
@@ -32230,7 +32547,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action619<
     'input,
 >(
@@ -32260,7 +32578,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action620<
     'input,
 >(
@@ -32296,7 +32615,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action621<
     'input,
 >(
@@ -32332,7 +32652,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action622<
     'input,
 >(
@@ -32366,7 +32687,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action623<
     'input,
 >(
@@ -32400,7 +32722,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action624<
     'input,
 >(
@@ -32434,7 +32757,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action625<
     'input,
 >(
@@ -32468,7 +32792,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action626<
     'input,
 >(
@@ -32500,7 +32825,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action627<
     'input,
 >(
@@ -32532,7 +32858,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action628<
     'input,
 >(
@@ -32566,7 +32893,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action629<
     'input,
 >(
@@ -32600,7 +32928,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action630<
     'input,
 >(
@@ -32632,7 +32961,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action631<
     'input,
 >(
@@ -32664,7 +32994,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action632<
     'input,
 >(
@@ -32696,7 +33027,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action633<
     'input,
 >(
@@ -32728,7 +33060,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action634<
     'input,
 >(
@@ -32758,7 +33091,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action635<
     'input,
 >(
@@ -32788,7 +33122,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action636<
     'input,
 >(
@@ -32826,7 +33161,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action637<
     'input,
 >(
@@ -32864,7 +33200,8 @@ ___8,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action638<
     'input,
 >(
@@ -32900,7 +33237,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action639<
     'input,
 >(
@@ -32936,7 +33274,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action640<
     'input,
 >(
@@ -32972,7 +33311,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action641<
     'input,
 >(
@@ -33008,7 +33348,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action642<
     'input,
 >(
@@ -33042,7 +33383,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action643<
     'input,
 >(
@@ -33076,7 +33418,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action644<
     'input,
 >(
@@ -33112,7 +33455,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action645<
     'input,
 >(
@@ -33148,7 +33492,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action646<
     'input,
 >(
@@ -33182,7 +33527,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action647<
     'input,
 >(
@@ -33216,7 +33562,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action648<
     'input,
 >(
@@ -33250,7 +33597,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action649<
     'input,
 >(
@@ -33284,7 +33632,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action650<
     'input,
 >(
@@ -33316,7 +33665,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action651<
     'input,
 >(
@@ -33348,7 +33698,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action652<
     'input,
 >(
@@ -33372,7 +33723,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action653<
     'input,
 >(
@@ -33394,7 +33746,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action654<
     'input,
 >(
@@ -33416,7 +33769,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action655<
     'input,
 >(
@@ -33440,7 +33794,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action656<
     'input,
 >(
@@ -33464,7 +33819,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action657<
     'input,
 >(
@@ -33488,7 +33844,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action658<
     'input,
 >(
@@ -33510,7 +33867,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action659<
     'input,
 >(
@@ -33534,7 +33892,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action660<
     'input,
 >(
@@ -33558,7 +33917,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action661<
     'input,
 >(
@@ -33582,7 +33942,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action662<
     'input,
 >(
@@ -33604,7 +33965,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action663<
     'input,
 >(
@@ -33628,7 +33990,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action664<
     'input,
 >(
@@ -33652,7 +34015,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action665<
     'input,
 >(
@@ -33676,7 +34040,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action666<
     'input,
 >(
@@ -33698,7 +34063,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action667<
     'input,
 >(
@@ -33722,7 +34088,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action668<
     'input,
 >(
@@ -33746,7 +34113,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action669<
     'input,
 >(
@@ -33770,7 +34138,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action670<
     'input,
 >(
@@ -33792,7 +34161,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action671<
     'input,
 >(
@@ -33816,7 +34186,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action672<
     'input,
 >(
@@ -33840,7 +34211,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action673<
     'input,
 >(
@@ -33864,7 +34236,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action674<
     'input,
 >(
@@ -33886,7 +34259,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action675<
     'input,
 >(
@@ -33910,7 +34284,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action676<
     'input,
 >(
@@ -33934,7 +34309,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action677<
     'input,
 >(
@@ -33958,7 +34334,8 @@ ___temp0,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action678<
     'input,
 >(
@@ -33990,7 +34367,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action679<
     'input,
 >(
@@ -34022,7 +34400,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action680<
     'input,
 >(
@@ -34056,7 +34435,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action681<
     'input,
 >(
@@ -34090,7 +34470,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action682<
     'input,
 >(
@@ -34120,7 +34501,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action683<
     'input,
 >(
@@ -34150,7 +34532,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action684<
     'input,
 >(
@@ -34182,7 +34565,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action685<
     'input,
 >(
@@ -34214,7 +34598,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action686<
     'input,
 >(
@@ -34244,7 +34629,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action687<
     'input,
 >(
@@ -34274,7 +34660,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action688<
     'input,
 >(
@@ -34306,7 +34693,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action689<
     'input,
 >(
@@ -34338,7 +34726,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action690<
     'input,
 >(
@@ -34366,7 +34755,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action691<
     'input,
 >(
@@ -34394,7 +34784,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action692<
     'input,
 >(
@@ -34424,7 +34815,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action693<
     'input,
 >(
@@ -34454,7 +34846,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action694<
     'input,
 >(
@@ -34484,7 +34877,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action695<
     'input,
 >(
@@ -34514,7 +34908,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action696<
     'input,
 >(
@@ -34546,7 +34941,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action697<
     'input,
 >(
@@ -34578,7 +34974,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action698<
     'input,
 >(
@@ -34606,7 +35003,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action699<
     'input,
 >(
@@ -34634,7 +35032,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action700<
     'input,
 >(
@@ -34664,7 +35063,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action701<
     'input,
 >(
@@ -34694,7 +35094,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action702<
     'input,
 >(
@@ -34722,7 +35123,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action703<
     'input,
 >(
@@ -34750,7 +35152,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action704<
     'input,
 >(
@@ -34780,7 +35183,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action705<
     'input,
 >(
@@ -34810,7 +35214,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action706<
     'input,
 >(
@@ -34836,7 +35241,8 @@ ___1,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action707<
     'input,
 >(
@@ -34862,7 +35268,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action708<
     'input,
 >(
@@ -34890,7 +35297,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action709<
     'input,
 >(
@@ -34918,7 +35326,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action710<
     'input,
 >(
@@ -34952,7 +35361,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action711<
     'input,
 >(
@@ -34986,7 +35396,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action712<
     'input,
 >(
@@ -35022,7 +35433,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action713<
     'input,
 >(
@@ -35058,7 +35470,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action714<
     'input,
 >(
@@ -35090,7 +35503,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action715<
     'input,
 >(
@@ -35122,7 +35536,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action716<
     'input,
 >(
@@ -35156,7 +35571,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action717<
     'input,
 >(
@@ -35190,7 +35606,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action718<
     'input,
 >(
@@ -35222,7 +35639,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action719<
     'input,
 >(
@@ -35254,7 +35672,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action720<
     'input,
 >(
@@ -35288,7 +35707,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action721<
     'input,
 >(
@@ -35322,7 +35742,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action722<
     'input,
 >(
@@ -35352,7 +35773,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action723<
     'input,
 >(
@@ -35382,7 +35804,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action724<
     'input,
 >(
@@ -35414,7 +35837,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action725<
     'input,
 >(
@@ -35446,7 +35870,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action726<
     'input,
 >(
@@ -35478,7 +35903,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action727<
     'input,
 >(
@@ -35510,7 +35936,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action728<
     'input,
 >(
@@ -35544,7 +35971,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action729<
     'input,
 >(
@@ -35578,7 +36006,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action730<
     'input,
 >(
@@ -35608,7 +36037,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action731<
     'input,
 >(
@@ -35638,7 +36068,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action732<
     'input,
 >(
@@ -35670,7 +36101,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action733<
     'input,
 >(
@@ -35702,7 +36134,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action734<
     'input,
 >(
@@ -35732,7 +36165,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action735<
     'input,
 >(
@@ -35762,7 +36196,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action736<
     'input,
 >(
@@ -35794,7 +36229,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action737<
     'input,
 >(
@@ -35826,7 +36262,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action738<
     'input,
 >(
@@ -35854,7 +36291,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action739<
     'input,
 >(
@@ -35882,7 +36320,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action740<
     'input,
 >(
@@ -35912,7 +36351,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action741<
     'input,
 >(
@@ -35942,7 +36382,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action742<
     'input,
 >(
@@ -35976,7 +36417,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action743<
     'input,
 >(
@@ -36010,7 +36452,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action744<
     'input,
 >(
@@ -36046,7 +36489,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action745<
     'input,
 >(
@@ -36082,7 +36526,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action746<
     'input,
 >(
@@ -36114,7 +36559,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action747<
     'input,
 >(
@@ -36146,7 +36592,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action748<
     'input,
 >(
@@ -36180,7 +36627,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action749<
     'input,
 >(
@@ -36214,7 +36662,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action750<
     'input,
 >(
@@ -36246,7 +36695,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action751<
     'input,
 >(
@@ -36278,7 +36728,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action752<
     'input,
 >(
@@ -36312,7 +36763,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action753<
     'input,
 >(
@@ -36346,7 +36798,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action754<
     'input,
 >(
@@ -36376,7 +36829,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action755<
     'input,
 >(
@@ -36406,7 +36860,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action756<
     'input,
 >(
@@ -36438,7 +36893,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action757<
     'input,
 >(
@@ -36470,7 +36926,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action758<
     'input,
 >(
@@ -36502,7 +36959,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action759<
     'input,
 >(
@@ -36534,7 +36992,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action760<
     'input,
 >(
@@ -36568,7 +37027,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action761<
     'input,
 >(
@@ -36602,7 +37062,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action762<
     'input,
 >(
@@ -36632,7 +37093,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action763<
     'input,
 >(
@@ -36662,7 +37124,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action764<
     'input,
 >(
@@ -36694,7 +37157,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action765<
     'input,
 >(
@@ -36726,7 +37190,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action766<
     'input,
 >(
@@ -36756,7 +37221,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action767<
     'input,
 >(
@@ -36786,7 +37252,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action768<
     'input,
 >(
@@ -36818,7 +37285,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action769<
     'input,
 >(
@@ -36850,7 +37318,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action770<
     'input,
 >(
@@ -36878,7 +37347,8 @@ ___2,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action771<
     'input,
 >(
@@ -36906,7 +37376,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action772<
     'input,
 >(
@@ -36936,7 +37407,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action773<
     'input,
 >(
@@ -36966,7 +37438,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action774<
     'input,
 >(
@@ -37002,7 +37475,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action775<
     'input,
 >(
@@ -37038,7 +37512,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action776<
     'input,
 >(
@@ -37076,7 +37551,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action777<
     'input,
 >(
@@ -37114,7 +37590,8 @@ ___8,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action778<
     'input,
 >(
@@ -37148,7 +37625,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action779<
     'input,
 >(
@@ -37182,7 +37660,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action780<
     'input,
 >(
@@ -37218,7 +37697,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action781<
     'input,
 >(
@@ -37254,7 +37734,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action782<
     'input,
 >(
@@ -37288,7 +37769,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action783<
     'input,
 >(
@@ -37322,7 +37804,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action784<
     'input,
 >(
@@ -37358,7 +37841,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action785<
     'input,
 >(
@@ -37394,7 +37878,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action786<
     'input,
 >(
@@ -37426,7 +37911,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action787<
     'input,
 >(
@@ -37458,7 +37944,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action788<
     'input,
 >(
@@ -37492,7 +37979,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action789<
     'input,
 >(
@@ -37526,7 +38014,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action790<
     'input,
 >(
@@ -37560,7 +38049,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action791<
     'input,
 >(
@@ -37594,7 +38084,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action792<
     'input,
 >(
@@ -37630,7 +38121,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action793<
     'input,
 >(
@@ -37666,7 +38158,8 @@ ___7,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action794<
     'input,
 >(
@@ -37698,7 +38191,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action795<
     'input,
 >(
@@ -37730,7 +38224,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action796<
     'input,
 >(
@@ -37764,7 +38259,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action797<
     'input,
 >(
@@ -37798,7 +38294,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action798<
     'input,
 >(
@@ -37830,7 +38327,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action799<
     'input,
 >(
@@ -37862,7 +38360,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action800<
     'input,
 >(
@@ -37896,7 +38395,8 @@ ___5,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action801<
     'input,
 >(
@@ -37930,7 +38430,8 @@ ___6,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action802<
     'input,
 >(
@@ -37960,7 +38461,8 @@ ___3,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action803<
     'input,
 >(
@@ -37990,7 +38492,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action804<
     'input,
 >(
@@ -38022,7 +38525,8 @@ ___4,
 }
 
 #[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits)]
 fn ___action805<
     'input,
 >(


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

I've procrastinated a little bit by seeing what happens if `clippy::all` was removed from the generated code.

In some cases it just meant making the lints more precise in what was being allowed(like `needless_lifetimes`, `just_underscores_and_digits`, etc).

It did catch that in a couple places `#[cfg_attr(rustfmt, rustfmt_skip)]` was being emitted which has been deprecated in favor of `#[rustfmt::skip]`. There were a bunch of unnecessary clones that have been removed.

It also suggests adding a `Default` impl to any parsers that are generated which might have a niche application with the more built-in support for default Rust has been getting.

There were two cases where trivial math was being generated like `* 1` and `1 - 1` that I removed(which are actually clippy errors not warnings).

Updating the `lrgrammar.rs` with `snap.sh` is really noisy but I guess that's what happens when you have a 40k line file checked in

In part this is motivated by #769 in trying to limit how much of clippy is allowed by default.