### PR TITLE
Doc Typo and New Clippy Lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 
 [[package]]
 name = "indexmap"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -218,9 +218,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -16,7 +16,7 @@ lalrpop-util = "0.20.0"
 lalrpop = "0.20.0"
 # If you are supplying your own external lexer you can disable default features so that the
 # built-in lexer feature is not included
-# lalrpop = { version = "0.19.1", default-features = false }
+# lalrpop = { version = "0.20.0", default-features = false }
 ```
 
 Next create a [`build.rs`](https://doc.rust-lang.org/cargo/reference/build-scripts.html) file

--- a/lalrpop/src/lexer/nfa/mod.rs
+++ b/lalrpop/src/lexer/nfa/mod.rs
@@ -37,16 +37,16 @@ pub struct Test {
 
 impl PartialOrd for Test {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        match self.start().cmp(&other.start()) {
-            std::cmp::Ordering::Equal => Some(self.end().cmp(&other.end())),
-            ord => Some(ord),
-        }
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for Test {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
+        match self.start().cmp(&other.start()) {
+            std::cmp::Ordering::Equal => self.end().cmp(&other.end()),
+            ord => ord,
+        }
     }
 }
 

--- a/lalrpop/src/lr1/first/mod.rs
+++ b/lalrpop/src/lr1/first/mod.rs
@@ -23,7 +23,7 @@ impl FirstSets {
             for production in grammar.nonterminals.values().flat_map(|p| &p.productions) {
                 let nt = &production.nonterminal;
                 let lookahead = this.first0(&production.symbols);
-                let first_set = this.map.entry(nt.clone()).or_insert_with(TokenSet::new);
+                let first_set = this.map.entry(nt.clone()).or_default();
                 changed |= first_set.union_with(&lookahead);
             }
         }

--- a/lalrpop/src/lr1/lane_table/table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/table/mod.rs
@@ -55,7 +55,7 @@ impl<'grammar> LaneTable<'grammar> {
     pub fn add_lookahead(&mut self, state: StateIndex, conflict: ConflictIndex, tokens: &TokenSet) {
         self.lookaheads
             .entry((state, conflict))
-            .or_insert_with(TokenSet::new)
+            .or_default()
             .union_with(tokens);
     }
 
@@ -167,13 +167,13 @@ impl<'grammar> Debug for LaneTable<'grammar> {
                     self.lookaheads
                         .get(&(index, ConflictIndex::new(i)))
                         .map(|token_set| format!("{:?}", token_set))
-                        .unwrap_or_else(String::new)
+                        .unwrap_or_default()
                 }))
                 .chain(Some(
                     self.successors
                         .get(&index)
                         .map(|c| format!("{:?}", c))
-                        .unwrap_or_else(String::new),
+                        .unwrap_or_default(),
                 ))
                 .collect()
         });

--- a/lalrpop/src/tok/test.rs
+++ b/lalrpop/src/tok/test.rs
@@ -597,6 +597,7 @@ fn where1() {
 }
 
 #[test]
+#[allow(clippy::needless_raw_string_hashes)]
 fn regex1() {
     test(
         r###"raa r##" #"#"" "#"##rrr"###,


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.
-->

- A typo in the docs around lalrpop version for commented out alternative
- A slightly more "stylistic" implementation of PartialOrd/Ord for Test(Avoiding an unwrap)
- Use a bunch of `.*_default()`