### PR TITLE
Bump itertools dep to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 ascii-canvas = { version = "3.0", default_features = false }
 bit-set = { version = "0.5.2", default_features = false }
 ena = { version = "0.14", default_features = false }
-itertools = { version = "0.10", default_features = false, features = ["use_std"] }
+itertools = { version = "0.11", default_features = false, features = ["use_std"] }
 petgraph = { version = "0.6", default_features = false }
 regex = { workspace = true }
 regex-syntax = { workspace = true }


### PR DESCRIPTION
Itertools changelog: https://github.com/rust-itertools/itertools/blob/master/CHANGELOG.md

We don't use any of the functionality with breaking changes.  This is just about getting on the latest version so we keep getting fixes.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->