### PR TITLE
Minor cleanup

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -10,7 +10,7 @@ jobs:
   lint-book:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
           - rust: stable
             cargo-update: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -38,7 +38,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
@@ -50,7 +50,7 @@ jobs:
   min_version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
@@ -63,7 +63,7 @@ jobs:
     env:
       CARGO_INCREMENTAL: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
             toolchain: stable

--- a/lalrpop/src/lr1/mod.rs
+++ b/lalrpop/src/lr1/mod.rs
@@ -20,7 +20,7 @@ use std::io::{self, Write};
 #[cfg(test)]
 mod interpret;
 
-pub use self::core::{Lr1Result, Lr1TableConstructionError};
+pub use self::core::Lr1Result;
 pub use self::error::report_error;
 pub use self::tls::Lr1Tls;
 

--- a/lalrpop/src/util.rs
+++ b/lalrpop/src/util.rs
@@ -1,6 +1,5 @@
 use std::fmt::{Display, Error, Formatter};
 
-pub use std::collections::btree_map as map;
 pub struct Sep<S>(pub &'static str, pub S);
 
 impl<'a, S: Display> Display for Sep<&'a Vec<S>> {


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

- Removes 2 unused imports
- Upgrades to `actions/checkout@v4`