### PR TITLE
LALRPOP Configuration fixes

### DIFF
--- a/doc/src/advanced_setup.md
+++ b/doc/src/advanced_setup.md
@@ -28,6 +28,21 @@ fn main() {
 }
 ```
 
+#### Rerun Directives
+
+Cargo will rerun the build script on each compilation even if the lalrpop file has not changed.
+To disable this behavior, use the `emit_rerun_directives` function when setting up your lalrpop `Configuration`.
+
+```rust
+fn main() {
+    lalrpop::Configuration::new()
+        .emit_rerun_directives(true)
+        .process_current_dir();
+}
+```
+
+By default, this is set to false in case other parts of the build script or compilation code expects `build.rs` to be run unconditionally.
+
 ### Using the Legacy LALR Parser
 
 By default, LALRPOP uses the [lane table][]

--- a/doc/src/generate_in_source.md
+++ b/doc/src/generate_in_source.md
@@ -6,12 +6,10 @@ If you want to keep the previous behaviour, you can use `generate_in_source_tree
 in your configuration:
 
 ```rust
-extern crate lalrpop;
-
 fn main() {
     lalrpop::Configuration::new()
         .generate_in_source_tree()
-        .process();
+        .process().unwrap();
 }
 ```
 

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -96,7 +96,13 @@ fn gen_resolve_file(session: &Session, lalrpop_file: &Path, ext: &str) -> io::Re
         .unwrap()
         .contains(char::is_whitespace)
     {
-        eprintln!("The lalrpop file named `{}` contains whitespace which may make this file difficult to import.", lalrpop_file.display())
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "LALRPOP file names cannot contain whitespace: {}",
+                lalrpop_file.display()
+            ),
+        ));
     }
 
     // If the lalrpop file is not in in_dir, the result is that the

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -91,9 +91,21 @@ fn gen_resolve_file(session: &Session, lalrpop_file: &Path, ext: &str) -> io::Re
     // But I don't think we want a full blown syn dependency unless fully converting to proc macros.
     if lalrpop_file
         .file_name()
-        .unwrap()
+        .ok_or(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "LALRPOP could not extract a valid file name: {}",
+                lalrpop_file.display()
+            ),
+        ))?
         .to_str()
-        .unwrap()
+        .ok_or(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "LALRPOP file names must be valid UTF-8: {}",
+                lalrpop_file.display()
+            ),
+        ))?
         .contains(char::is_whitespace)
     {
         return Err(io::Error::new(

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -87,6 +87,18 @@ fn gen_resolve_file(session: &Session, lalrpop_file: &Path, ext: &str) -> io::Re
         in_dir
     };
 
+    // Ideally we do something like syn::parse_str::<syn::Ident>(lalrpop_file.file_name())?;
+    // But I don't think we want a full blown syn dependency unless fully converting to proc macros.
+    if lalrpop_file
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .contains(char::is_whitespace)
+    {
+        eprintln!("The lalrpop file named `{}` contains whitespace which may make this file difficult to import.", lalrpop_file.display())
+    }
+
     // If the lalrpop file is not in in_dir, the result is that the
     // .rs file is created in the same directory as the lalrpop file
     // for compatibility reasons


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->
Hello. I would like to start addressing some of the issues raised around lalrpop's Configuration settings for setting paths and such. There are a couple relevant issues that I think should be address on the way to a potential 1.0(since they may involve/give the chance to making breaking changes).

Maybe there is a more radical change with configurations that should be made, but I don't have the high level overview to  make that call.

Here are the following issues I would like to address eventually, I'm open to suggestions/feedback. #545 #611 #677 #690 #699 #710 (maybe #539)

So far, this pr adds a little bit of documentation for the rerun directives and looks at identifying ill named Rust modules from file names. The latter would be a warning of the form `eprintln` except that cargo will suppress these as long as the build doesn't fail. I think having spaces in the lalrpop file name is rare enough to just raise an error(a potentially breaking change). It does seem that if lalrpop was a proc_macro, it could leverage some of the nightly diagnostics features instead for this purpose.