### PR TITLE
Restore test for zero length skip matches

### DIFF
--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -185,6 +185,8 @@ lalrpop_mod_test!(
 );
 mod user_defined_error_visibility;
 
+lalrpop_mod_test!(zero_length_match);
+
 pub fn use_cfg_created_parser() {
     #[cfg(feature = "test-set")]
     cfg::CreatedParser::new();
@@ -1181,4 +1183,10 @@ fn test_nested_pattern_string_error() {
             panic!("Unexpected error: {:?}", err);
         }
     }
+}
+
+#[test]
+fn test_zero_length_match() {
+    let res = zero_length_match::AParser::new().parse("B");
+    assert!(matches!(res, Err(ParseError::InvalidToken { location: _ })));
 }

--- a/lalrpop-test/src/zero_length_match.lalrpop
+++ b/lalrpop-test/src/zero_length_match.lalrpop
@@ -1,0 +1,11 @@
+grammar;
+
+pub A: String = {
+	"A" => "A".to_string()
+};
+
+match {
+	r"\s*" => {}
+} else {
+	_
+}

--- a/lalrpop-util/src/lexer.rs
+++ b/lalrpop-util/src/lexer.rs
@@ -131,6 +131,11 @@ impl<'input, 'builder, E> Iterator for Matcher<'input, 'builder, E> {
             self.consumed = end_offset;
 
             if self.skip_vec[index] {
+                if longest_match == 0 {
+                    return Some(Err(ParseError::InvalidToken {
+                        location: start_offset,
+                    }));
+                }
                 continue;
             }
 


### PR DESCRIPTION
If a zero length skip pattern was the longest match, we were supplied an invalid token.  The current code infinite loops in this state.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->