### PR TITLE
Consistent LALR docs and clippy

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -418,7 +418,7 @@ Thanks to the following contributors for this release:
 - We now support `#![..]` attributes in `.lalrpop` files.
 - We now use lane table by default: since the lane table algorithm
   automatically generates compressed tables where possible, the
-  `#[lalr]` attribute is still accepted, but has no effect.
+  `#[LALR]` attribute is still accepted, but has no effect.
   - If you encounter problems, please report bugs! In the meantime,
     though, you can use the `LALRPOP_LANE_TABLE=disabled` environment
     variable to change back.

--- a/doc/src/advanced_setup.md
+++ b/doc/src/advanced_setup.md
@@ -54,5 +54,5 @@ available.
 
 To enable it, build with the `LALRPOP_LANE_TABLE=disabled` environment
 variable by setting `std::env::set_var` in your `build.rs` and add the
-`#[lalr]` attribute above the `grammar;` declaration in your lalrpop grammar
+`#[LALR]` attribute above the `grammar;` declaration in your lalrpop grammar
 file.

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -498,6 +498,7 @@ fn emit_recursive_ascent(
             )?,
         }
 
+        rust!(rust, "#[allow(unused_imports)]");
         rust!(
             rust,
             "{}use self::{}parse{}::{}Parser;",

--- a/lalrpop/src/lr1/build_lalr/mod.rs
+++ b/lalrpop/src/lr1/build_lalr/mod.rs
@@ -30,7 +30,7 @@ pub fn build_lalr_states(grammar: &Grammar, start: NonterminalString) -> Lr1Resu
     // for LALR. In fact, LALR is pointless!
     if build::use_lane_table() {
         println!("Warning: Now that the new lane-table algorithm is the default,");
-        println!("         #[lalr] mode has no effect and can be removed.");
+        println!("         #[LALR] mode has no effect and can be removed.");
         return Ok(lr_states);
     }
 

--- a/lalrpop/src/normalize/precedence/mod.rs
+++ b/lalrpop/src/normalize/precedence/mod.rs
@@ -70,6 +70,7 @@ pub const SIDE_ARG: &str = "side";
 /// An associative rule means that all recursive occurrences are replaced with the current level,
 /// which is different from non-associativity. This can be useful for unary operators that may be
 /// iterated, such as `-` or `!`, or non ambiguous operators. This is the default associativity.
+#[allow(clippy::enum_variant_names)]
 #[derive(Clone, Copy, Eq, PartialEq, Default)]
 pub enum Assoc {
     Left,

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -18822,6 +18822,7 @@ ___symbols.push((___start, ___Symbol::Variant95(___nt), ___end));
 (0, 165)
 }
 }
+#[allow(unused_imports)]
 pub use self::___parse___Top::TopParser;
 
 #[allow(unused_variables)]

--- a/lalrpop/src/parser/test.rs
+++ b/lalrpop/src/parser/test.rs
@@ -48,9 +48,9 @@ fn match_complex() {
     match *first_item {
         GrammarItem::MatchToken(ref data) => {
             // match { ... }
-            let contents0 = data.contents.get(0).unwrap();
+            let contents0 = data.contents.first().unwrap();
             // r"(?i)begin" => "BEGIN"
-            let item00 = contents0.items.get(0).unwrap();
+            let item00 = contents0.items.first().unwrap();
             match *item00 {
                 MatchItem::Mapped(ref sym, ref mapping, _) => {
                     assert_eq!(format!("{:?}", sym), "r#\"(?i)begin\"#");
@@ -70,7 +70,7 @@ fn match_complex() {
             // else { ... }
             let contents1 = data.contents.get(1).unwrap();
             // r"[a-zA-Z_][a-zA-Z0-9_]*" => IDENTIFIER,
-            let item10 = contents1.items.get(0).unwrap();
+            let item10 = contents1.items.first().unwrap();
             match *item10 {
                 MatchItem::Mapped(ref sym, ref mapping, _) => {
                     assert_eq!(format!("{:?}", sym), "r#\"[a-zA-Z_][a-zA-Z0-9_]*\"#");
@@ -81,7 +81,7 @@ fn match_complex() {
             // else { ... }
             let contents2 = data.contents.get(2).unwrap();
             // "other",
-            let item20 = contents2.items.get(0).unwrap();
+            let item20 = contents2.items.first().unwrap();
             match *item20 {
                 MatchItem::Unmapped(ref sym, _) => {
                     assert_eq!(format!("{:?}", sym), "\"other\"");


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.
-->

Addresses the documentation confusion with #862 and some of the new clippy lints.