### PR TITLE
Only generate unicode tokens if the unicode feature is enabled

### DIFF
--- a/lalrpop/src/lexer/re/mod.rs
+++ b/lalrpop/src/lexer/re/mod.rs
@@ -1,7 +1,7 @@
 //! A parser and representation of regular expressions.
 
 use regex_syntax::hir::Hir;
-use regex_syntax::{self, Error, Parser};
+use regex_syntax::{self, Error, ParserBuilder};
 
 #[cfg(test)]
 mod test;
@@ -19,6 +19,11 @@ pub fn parse_literal(s: &str) -> Regex {
 
 /// Parse a regular expression like `a+` etc.
 pub fn parse_regex(s: &str) -> Result<Regex, RegexError> {
-    let expr = Parser::new().parse(s)?;
+    let enable_unicode = cfg!(feature = "unicode");
+    let expr = ParserBuilder::new()
+        .utf8(enable_unicode)
+        .unicode(enable_unicode)
+        .build()
+        .parse(s)?;
     Ok(expr)
 }


### PR DESCRIPTION
regex_syntax::parse() converts our regex strings into the HIR of the regex, part of that includes unpacking various metacharacters into a list of symbols.  In many cases, this expansion changes depending if it should expand into unicode or not.

Prior to #814, we were still outputting unicode regexes unconditionally, but regex internals seem to be compiling them away and avoiding errors. The switch in #814 caused these to be result in real errors.

Follow-up work will be needed to determine why existing tests didn't detect this.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->