### PR TITLE
<= Rust 1.76 lints

### DIFF
--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -520,7 +520,7 @@ fn emit_recursive_ascent(
 
     action::emit_action_code(grammar, &mut rust)?;
 
-    rust!(rust, "#[allow(clippy::type_complexity)]");
+    rust!(rust, "#[allow(clippy::type_complexity, dead_code)]");
     emit_to_triple_trait(grammar, max_start_nt_visibility, &mut rust)?;
 
     Ok(rust.into_inner())

--- a/lalrpop/src/lr1/lane_table/table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/table/mod.rs
@@ -121,11 +121,11 @@ impl<'grammar> LaneTable<'grammar> {
                 "rows: inserting state_index={:?} conflict_index={:?} token_set={:?}",
                 state_index, conflict_index, token_set
             );
-            match {
-                map.entry(state_index)
-                    .or_insert_with(|| ContextSet::new(self.conflicts))
-                    .insert(conflict_index, token_set)
-            } {
+            match map
+                .entry(state_index)
+                .or_insert_with(|| ContextSet::new(self.conflicts))
+                .insert(conflict_index, token_set)
+            {
                 Ok(_changed) => {}
                 Err(OverlappingLookahead) => {
                     debug!("rows: intra-row conflict inserting state_index={:?} conflict_index={:?} token_set={:?}",

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -38557,7 +38557,7 @@ ___4,
 ___5,
 )
 }
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, dead_code)]
 
 pub  trait ___ToTriple<'input, >
 {


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->