### PR TITLE
Kick the tires on a documentation cheatsheet

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -3,6 +3,7 @@
 - [LALRPOP](README.md)
 - [Crash course on parsers](crash_course.md)
 - [Quick start guide](quick_start_guide.md)
+- [Cheatsheet](cheatsheet.md)
 - [Tutorial](tutorial/index.md)
   - [Adding LALRPOP to your project](tutorial/001_adding_lalrpop.md)
   - [Parsing parenthesized numbers](tutorial/002_paren_numbers.md)

--- a/doc/src/cheatsheet.md
+++ b/doc/src/cheatsheet.md
@@ -10,7 +10,7 @@ functionality, use this table to jump to the right section.
 | error_recovery | `! => { ... }` | recovers from parser errors | [Error recovery](tutorial/008_error_recovery.md) |
 | grammar_parameter | `grammar(scale: isize);` | input parameters usable in the generated parser | [Passing state parameter](tutorial/009_state_parameter.md) |
 | ?? | `Num => func(<i32>)` | maybe automatic number parsing?? | - |
-| custom_error | `"e" =>? ParseError::User { error: "an error" }` | make an action failable | [Fallible actions](tutorial/007_fallible_actions.md) |
+| custom_error | `"e" =>? Err(ParseError::User { error: "an error" })` | makes an action fallible | [Fallible actions](tutorial/007_fallible_actions.md) |
 | custom_macros | `Comma<T> =  { ... }` | allows a non-terminal to be generic about some parameters | [Macros](tutorial/006_macros.md) |
 | quantifier_macros | `<Num?> <Num*> <Num+>` |  a non-terminal which can appear 0..1, 0+, 1+ times | [Macros](tutorial/006_macros.md) |
 | tuple_macro | `<a:(<Num> ",")*>` | when used with a qunatifier allows crating lists | [Macros](tutorial/006_macros.md) |

--- a/doc/src/cheatsheet.md
+++ b/doc/src/cheatsheet.md
@@ -18,6 +18,6 @@ functionality, use this table to jump to the right section.
 | extern_error | `type Error = MyError;` | sets the error to use in the `ParseError::User` variant | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
 | extern_location | `type Location = MyLoc;` | sets the type to for locations instead of `usize` | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
 | extern_tok | `enum MyToken { }` | declares the type of lexer tokens to be consumed by the generated parser  | [Using tokens with references](lexer_tutorial/004_token_references.md) |
-| auto_parameters | `<>` | in an action it turns into a list of parameters | [Type inference](tutorial/003_type_inference.md) |
+| auto_parameters | `<>` | refers to all the parameters of the non-terminal as a tuple | [Type inference](tutorial/003_type_inference.md) |
 |conditional actions | `<T> if T == "a" => (),` | - | - |
 |precedence| `#[precedence(level="0")]` | - | [Handling full expressions](tutorial/004_full_expressions.md) |

--- a/doc/src/cheatsheet.md
+++ b/doc/src/cheatsheet.md
@@ -17,7 +17,7 @@ functionality, use this table to jump to the right section.
 | extern | `extern { }` | allows to override some parts of the generated parser | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
 | extern_error | `type Error = MyError;` | sets the error to use in the `ParseError::User` variant | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
 | extern_location | `type Location = MyLoc;` | sets the type to for locations instead of `usize` | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
-| extern_tok | `enum Tok { }` | set the type to use for tokens?? | [Using tokens with references](lexer_tutorial/004_token_references.md) |
+| extern_tok | `enum MyToken { }` | declares the type of lexer tokens to be consumed by the generated parser  | [Using tokens with references](lexer_tutorial/004_token_references.md) |
 | auto_parameters | `<>` | in an action it turns into a list of parameters | [Type inference](tutorial/003_type_inference.md) |
 |conditional actions | `<T> if T == "a" => (),` | - | - |
 |precedence| `#[precedence(level="0")]` | - | [Handling full expressions](tutorial/004_full_expressions.md) |

--- a/doc/src/cheatsheet.md
+++ b/doc/src/cheatsheet.md
@@ -13,7 +13,7 @@ functionality, use this table to jump to the right section.
 | custom_error | `"e" =>? Err(ParseError::User { error: "an error" })` | makes an action fallible | [Fallible actions](tutorial/007_fallible_actions.md) |
 | custom_macros | `Comma<T> =  { ... }` | allows a non-terminal to be generic about some parameters | [Macros](tutorial/006_macros.md) |
 | quantifier_macros | `<Num?> <Num*> <Num+>` |  a non-terminal which can appear 0..1, 0+, 1+ times | [Macros](tutorial/006_macros.md) |
-| tuple_macro | `<a:(<Num> ",")*>` | when used with a qunatifier allows crating lists | [Macros](tutorial/006_macros.md) |
+| tuple_macro | `<a:(<Num> ",")*>` | applies a quantifier to a group of matches | [Macros](tutorial/006_macros.md) |
 | extern | `extern { }` | allows to override some parts of the generated parser | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
 | extern_error | `type Error = MyError;` | sets the error to use in the `ParseError::User` variant | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
 | extern_location | `type Location = MyLoc;` | sets the type to for locations instead of `usize` | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |

--- a/doc/src/cheatsheet.md
+++ b/doc/src/cheatsheet.md
@@ -20,4 +20,4 @@ functionality, use this table to jump to the right section.
 | extern_tok | `enum MyToken { }` | declares the type of lexer tokens to be consumed by the generated parser  | [Using tokens with references](lexer_tutorial/004_token_references.md) |
 | auto_parameters | `<>` | refers to all the parameters of the non-terminal as a tuple | [Type inference](tutorial/003_type_inference.md) |
 |conditional actions | `Expr<I> = { ... , <T> if I == "a" => (), ...}` | Conditional definition of a macro's alternative | [index pointer](tutorial/index.md) |
-|precedence| `#[precedence(level="0")]` | - | [Handling full expressions](tutorial/004_full_expressions.md) |
+|precedence| `#[precedence(level="0")]` | creates a hierarchy to parser actions for which ones should be applied first | [Handling full expressions](tutorial/004_full_expressions.md) |

--- a/doc/src/cheatsheet.md
+++ b/doc/src/cheatsheet.md
@@ -4,7 +4,7 @@ Users of Lalrpop has compiled the following cheatsheet table as a quick way to
 look up useful Lalrpop-isms. If you are looking for a specific piece of
 functionality, use this table to jump to the right section.
 
-| name | snipped | description | tutorial |
+| name | snippet | description | tutorial |
 |---|---|---|---|
 | position | `<@L> T <@R>` | uhm, I think it gives the index of the parser in the input | - |
 | error_recovery | `! => { ... }` | recovers from parser errors | [Error recovery](tutorial/008_error_recovery.md) |

--- a/doc/src/cheatsheet.md
+++ b/doc/src/cheatsheet.md
@@ -16,7 +16,7 @@ functionality, use this table to jump to the right section.
 | tuple_macro | `<a:(<Num> ",")*>` | when used with a qunatifier allows crating lists | [Macros](tutorial/006_macros.md) |
 | extern | `extern { }` | allows to override some parts of the generated parser | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
 | extern_error | `type Error = MyError;` | sets the error to use in the `ParseError::User` variant | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
-| extern_location | `type Location = MyLoc;` | set the type to for locations instead of `usize` | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
+| extern_location | `type Location = MyLoc;` | sets the type to for locations instead of `usize` | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
 | extern_tok | `enum Tok { }` | set the type to use for tokens?? | [Using tokens with references](lexer_tutorial/004_token_references.md) |
 | auto_parameters | `<>` | in an action it turns into a list of parameters | [Type inference](tutorial/003_type_inference.md) |
 |conditional actions | `<T> if T == "a" => (),` | - | - |

--- a/doc/src/cheatsheet.md
+++ b/doc/src/cheatsheet.md
@@ -11,7 +11,7 @@ functionality, use this table to jump to the right section.
 | grammar_parameter | `grammar(scale: isize);` | input parameters usable in the generated parser | [Passing state parameter](tutorial/009_state_parameter.md) |
 | ?? | `Num => func(<i32>)` | maybe automatic number parsing?? | - |
 | custom_error | `"e" =>? Err(ParseError::User { error: "an error" })` | makes an action fallible | [Fallible actions](tutorial/007_fallible_actions.md) |
-| custom_macros | `Comma<T> =  { ... }` | allows a non-terminal to be generic about some parameters | [Macros](tutorial/006_macros.md) |
+| custom_macros | `Comma<T> =  { ... }` | makes a non-terminal generic in other non-terminals | [Macros](tutorial/006_macros.md) |
 | quantifier_macros | `<Num?> <Num*> <Num+>` |  a non-terminal which can appear 0..1, 0+, 1+ times | [Macros](tutorial/006_macros.md) |
 | tuple_macro | `<a:(<Num> ",")*>` | applies a quantifier to a group of matches | [Macros](tutorial/006_macros.md) |
 | extern | `extern { }` | allows to override some parts of the generated parser | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |

--- a/doc/src/cheatsheet.md
+++ b/doc/src/cheatsheet.md
@@ -7,7 +7,7 @@ functionality, use this table to jump to the right section.
 | name | snipped | description | tutorial |
 |---|---|---|---|
 | position | `<@L> T <@R>` | uhm, I think it gives the index of the parser in the input | - |
-| error_recovery | `! => { ... }` | recover from parser errors | [Error recovery](tutorial/008_error_recovery.md) |
+| error_recovery | `! => { ... }` | recovers from parser errors | [Error recovery](tutorial/008_error_recovery.md) |
 | grammar_parameter | `grammar(scale: isize);` | input parameters usable in the generated parser | [Passing state parameter](tutorial/009_state_parameter.md) |
 | ?? | `Num => func(<i32>)` | maybe automatic number parsing?? | - |
 | custom_error | `"e" =>? ParseError::User { error: "an error" }` | make an action failable | [Fallible actions](tutorial/007_fallible_actions.md) |

--- a/doc/src/cheatsheet.md
+++ b/doc/src/cheatsheet.md
@@ -6,7 +6,7 @@ functionality, use this table to jump to the right section.
 
 | name | snippet | description | tutorial |
 |---|---|---|---|
-| position | `<left: @L> T <right: @R>` | captures the offset of the first byte and the offset of the last byte plus one (as `left` and `right` respectively) | - |
+| position | `<left: @L> T <right: @R>` | captures the offset of the first byte and the offset of the last byte plus one (as `left` and `right` respectively) | [index pointer](tutorial/index.md) |
 | error_recovery | `! => { ... }` | recovers from parser errors | [Error recovery](tutorial/008_error_recovery.md) |
 | grammar_parameter | `grammar(scale: isize);` | input parameters usable in the generated parser | [Passing state parameter](tutorial/009_state_parameter.md) |
 | ?? | `Num => func(<i32>)` | maybe automatic number parsing?? | - |
@@ -19,5 +19,5 @@ functionality, use this table to jump to the right section.
 | extern_location | `type Location = MyLoc;` | sets the type to for locations instead of `usize` | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
 | extern_tok | `enum MyToken { }` | declares the type of lexer tokens to be consumed by the generated parser  | [Using tokens with references](lexer_tutorial/004_token_references.md) |
 | auto_parameters | `<>` | refers to all the parameters of the non-terminal as a tuple | [Type inference](tutorial/003_type_inference.md) |
-|conditional actions | `<T> if T == "a" => (),` | - | - |
+|conditional actions | `<T> if T == "a" => (),` | - | [index pointer](tutorial/index.md) |
 |precedence| `#[precedence(level="0")]` | - | [Handling full expressions](tutorial/004_full_expressions.md) |

--- a/doc/src/cheatsheet.md
+++ b/doc/src/cheatsheet.md
@@ -1,0 +1,23 @@
+# Cheatsheet
+
+Users of Lalrpop has compiled the following cheatsheet table as a quick way to
+look up useful Lalrpop-isms. If you are looking for a specific piece of
+functionality, use this table to jump to the right section.
+
+| name | snipped | description | tutorial |
+|---|---|---|---|
+| position | `<@L> T <@R>` | uhm, I think it gives the index of the parser in the input | - |
+| error_recovery | `! => { ... }` | recover from parser errors | [Error recovery](tutorial/008_error_recovery.md) |
+| grammar_parameter | `grammar(scale: isize);` | input parameters usable in the generated parser | [Passing state parameter](tutorial/009_state_parameter.md) |
+| ?? | `Num => func(<i32>)` | maybe automatic number parsing?? | - |
+| custom_error | `"e" =>? ParseError::User { error: "an error" }` | make an action failable | [Fallible actions](tutorial/007_fallible_actions.md) |
+| custom_macros | `Comma<T> =  { ... }` | allows a non-terminal to be generic about some parameters | [Macros](tutorial/006_macros.md) |
+| quantifier_macros | `<Num?> <Num*> <Num+>` |  a non-terminal which can appear 0..1, 0+, 1+ times | [Macros](tutorial/006_macros.md) |
+| tuple_macro | `<a:(<Num> ",")*>` | when used with a qunatifier allows crating lists | [Macros](tutorial/006_macros.md) |
+| extern | `extern { }` | allows to override some parts of the generated parser | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
+| extern_error | `type Error = MyError;` | sets the error to use in the `ParseError::User` variant | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
+| extern_location | `type Location = MyLoc;` | set the type to for locations instead of `usize` | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
+| extern_tok | `enum Tok { }` | set the type to use for tokens?? | [Using tokens with references](lexer_tutorial/004_token_references.md) |
+| auto_parameters | `<>` | in an action it turns into a list of parameters | [Type inference](tutorial/003_type_inference.md) |
+|conditional actions | `<T> if T == "a" => (),` | - | - |
+|precedence| `#[precedence(level="0")]` | - | [Handling full expressions](tutorial/004_full_expressions.md) |

--- a/doc/src/cheatsheet.md
+++ b/doc/src/cheatsheet.md
@@ -19,5 +19,5 @@ functionality, use this table to jump to the right section.
 | extern_location | `type Location = MyLoc;` | sets the type to for locations instead of `usize` | [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md) |
 | extern_tok | `enum MyToken { }` | declares the type of lexer tokens to be consumed by the generated parser  | [Using tokens with references](lexer_tutorial/004_token_references.md) |
 | auto_parameters | `<>` | refers to all the parameters of the non-terminal as a tuple | [Type inference](tutorial/003_type_inference.md) |
-|conditional actions | `<T> if T == "a" => (),` | - | [index pointer](tutorial/index.md) |
+|conditional actions | `Expr<I> = { ... , <T> if I == "a" => (), ...}` | Conditional definition of a macro's alternative | [index pointer](tutorial/index.md) |
 |precedence| `#[precedence(level="0")]` | - | [Handling full expressions](tutorial/004_full_expressions.md) |

--- a/doc/src/cheatsheet.md
+++ b/doc/src/cheatsheet.md
@@ -6,7 +6,7 @@ functionality, use this table to jump to the right section.
 
 | name | snippet | description | tutorial |
 |---|---|---|---|
-| position | `<@L> T <@R>` | uhm, I think it gives the index of the parser in the input | - |
+| position | `<left: @L> T <right: @R>` | captures the offset of the first byte and the offset of the last byte plus one (as `left` and `right` respectively) | - |
 | error_recovery | `! => { ... }` | recovers from parser errors | [Error recovery](tutorial/008_error_recovery.md) |
 | grammar_parameter | `grammar(scale: isize);` | input parameters usable in the generated parser | [Passing state parameter](tutorial/009_state_parameter.md) |
 | ?? | `Num => func(<i32>)` | maybe automatic number parsing?? | - |

--- a/doc/src/cheatsheet.md
+++ b/doc/src/cheatsheet.md
@@ -9,7 +9,6 @@ functionality, use this table to jump to the right section.
 | position | `<left: @L> T <right: @R>` | captures the offset of the first byte and the offset of the last byte plus one (as `left` and `right` respectively) | [index pointer](tutorial/index.md) |
 | error_recovery | `! => { ... }` | recovers from parser errors | [Error recovery](tutorial/008_error_recovery.md) |
 | grammar_parameter | `grammar(scale: isize);` | input parameters usable in the generated parser | [Passing state parameter](tutorial/009_state_parameter.md) |
-| ?? | `Num => func(<i32>)` | maybe automatic number parsing?? | - |
 | custom_error | `"e" =>? Err(ParseError::User { error: "an error" })` | makes an action fallible | [Fallible actions](tutorial/007_fallible_actions.md) |
 | custom_macros | `Comma<T> =  { ... }` | makes a non-terminal generic in other non-terminals | [Macros](tutorial/006_macros.md) |
 | quantifier_macros | `<Num?> <Num*> <Num+>` |  a non-terminal which can appear 0..1, 0+, 1+ times | [Macros](tutorial/006_macros.md) |

--- a/doc/src/cheatsheet.md
+++ b/doc/src/cheatsheet.md
@@ -1,6 +1,6 @@
 # Cheatsheet
 
-Users of Lalrpop has compiled the following cheatsheet table as a quick way to
+Users of Lalrpop have compiled the following cheatsheet table as a quick way to
 look up useful Lalrpop-isms. If you are looking for a specific piece of
 functionality, use this table to jump to the right section.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.
-->

I think the idea of a feature list "cheatsheet" is a great idea as suggested in #387. I've done a pretty minimal adaptation of the table elements suggested in that list with their corresponding links.

I don't have a clear idea of the right way to present this, so open to all suggestions.