### PR TITLE
Release 0.20.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "calculator"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-test"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "diff",
  "lalrpop",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "regex-automata",
 ]
@@ -525,7 +525,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "whitespace"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "lalrpop",
  "lalrpop-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 repository = "https://github.com/lalrpop/lalrpop"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0 OR MIT"
-version = "0.20.0" # LALRPOP
+version = "0.20.1" # LALRPOP
 edition = "2021"
 # This is (very) soft limit of the minimum supported version.
 # Please update it when lalrpop requires a new feature.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,22 @@
+<a name="0.20.1"></a>
+## 0.20.1 (2023-10-**)
+
+#### Features
+
+* Dangling symlinks in crate no longer cause build failure (thanks to legeana for the report!)
+* Lalrpop now uses the ascii-aware space regex when the unicode feature is not enabled (thanks to QuarticCat!)
+* Lalrpop no longer depends on the `is-terminal` crate (thanks to Kmeakin!)
+* Better performance with the default lexer using the underlying `regex-automata` crate (thanks to QuarticCat!)
+* Allow the catch-all `_` case for token matching can now be set to a higher precedence in match (thanks to fpoli!)
+* Fewer clippy lints triggered in generated code
+
+#### Compatibility note
+
+* MSRV increased to `1.70` in accordance to the MSRV policy.
+* `process_root_unconditionally` now correctly lints as having been deprecated.
+* Internal types which lead with a `__` and should not be relied upon are no longer publicly exposed (thanks to arnaudgolfouse!)
+* Lalrpop files containing a space in their name now return an error.
+
 <a name="0.20.0"></a>
 ## 0.20.0 (2023-05-02)
 
@@ -67,7 +86,7 @@ This release fixes an incompatibility with regex.
 
 This release addresses backwards compatibility warnings and security alerts, along with a few smaller features.
 
-Special thanks to our newest maintainers, Yann Hamdaoui and YunWon Jeong for helping to coordinate this release. 
+Special thanks to our newest maintainers, Yann Hamdaoui and YunWon Jeong for helping to coordinate this release.
 
 #### Features
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,16 +3,19 @@
 
 #### Features
 
-* Dangling symlinks in crate no longer cause build failure (thanks to legeana for the report!)
-* Lalrpop now uses the ascii-aware space regex when the unicode feature is not enabled (thanks to QuarticCat!)
 * Lalrpop no longer depends on the `is-terminal` crate (thanks to Kmeakin!)
 * Better performance with the default lexer using the underlying `regex-automata` crate (thanks to QuarticCat!)
 * Allow the catch-all `_` case for token matching can now be set to a higher precedence in match (thanks to fpoli!)
 * Fewer clippy lints triggered in generated code
 
+#### Bugfixes
+
+* Lalrpop now uses the ascii-aware space regex when the unicode feature is not enabled (thanks to QuarticCat!)
+* Dangling symlinks in crate no longer cause build failure (thanks to legeana for the report!)
+
 #### Compatibility note
 
-* MSRV increased to `1.70` in accordance to the MSRV policy.
+* MSRV increased to `1.70`.
 * `process_root_unconditionally` now correctly lints as having been deprecated.
 * Internal types which lead with a `__` and should not be relied upon are no longer publicly exposed (thanks to arnaudgolfouse!)
 * Lalrpop files containing a space in their name now return an error.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,8 @@
 <a name="0.20.1"></a>
 ## 0.20.1 (2023-10-**)
 
+Special thanks to our newest maintainers, Daniel Burgener and Patrick LaFontaine for helping to coordinate this release.
+
 #### Features
 
 * Lalrpop no longer depends on the `is-terminal` crate (thanks to Kmeakin!)

--- a/doc/calculator/Cargo.toml
+++ b/doc/calculator/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "calculator"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 workspace = "../.." # <-- We added this and everything after!
 edition = "2021"
 
 [build-dependencies]
-lalrpop = { version = "0.20.0", path = "../../lalrpop" }
+lalrpop = { version = "0.20.1", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.20.0", path = "../../lalrpop-util", features = ["lexer", "unicode"] }
+lalrpop-util = { version = "0.20.1", path = "../../lalrpop-util", features = ["lexer", "unicode"] }

--- a/doc/nobol/Cargo.toml
+++ b/doc/nobol/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Felix S Klock II <pnkfelix@pnkfx.org>"]
 workspace = "../.." # <-- We added this and everything after!
 
 [build-dependencies]
-lalrpop = { version = "0.20.0", path = "../../lalrpop" }
+lalrpop = { version = "0.20.1", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.20.0", path = "../../lalrpop-util", features = ["lexer", "unicode"] }
+lalrpop-util = { version = "0.20.1", path = "../../lalrpop-util", features = ["lexer", "unicode"] }

--- a/doc/pascal/lalrpop/Cargo.toml
+++ b/doc/pascal/lalrpop/Cargo.toml
@@ -5,12 +5,12 @@ authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2021"
 
 [build-dependencies]
-lalrpop = { version = "0.20.0", path = "../../../lalrpop" }
+lalrpop = { version = "0.20.1", path = "../../../lalrpop" }
 
 [dependencies]
 pico-args = "0.5"
 
 [dependencies.lalrpop-util]
-version = "0.20.0"
+version = "0.20.1"
 path = "../../../lalrpop-util"
 features = ["lexer"]

--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -9,14 +9,14 @@ the following lines to your `Cargo.toml`:
 ```toml
 # The generated code depends on lalrpop-util.
 [dependencies]
-lalrpop-util = "0.20.0"
+lalrpop-util = "0.20.1"
 
 # Add a build-time dependency on the lalrpop library:
 [build-dependencies]
-lalrpop = "0.20.0"
+lalrpop = "0.20.1"
 # If you are supplying your own external lexer you can disable default features so that the
 # built-in lexer feature is not included
-# lalrpop = { version = "0.20.0", default-features = false }
+# lalrpop = { version = "0.20.1", default-features = false }
 ```
 
 Next create a [`build.rs`](https://doc.rust-lang.org/cargo/reference/build-scripts.html) file

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -31,10 +31,10 @@ authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2021"
 
 [build-dependencies] # <-- We added this and everything after!
-lalrpop = "0.20.0"
+lalrpop = "0.20.1"
 
 [dependencies]
-lalrpop-util = { version = "0.20.0", features = ["lexer", "unicode"] }
+lalrpop-util = { version = "0.20.1", features = ["lexer", "unicode"] }
 ```
 
 Cargo can run [build scripts] as a pre-processing step,

--- a/doc/whitespace/Cargo.toml
+++ b/doc/whitespace/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "whitespace"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Mako <jlauve@rsmw.net>"]
 edition = "2021"
 
 [build-dependencies.lalrpop]
-version = "0.20.0"
+version = "0.20.1"
 path = "../../lalrpop"
 
 [dependencies.lalrpop-util]
-version = "0.20.0"
+version = "0.20.1"
 path = "../../lalrpop-util"

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -1,4 +1,4 @@
-// auto-generated: "lalrpop 0.20.0"
+// auto-generated: "lalrpop 0.20.1"
 // sha3: 41f98a6a8c1305d7ef67ac81e1eb4a8b9450d8a01a72a06b1fc8bb7900055a0b
 use string_cache::DefaultAtom as Atom;
 use crate::grammar::parse_tree::*;

--- a/version.sh
+++ b/version.sh
@@ -3,6 +3,8 @@
 # A script to bump the version number on all Cargo.toml files etc in
 # an atomic fashion.
 
+set -e -o pipefail
+
 if [ "$1" == "" ]; then
     echo "Usage: version.sh <new-version-number>"
     exit 1


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.
-->

This is an attempt to "kick-the-tires" on a new release based on https://github.com/orgs/lalrpop/discussions/823.

I did an initial draft of the release notes in `RELEASES.md` and ran `./version.sh` to update the version number in all the places.