### PR TITLE
Update SUMMARY.md with conditional compilations page

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -21,5 +21,6 @@
   - [Using an external library](lexer_tutorial/005_external_lib.md)
 - [Advanced setup](advanced_setup.md)
   - [Generate in source tree](generate_in_source.md)
+  - [Conditional compilation](conditional-compilation.md)
 -----------
 [Contributors](misc/contributors.md)


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.
-->

I never knew lalrpop had some support for `#[cfg(feature = "cool")]`. It doesn't seem to render on the documentation. I think this is the way to fix it?