### PR TITLE
Traverse into symlinks to dirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "term",
  "tiny-keccak",
  "unicode-xid",
+ "walkdir",
 ]
 
 [[package]]
@@ -424,6 +425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +528,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +566,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -30,6 +30,7 @@ string_cache = { version = "0.8", default_features = false }
 term = { version = "0.7", default_features = false }
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 unicode-xid = { version = "0.2", default_features = false }
+walkdir = "2.4.0"
 
 # This dependency is only needed for binary builds, if you use LALRPOP as
 # library, disable it in your project by setting default_features = false.

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -211,7 +211,7 @@ fn lalrpop_files<P: AsRef<Path>>(root_dir: P) -> io::Result<Vec<PathBuf>> {
 
         let path = entry.path();
 
-        if file_type.is_dir() {
+        if path.is_dir() {
             result.extend(lalrpop_files(&path)?);
         }
 

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -205,6 +205,35 @@ fn needs_rebuild(lalrpop_file: &Path, rs_file: &Path) -> io::Result<bool> {
     }
 }
 
+/// Handles a [walkdir::Error] if the root cause is a dangling symlink.
+///
+/// Returns `Ok` if the error could be handled, otherwise returns `Err(err)`.
+fn handle_dangling_symlink_error(err: walkdir::Error) -> Result<(), walkdir::Error> {
+    let is_not_found = err.io_error().map(|io_err| io_err.kind()) == Some(io::ErrorKind::NotFound);
+    if !is_not_found {
+        return Err(err);
+    }
+
+    // As of now on Linux, this is the path of the symlink (not where it points to) in case of a
+    // dangling symlink:
+    let path = match err.path() {
+        Some(path) => path,
+        None => {
+            return Err(err);
+        }
+    };
+
+    if !path.is_symlink() {
+        return Err(err);
+    }
+
+    eprintln!(
+        "Warning: ignoring dangling/erroneous symlink {}",
+        path.display()
+    );
+    Ok(())
+}
+
 fn lalrpop_files<P: AsRef<Path>>(root_dir: P) -> io::Result<Vec<PathBuf>> {
     let mut result = vec![];
 
@@ -213,7 +242,14 @@ fn lalrpop_files<P: AsRef<Path>>(root_dir: P) -> io::Result<Vec<PathBuf>> {
         // Use deterministic ordering:
         .sort_by_file_name();
     for entry in walkdir {
-        let entry = entry?;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                handle_dangling_symlink_error(err)?;
+                continue;
+            }
+        };
+
         // `file_type` follows symlinks, so if `entry` points to a symlink to a file, then
         // `is_file` returns true.
         if !entry.file_type().is_file() {

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -211,9 +211,7 @@ fn lalrpop_files<P: AsRef<Path>>(root_dir: P) -> io::Result<Vec<PathBuf>> {
     let walkdir = WalkDir::new(root_dir)
         .follow_links(true)
         // Use deterministic ordering:
-        .sort_by_file_name()
-        // Prevent loops:
-        .same_file_system(true);
+        .sort_by_file_name();
     for entry in walkdir {
         let entry = entry?;
         // `file_type` follows symlinks, so if `entry` points to a symlink to a file, then


### PR DESCRIPTION
The lalrpop_files function traverses recursively into subdirectories of the provided root directory and returns all .lalrpop files. However, lalrpop_files used to skip symlinks to directories because it used the DirEntry::file_type method to detect directories, which doesn't follow symlinks. Since lalrpop_files does follow symlinks to files, this old behavior for symlinks was inconsistent and unintuitive.

With this commit, we're now using the Path::is_dir method, which does follow symlinks, so now lalrpop_files traverses also into symlinks to directories.