### PR TITLE
Fix #593, remove snap.sh

### DIFF
--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -1109,7 +1109,7 @@ fn verify_lalrpop_generates_itself() {
         &actual,
         &expected,
         "The snapshot does not match what lalrpop generates now.\n\
-         Use ./snap.sh to generate a new snapshot of the lrgrammar",
+         Use ./update_lrgrammar.sh to generate a new snapshot of the lrgrammar",
     );
 }
 

--- a/snap.sh
+++ b/snap.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-cargo run -p lalrpop -- --force --no-whitespace --out-dir . lalrpop/src/parser/lrgrammar.lalrpop

--- a/version.sh
+++ b/version.sh
@@ -36,4 +36,4 @@ perl -p -i -e 's/version *= *"'$VERSION'"/version = "'$1'"/' \
 perl -p -i -e 's/^lalrpop([\-a-z]*) *= *"[0-9.]+"/lalrpop\1 = "'$1'"/' \
     doc/src/quick_start_guide.md doc/src/tutorial/001_adding_lalrpop.md
 
-./snap.sh
+./update_lrgrammar.sh


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

As in #593 it seems like lalrpop has two shell scripts that do the same thing, so lets simplify that.