### PR TITLE
Add symlinks to license files

### DIFF
--- a/lalrpop-util/LICENSE-APACHE
+++ b/lalrpop-util/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/lalrpop-util/LICENSE-MIT
+++ b/lalrpop-util/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/lalrpop/LICENSE-APACHE
+++ b/lalrpop/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/lalrpop/LICENSE-MIT
+++ b/lalrpop/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

Closes #600 

I don't fully understand the license implications here but from my reading, the correct solution from cargo has not fully manifested yet. In looking what other projects like tokio/regex do, they include the license files in each project so it seems reasonable to follow that strategy.

See https://github.com/bytecodealliance/wasmtime/pull/4664 https://github.com/tokio-rs/tracing/pull/842 https://github.com/rust-lang/cargo/issues/8537 for some discussion on these issues.