### PR TITLE
Clippy 1.72 release fixes

### DIFF
--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -1172,9 +1172,7 @@ fn test_nested_pattern_string_error() {
     let tokens = util::tok::tokenize("\"not matched\"")
         .into_iter()
         .map(|t| t.1);
-    let err = nested::EParser::new()
-        .parse(tokens.into_iter())
-        .unwrap_err();
+    let err = nested::EParser::new().parse(tokens).unwrap_err();
     match err {
         ParseError::UnrecognizedToken { token, expected: _ } => {
             assert_eq!(token.1, Tok::String("not matched"));

--- a/lalrpop/src/lexer/nfa/test.rs
+++ b/lalrpop/src/lexer/nfa/test.rs
@@ -141,13 +141,13 @@ fn text_boundaries() {
 
 #[test]
 fn word_boundaries() {
-    let num = re::parse_regex(r#"\baBCdeF"#).unwrap();
+    let num = re::parse_regex(r"\baBCdeF").unwrap();
     assert_eq!(
         Nfa::from_re(&num).unwrap_err(),
         NfaConstructionError::LookAround
     );
 
-    let num = re::parse_regex(r#"aBCdeF\B"#).unwrap();
+    let num = re::parse_regex(r"aBCdeF\B").unwrap();
     assert_eq!(
         Nfa::from_re(&num).unwrap_err(),
         NfaConstructionError::LookAround

--- a/lalrpop/src/lr1/build/test.rs
+++ b/lalrpop/src/lr1/build/test.rs
@@ -281,6 +281,7 @@ T: () = {
 fn issue_144() {
     let _tls = Tls::test();
 
+    #[allow(clippy::needless_raw_string_hashes)] // Fix merged for next clippy release, after 1.72
     let grammar = normalized_grammar(
         r##"
 grammar;

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -162,7 +162,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         rust!(
             self.out,
             "#[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, \
-             unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding, clippy::needless_raw_string_hashes)]"
+             unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding, clippy::needless_raw_string_hashes, clippy::manual_range_patterns)]"
         );
         rust!(self.out, "mod {}parse{} {{", self.prefix, self.start_symbol);
         rust!(self.out, "");

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -162,7 +162,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         rust!(
             self.out,
             "#[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, \
-             unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding)]"
+             unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding, clippy::needless_raw_string_hashes)]"
         );
         rust!(self.out, "mod {}parse{} {{", self.prefix, self.start_symbol);
         rust!(self.out, "");

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -162,7 +162,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         rust!(
             self.out,
             "#[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, \
-             unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding, clippy::needless_raw_string_hashes, clippy::manual_range_patterns)]"
+             unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding, clippy::needless_raw_string_hashes)]"
         );
         rust!(self.out, "mod {}parse{} {{", self.prefix, self.start_symbol);
         rust!(self.out, "");

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -852,7 +852,19 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
                 rust!(
                     self.out,
                     "{} => match {}token {{",
-                    indices.iter().map(|(index, _)| index).format(" | "),
+                    if indices.windows(2).all(|w| w[0].0 + 1 == w[1].0) {
+                        format!(
+                            "{}..={}",
+                            indices.first().unwrap().0,
+                            indices.last().unwrap().0
+                        )
+                    } else {
+                        indices
+                            .iter()
+                            .map(|(index, _)| index)
+                            .format(" | ")
+                            .to_string()
+                    },
                     self.prefix
                 );
                 rust!(
@@ -871,7 +883,19 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
                 rust!(
                     self.out,
                     "{indices} => {p}Symbol::{variant_name}({p}token),",
-                    indices = indices.iter().map(|(index, _)| index).format(" | "),
+                    indices = if indices.windows(2).all(|w| w[0].0 + 1 == w[1].0) {
+                        format!(
+                            "{}..={}",
+                            indices.first().unwrap().0,
+                            indices.last().unwrap().0
+                        )
+                    } else {
+                        indices
+                            .iter()
+                            .map(|(index, _)| index)
+                            .format(" | ")
+                            .to_string()
+                    },
                     p = self.prefix,
                     variant_name = variant_name,
                 )

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -805,7 +805,11 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
             .emit()?;
         rust!(self.out, "{{");
 
-        rust!(self.out, "match {p}token_index {{", p = self.prefix,);
+        rust!(
+            self.out,
+            "#[allow(clippy::manual_range_patterns)]match {p}token_index {{",
+            p = self.prefix,
+        );
 
         let mut token_to_symbol_mapping = Vec::new();
 
@@ -852,19 +856,11 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
                 rust!(
                     self.out,
                     "{} => match {}token {{",
-                    if indices.windows(2).all(|w| w[0].0 + 1 == w[1].0) {
-                        format!(
-                            "{}..={}",
-                            indices.first().unwrap().0,
-                            indices.last().unwrap().0
-                        )
-                    } else {
-                        indices
-                            .iter()
-                            .map(|(index, _)| index)
-                            .format(" | ")
-                            .to_string()
-                    },
+                    indices
+                        .iter()
+                        .map(|(index, _)| index)
+                        .format(" | ")
+                        .to_string(),
                     self.prefix
                 );
                 rust!(
@@ -883,19 +879,11 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
                 rust!(
                     self.out,
                     "{indices} => {p}Symbol::{variant_name}({p}token),",
-                    indices = if indices.windows(2).all(|w| w[0].0 + 1 == w[1].0) {
-                        format!(
-                            "{}..={}",
-                            indices.first().unwrap().0,
-                            indices.last().unwrap().0
-                        )
-                    } else {
-                        indices
-                            .iter()
-                            .map(|(index, _)| index)
-                            .format(" | ")
-                            .to_string()
-                    },
+                    indices = indices
+                        .iter()
+                        .map(|(index, _)| index)
+                        .format(" | ")
+                        .to_string(),
                     p = self.prefix,
                     variant_name = variant_name,
                 )

--- a/lalrpop/src/lr1/error/test.rs
+++ b/lalrpop/src/lr1/error/test.rs
@@ -167,14 +167,14 @@ Ident = r#"[a-zA-Z][a-zA-Z0-9]*"#;
 fn issue_249() {
     let _tls = Tls::test();
     let grammar = normalized_grammar(
-        r##"
+        r#"
 grammar;
 
 pub Func = StructDecl* VarDecl*;
 StructDecl = "<" StructParameter* ">";
 StructParameter = "may_dangle"?;
 VarDecl = "let";
-"##,
+"#,
     );
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let err = build_states(&grammar, nt("Func")).unwrap_err();

--- a/lalrpop/src/lr1/trace/trace_graph/mod.rs
+++ b/lalrpop/src/lr1/trace/trace_graph/mod.rs
@@ -354,7 +354,6 @@ impl<'graph, 'grammar> PathEnumerator<'graph, 'grammar> {
             None => {
                 if self.stack[1].symbol_sets.prefix.is_empty() {
                     symbols.push(ExampleSymbol::Epsilon)
-                } else {
                 }
             }
         }

--- a/lalrpop/src/normalize/prevalidate/test.rs
+++ b/lalrpop/src/normalize/prevalidate/test.rs
@@ -73,7 +73,7 @@ fn duplicate_annotation() {
 #[test]
 fn pub_inline_annotation() {
     check_err(
-        r#"public items cannot be marked #\[inline\]"#,
+        r"public items cannot be marked #\[inline\]",
         r#"grammar; #[inline] pub Term = ();"#,
         r#"           ~~~~~~            "#,
     );
@@ -91,7 +91,7 @@ fn multiple_match_token() {
 #[test]
 fn match_after_extern_token() {
     check_err(
-        r#"match and extern \(with custom tokens\) definitions are mutually exclusive"#,
+        r"match and extern \(with custom tokens\) definitions are mutually exclusive",
         r#"grammar; extern { enum Tok { } } match { _ }"#,
         r#"                                 ~~~~~      "#,
     );
@@ -100,7 +100,7 @@ fn match_after_extern_token() {
 #[test]
 fn extern_after_match_token() {
     check_err(
-        r#"extern \(with custom tokens\) and match definitions are mutually exclusive"#,
+        r"extern \(with custom tokens\) and match definitions are mutually exclusive",
         r#"grammar; match { _ } extern { enum Tok { } }"#,
         r#"                     ~~~~~~                 "#,
     );
@@ -127,7 +127,7 @@ fn match_catch_all_last_of_first() {
 #[test]
 fn expandable_expression_requires_named_variables() {
     check_err(
-        r#"Using `<>` between curly braces \(e.g., `\{<>\}`\) only works when your parsed values have been given names \(e.g., `<x:Foo>`, not just `<Foo>`\)"#,
+        r"Using `<>` between curly braces \(e.g., `\{<>\}`\) only works when your parsed values have been given names \(e.g., `<x:Foo>`, not just `<Foo>`\)",
         r#"grammar; Term = { <A> => Foo {<>} };"#,
         r#"                  ~~~~~~~~~~~~~~~~  "#,
     );

--- a/lalrpop/src/normalize/token_check/mod.rs
+++ b/lalrpop/src/normalize/token_check/mod.rs
@@ -349,10 +349,10 @@ fn construct(grammar: &mut Grammar, match_block: MatchBlock) -> NormResult<()> {
         Ok(dfa) => dfa,
         Err(DfaConstructionError::NfaConstructionError { index, error }) => {
             let feature = match error {
-                NamedCaptures => r#"named captures (`(?P<foo>...)`)"#,
+                NamedCaptures => r"named captures (`(?P<foo>...)`)",
                 NonGreedy => r#""non-greedy" repetitions (`*?` or `+?`)"#,
-                LookAround => r#"all boundaries like `\b` or `\B` or `^` or `$`"#,
-                ByteRegex => r#"byte-based matches"#,
+                LookAround => r"all boundaries like `\b` or `\B` or `^` or `$`",
+                ByteRegex => r"byte-based matches",
             };
             let literal = &match_entries[index.index()].match_literal;
             return_err!(

--- a/lalrpop/src/normalize/token_check/test.rs
+++ b/lalrpop/src/normalize/token_check/test.rs
@@ -117,8 +117,8 @@ fn match_mappings() {
     check_intern_token(
         r#"grammar; match { r"(?i)begin" => "BEGIN" } else { "abc" => ALPHA } X = "BEGIN" ALPHA;"#,
         vec![
-            ("BEGIN", r##"Some(("BEGIN", "BEGIN"))"##),
-            ("begin", r##"Some(("BEGIN", "begin"))"##),
+            ("BEGIN", r#"Some(("BEGIN", "BEGIN"))"#),
+            ("begin", r#"Some(("BEGIN", "begin"))"#),
             ("abc", r#"Some((ALPHA, "abc"))"#),
         ],
     );
@@ -133,8 +133,8 @@ fn match_precedence() {
     check_intern_token(
         r#"grammar; match { r"(?i)begin" => "BEGIN" } else { r"\w+" => ID } X = ();"#,
         vec![
-            ("BEGIN", r##"Some(("BEGIN", "BEGIN"))"##),
-            ("begin", r##"Some(("BEGIN", "begin"))"##),
+            ("BEGIN", r#"Some(("BEGIN", "BEGIN"))"#),
+            ("begin", r#"Some(("BEGIN", "begin"))"#),
             ("abc", r#"Some((ID, "abc"))"#),
         ],
     );
@@ -173,7 +173,7 @@ fn match_catch_all() {
 // This test requires regex's unicode case support
 #[cfg_attr(not(feature = "unicode"), ignore)]
 fn complex_match() {
-    let grammar = r##"
+    let grammar = r#"
         grammar;
         match {
             "abc"        => "ABC",
@@ -183,7 +183,7 @@ fn complex_match() {
         pub Query: String = {
             "ABC" BEGIN => String::from("Success")
         };
-"##;
+"#;
     assert!(validate_grammar(grammar).is_ok())
 }
 

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -3252,7 +3252,7 @@ ___token: Tok<'input>,
 _: core::marker::PhantomData<(&'input ())>,
 ) -> ___Symbol<'input>
 {
-match ___token_index {
+#[allow(clippy::manual_range_patterns)]match ___token_index {
 0 | 1 | 2 | 3 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 21 | 22 | 23 | 24 | 25 | 26 | 33 | 34 | 35 | 36 | 37 | 39 | 40 | 41 | 42 | 43 | 44 | 45 | 46 | 47 | 48 | 49 | 50 | 51 | 52 | 53 | 55 | 56 | 57 | 58 => ___Symbol::Variant0(___token),
 4 | 19 | 20 | 27 | 28 | 29 | 30 | 31 | 32 | 38 | 54 => match ___token {
 Tok::ShebangAttribute(___tok0) | Tok::EqualsGreaterThanCode(___tok0) | Tok::EqualsGreaterThanQuestionCode(___tok0) | Tok::CharLiteral(___tok0) | Tok::Escape(___tok0) | Tok::Id(___tok0) | Tok::Lifetime(___tok0) | Tok::MacroId(___tok0) | Tok::RegexLiteral(___tok0) | Tok::StringLiteral(___tok0) | Tok::Use(___tok0) if true => ___Symbol::Variant1(___tok0),

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -16,7 +16,7 @@ extern crate core;
 extern crate alloc;
 
 #[rustfmt::skip]
-#[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding)]
+#[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding, clippy::needless_raw_string_hashes)]
 mod ___parse___Top {
 
 use string_cache::DefaultAtom as Atom;

--- a/lalrpop/src/tok/test.rs
+++ b/lalrpop/src/tok/test.rs
@@ -97,7 +97,7 @@ fn rule_stringliteral_slash_dot_then_equalsgreaterthancode_functioncall() {
     test(
         r#" "\." => a(b, c),"#,
         vec![
-            (r#" ~~~~            "#, StringLiteral(r#"\."#)),
+            (r#" ~~~~            "#, StringLiteral(r"\.")),
             (r#"      ~~~~~~~~~~ "#, EqualsGreaterThanCode(" a(b, c)")),
             (r#"                ~"#, Comma),
         ],
@@ -109,7 +109,7 @@ fn rule_stringliteral_slash_dot_then_equalsgreaterthancode_many_characters_in_st
     test(
         r#" "\." => "Planet Earth" ,"#,
         vec![
-            (r#" ~~~~                    "#, StringLiteral(r#"\."#)),
+            (r#" ~~~~                    "#, StringLiteral(r"\.")),
             (
                 r#"      ~~~~~~~~~~~~~~~~~~ "#,
                 EqualsGreaterThanCode(r#" "Planet Earth" "#),
@@ -124,7 +124,7 @@ fn rule_stringliteral_slash_dot_then_equalsgreaterthancode_one_character_dot_in_
     test(
         r#" "\." => "." ,"#,
         vec![
-            (r#" ~~~~         "#, StringLiteral(r#"\."#)),
+            (r#" ~~~~         "#, StringLiteral(r"\.")),
             (r#"      ~~~~~~~ "#, EqualsGreaterThanCode(r#" "." "#)),
             (r#"             ~"#, Comma),
         ],
@@ -137,7 +137,7 @@ fn rule_stringliteral_slash_openningbracket_then_equalsgreaterthancode_one_chara
     test(
         r#" "\(" => "(" ,"#,
         vec![
-            (r#" ~~~~         "#, StringLiteral(r#"\("#)),
+            (r#" ~~~~         "#, StringLiteral(r"\(")),
             (r#"      ~~~~~~~ "#, EqualsGreaterThanCode(r#" "(" "#)),
             (r#"             ~"#, Comma),
         ],
@@ -149,7 +149,7 @@ fn rule_stringliteral_slash_openningbracket_then_equalsgreaterthancode_empty_str
     test(
         r#" "\(" => "" ,"#,
         vec![
-            (r#" ~~~~        "#, StringLiteral(r#"\("#)),
+            (r#" ~~~~        "#, StringLiteral(r"\(")),
             (r#"      ~~~~~~ "#, EqualsGreaterThanCode(r#" "" "#)),
             (r#"            ~"#, Comma),
         ],
@@ -161,7 +161,7 @@ fn rule_stringliteral_slash_dot_then_equalsgreaterthancode_one_character_dot() {
     test(
         r#" "\." => '.' ,"#,
         vec![
-            (r#" ~~~~         "#, StringLiteral(r#"\."#)),
+            (r#" ~~~~         "#, StringLiteral(r"\.")),
             (r#"      ~~~~~~~ "#, EqualsGreaterThanCode(r#" '.' "#)),
             (r#"             ~"#, Comma),
         ],
@@ -174,7 +174,7 @@ fn rule_stringliteral_slash_openningbracket_then_equalsgreaterthancode_one_chara
     test(
         r#" "\(" => '(' ,"#,
         vec![
-            (r#" ~~~~         "#, StringLiteral(r#"\("#)),
+            (r#" ~~~~         "#, StringLiteral(r"\(")),
             (r#"      ~~~~~~~ "#, EqualsGreaterThanCode(r#" '(' "#)),
             (r#"             ~"#, Comma),
         ],
@@ -195,9 +195,9 @@ fn equalsgreaterthancode_one_character_openningbracket() {
 #[test]
 fn equalsgreaterthancode_one_character_escaped_n() {
     test(
-        r#"=> '\n' ,"#,
+        r"=> '\n' ,",
         vec![
-            (r#"~~~~~~~~ "#, EqualsGreaterThanCode(r#" '\n' "#)),
+            (r#"~~~~~~~~ "#, EqualsGreaterThanCode(r" '\n' ")),
             (r#"        ~"#, Comma),
         ],
     );
@@ -206,9 +206,9 @@ fn equalsgreaterthancode_one_character_escaped_n() {
 #[test]
 fn equalsgreaterthancode_one_character_escaped_w() {
     test(
-        r#"=> '\w' ,"#,
+        r"=> '\w' ,",
         vec![
-            (r#"~~~~~~~~ "#, EqualsGreaterThanCode(r#" '\w' "#)),
+            (r#"~~~~~~~~ "#, EqualsGreaterThanCode(r" '\w' ")),
             (r#"        ~"#, Comma),
         ],
     );
@@ -217,11 +217,11 @@ fn equalsgreaterthancode_one_character_escaped_w() {
 #[test]
 fn equalsgreaterthancode_one_character_escaped_planet123() {
     test(
-        r#"=> '\planet123' ,"#,
+        r"=> '\planet123' ,",
         vec![
             (
                 r#"~~~~~~~~~~~~~~~~ "#,
-                EqualsGreaterThanCode(r#" '\planet123' "#),
+                EqualsGreaterThanCode(r" '\planet123' "),
             ),
             (r#"                ~"#, Comma),
         ],
@@ -421,7 +421,7 @@ fn equalsgreaterthancode_error_unterminated_string_literal() {
 #[test]
 fn equalsgreaterthancode_error_unterminated_character_literal() {
     test_err(
-        r#"=>  '\x233  "#,
+        r"=>  '\x233  ",
         (r#"    ~       "#, ErrorCode::UnterminatedCharacterLiteral),
     )
 }
@@ -437,11 +437,11 @@ fn equalsgreaterthancode_error_end_of_input_instead_of_closing_normal_character_
 #[test]
 fn equalsgreaterthancode_single_quote_literal() {
     test(
-        r#"=> { println!('\''); },"#,
+        r"=> { println!('\''); },",
         vec![
             (
                 r#"~~~~~~~~~~~~~~~~~~~~~~ "#,
-                EqualsGreaterThanCode(r#" { println!('\''); }"#),
+                EqualsGreaterThanCode(r" { println!('\''); }"),
             ),
             (r#"                      ~"#, Comma),
         ],
@@ -599,7 +599,7 @@ fn where1() {
 #[test]
 fn regex1() {
     test(
-        r#####"raa r##" #"#"" "#"##rrr"#####,
+        r###"raa r##" #"#"" "#"##rrr"###,
         vec![
             (r#####"~~~                    "#####, Id("raa")),
             (
@@ -687,7 +687,7 @@ fn regex2() {
 #[test]
 fn char_literals() {
     test(
-        r#"'foo' 'a 'b '!' '!!' '\'' 'c"#,
+        r"'foo' 'a 'b '!' '!!' '\'' 'c",
         vec![
             (r#"~~~~~                       "#, CharLiteral("foo")),
             (r#"      ~~                    "#, Lifetime("'a")),
@@ -707,23 +707,23 @@ fn string_escapes() {
 
     assert_eq!(apply_string_escapes(r#"foo"#, 5), Ok(Cow::Borrowed("foo")));
     assert_eq!(
-        apply_string_escapes(r#"\\"#, 10),
-        Ok(Cow::Owned::<str>(r#"\"#.into()))
+        apply_string_escapes(r"\\", 10),
+        Ok(Cow::Owned::<str>(r"\".into()))
     );
     assert_eq!(
         apply_string_escapes(r#"\""#, 15),
         Ok(Cow::Owned::<str>(r#"""#.into()))
     );
     assert_eq!(
-        apply_string_escapes(r#"up\ndown"#, 25),
+        apply_string_escapes(r"up\ndown", 25),
         Ok(Cow::Owned::<str>("up\ndown".into()))
     );
     assert_eq!(
-        apply_string_escapes(r#"forth\rback"#, 25),
+        apply_string_escapes(r"forth\rback", 25),
         Ok(Cow::Owned::<str>("forth\rback".into()))
     );
     assert_eq!(
-        apply_string_escapes(r#"left\tright"#, 40),
+        apply_string_escapes(r"left\tright", 40),
         Ok(Cow::Owned::<str>("left\tright".into()))
     );
 
@@ -737,7 +737,7 @@ fn string_escapes() {
     );
     // LALRPOP doesn't support the other Rust escape sequences.
     assert_eq!(
-        apply_string_escapes(r#"star: \u{2a}"#, 105),
+        apply_string_escapes(r"star: \u{2a}", 105),
         Err(Error {
             location: 112,
             code: ErrorCode::UnrecognizedEscape


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

With the new clippy release, I've gone through and either manually or `cargo clippy --fix`ed the triggered lints. I don't think anything here is particularly interesting/useful but may as well not let things slip.