### PR TITLE
Set unicode as a default feature in lalrpop-util

### DIFF
--- a/lalrpop-util/Cargo.toml
+++ b/lalrpop-util/Cargo.toml
@@ -17,7 +17,7 @@ regex-automata = { workspace = true, optional = true }
 lexer = ["regex-automata/std", "std"]
 unicode = ["regex-automata?/unicode"]
 std = []
-default = ["std"]
+default = ["std", "unicode"]
 
 [package.metadata.docs.rs]
 features = ["lexer"]

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -35,7 +35,7 @@ unicode-xid = { version = "0.2", default_features = false }
 # library, disable it in your project by setting default_features = false.
 pico-args = { version = "0.5", default_features = false, optional = true }
 
-lalrpop-util = { path = "../lalrpop-util", version = "0.20.0" }
+lalrpop-util = { path = "../lalrpop-util", version = "0.20.0", default_features = false }
 
 [dev-dependencies]
 diff = { workspace = true }
@@ -43,7 +43,7 @@ rand = "0.8"
 
 [features]
 default=["lexer", "unicode", "pico-args"]
-unicode = ["regex/unicode", "regex-syntax/unicode"]
+unicode = ["regex/unicode", "regex-syntax/unicode", "lalrpop-util/unicode"]
 lexer = ["lalrpop-util/lexer"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
We get breakage if lalrpop and lalrpop-util are not consistent, but the defaults aren't consistent

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->