### PR TITLE
add 'unicode' to tutorial import

### DIFF
--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -34,7 +34,7 @@ edition = "2021"
 lalrpop = "0.20.0"
 
 [dependencies]
-lalrpop-util = { version = "0.20.0", features = ["lexer"] }
+lalrpop-util = { version = "0.20.0", features = ["lexer", "unicode"] }
 ```
 
 Cargo can run [build scripts] as a pre-processing step,


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

As addressed in issue #750 the regex breaks the build. In this case the current [tutorial](https://lalrpop.github.io/lalrpop/tutorial/001_adding_lalrpop.html) does not import unicode which causes the very first example form the tutorial to fail with the error. 

```
called 'Result::unwrap()' on an 'Err' value: Syntax(
regex parse error:
    ^(\s*)
      ^^
error: Unicode-aware Perl class not found (make sure the unicode-perl feature is enabled)
)
```


This is all because the unicode ~crate~ feature is not imported in the cargo.toml, (like it is in the [source file](https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/Cargo.toml)) adding is there fixes the issue. 