### PR TITLE
First step to add a lexer example in tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +208,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lexer"
+version = "0.1.0"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "logos",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +243,39 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "logos"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161971eb88a0da7ae0c333e1063467c5b5727e7fb6b710b8db4814eade3a42e8"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e31badd9de5131fdf4921f6473d457e3dd85b11b7f091ceb50e4df7c3eeb12a"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2a69b3eb68d5bd595107c9ee58d7e07fe2bb5e360cc85b0f084dedac80de0a"
+dependencies = [
+ "logos-codegen",
+]
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
         "doc/nobol",
         "doc/pascal/lalrpop",
         "doc/whitespace",
+        "doc/lexer",
         "lalrpop-test",
         "lalrpop-util",
         "lalrpop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rust-version = "1.70"
 [workspace.dependencies]
 diff = { version = "0.1.12", default_features = false }
 regex = { version = "1.3", default_features = false, features = ["std"] }
-regex-syntax = { version = "0.8", default_features = false }
+regex-syntax = { version = "0.8.2", default_features = false }
 regex-automata = { version = "0.4", default_features = false, features = [
         "perf",
         "syntax",

--- a/doc/lexer/Cargo.toml
+++ b/doc/lexer/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "lexer"
+version = "0.1.0"
+edition = "2021"
+authors = ["Patrick LaFontaine <32135464+Pat-Lafon@users.noreply.github.com>"]
+
+[build-dependencies]
+lalrpop = { version = "0.20.2", path = "../../lalrpop" }
+
+[dependencies]
+lalrpop-util = { version = "0.20.2", path = "../../lalrpop-util", features = [
+    "lexer",
+    "unicode",
+] }
+logos = "0.14.0"

--- a/doc/lexer/Cargo.toml
+++ b/doc/lexer/Cargo.toml
@@ -9,7 +9,6 @@ lalrpop = { version = "0.20.2", path = "../../lalrpop" }
 
 [dependencies]
 lalrpop-util = { version = "0.20.2", path = "../../lalrpop-util", features = [
-    "lexer",
     "unicode",
 ] }
 logos = "0.14.0"

--- a/doc/lexer/build.rs
+++ b/doc/lexer/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    lalrpop::process_root().unwrap();
+}

--- a/doc/lexer/src/ast.rs
+++ b/doc/lexer/src/ast.rs
@@ -1,0 +1,29 @@
+#[derive(Clone, Debug, PartialEq)]
+pub enum Statement {
+    Variable {
+        name: String,
+        value: Box<Expression>,
+    },
+    Print {
+        value: Box<Expression>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Expression {
+    Integer(i64),
+    Variable(String),
+    BinaryOperation {
+        lhs: Box<Expression>,
+        operator: Operator,
+        rhs: Box<Expression>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Operator {
+    Add,
+    Sub,
+    Mul,
+    Div,
+}

--- a/doc/lexer/src/grammar.lalrpop
+++ b/doc/lexer/src/grammar.lalrpop
@@ -26,16 +26,16 @@ extern {
 }
 
 
-pub Script: Vec<Box<ast::Statement>> = {
+pub Script: Vec<ast::Statement> = {
   <stmts:Statement*> => stmts
 }
 
-pub Statement: Box<ast::Statement> = {
+pub Statement: ast::Statement = {
   "var" <name:"identifier"> "=" <value:Expression> ";" => {
-    Box::new(ast::Statement::Variable { name, value })
+    ast::Statement::Variable { name, value }
   },
   "print" <value:Expression> ";" => {
-    Box::new(ast::Statement::Print { value })
+    ast::Statement::Print { value }
   },
 }
 

--- a/doc/lexer/src/grammar.lalrpop
+++ b/doc/lexer/src/grammar.lalrpop
@@ -1,0 +1,87 @@
+use crate::tokens::{Token, LexicalError};
+use crate::ast;
+
+grammar;
+
+// ...
+
+extern {
+  type Location = usize;
+  type Error = LexicalError;
+
+  enum Token {
+    "var" => Token::KeywordVar,
+    "print" => Token::KeywordPrint,
+    "identifier" => Token::Identifier(<String>),
+    "int" => Token::Integer(<i64>),
+    "(" => Token::LParen,
+    ")" => Token::RParen,
+    "=" => Token::Assign,
+    ";" => Token::Semicolon,
+    "+" => Token::OperatorAdd,
+    "-" => Token::OperatorSub,
+    "*" => Token::OperatorMul,
+    "/" => Token::OperatorDiv,
+  }
+}
+
+
+pub Script: Vec<Box<ast::Statement>> = {
+  <stmts:Statement*> => stmts
+}
+
+pub Statement: Box<ast::Statement> = {
+  "var" <name:"identifier"> "=" <value:Expression> ";" => {
+    Box::new(ast::Statement::Variable { name, value })
+  },
+  "print" <value:Expression> ";" => {
+    Box::new(ast::Statement::Print { value })
+  },
+}
+
+pub Expression: Box<ast::Expression> = {
+  #[precedence(level="1")]
+  Term,
+
+  #[precedence(level="2")] #[assoc(side="left")]
+  <lhs:Expression> "*" <rhs:Expression> => {
+    Box::new(ast::Expression::BinaryOperation {
+      lhs,
+      operator: ast::Operator::Mul,
+      rhs
+    })
+  },
+  <lhs:Expression> "/" <rhs:Expression> => {
+    Box::new(ast::Expression::BinaryOperation {
+      lhs,
+      operator: ast::Operator::Div,
+      rhs
+    })
+  },
+
+  #[precedence(level="3")] #[assoc(side="left")]
+  <lhs:Expression> "+" <rhs:Expression> => {
+    Box::new(ast::Expression::BinaryOperation {
+      lhs,
+      operator: ast::Operator::Add,
+      rhs
+    })
+  },
+  <lhs:Expression> "-" <rhs:Expression> => {
+    Box::new(ast::Expression::BinaryOperation {
+      lhs,
+      operator: ast::Operator::Sub,
+      rhs
+    })
+  },
+}
+
+pub Term: Box<ast::Expression> = {
+  <val:"int"> => {
+    Box::new(ast::Expression::Integer(val))
+  },
+  <name:"identifier"> => {
+    Box::new(ast::Expression::Variable(name))
+  },
+  "(" <e:Expression> ")" => e
+}

--- a/doc/lexer/src/lexer.rs
+++ b/doc/lexer/src/lexer.rs
@@ -1,0 +1,29 @@
+use logos::{Logos, SpannedIter};
+
+use crate::tokens::{LexicalError, Token}; // your Token enum, as above
+
+pub type Spanned<Tok, Loc, Error> = Result<(Loc, Tok, Loc), Error>;
+
+pub struct Lexer<'input> {
+    // instead of an iterator over characters, we have a token iterator
+    token_stream: SpannedIter<'input, Token>,
+}
+
+impl<'input> Lexer<'input> {
+    pub fn new(input: &'input str) -> Self {
+        // the Token::lexer() method is provided by the Logos trait
+        Self {
+            token_stream: Token::lexer(input).spanned(),
+        }
+    }
+}
+
+impl<'input> Iterator for Lexer<'input> {
+    type Item = Spanned<Token, usize, LexicalError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.token_stream
+            .next()
+            .map(|(token, span)| Ok((span.start, token?, span.end)))
+    }
+}

--- a/doc/lexer/src/lib.rs
+++ b/doc/lexer/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod lexer;
+pub mod tokens;
+pub mod ast;
+
+use lalrpop_util::lalrpop_mod;
+
+lalrpop_mod!(pub grammar);

--- a/doc/lexer/src/lib.rs
+++ b/doc/lexer/src/lib.rs
@@ -1,6 +1,6 @@
+pub mod ast;
 pub mod lexer;
 pub mod tokens;
-pub mod ast;
 
 use lalrpop_util::lalrpop_mod;
 

--- a/doc/lexer/src/main.rs
+++ b/doc/lexer/src/main.rs
@@ -1,0 +1,16 @@
+use lexer::grammar::ScriptParser;
+use lexer::lexer::Lexer;
+
+fn main() {
+    let source_code = "var a = 42;
+var b = 23;
+
+# a comment
+print (a - b);";
+
+    let lexer = Lexer::new(&source_code[..]);
+    let parser = ScriptParser::new();
+    let ast = parser.parse(lexer).unwrap();
+
+    println!("{:?}", ast);
+}

--- a/doc/lexer/src/main.rs
+++ b/doc/lexer/src/main.rs
@@ -8,7 +8,7 @@ var b = 23;
 # a comment
 print (a - b);";
 
-    let lexer = Lexer::new(&source_code[..]);
+    let lexer = Lexer::new(source_code);
     let parser = ScriptParser::new();
     let ast = parser.parse(lexer).unwrap();
 

--- a/doc/lexer/src/tokens.rs
+++ b/doc/lexer/src/tokens.rs
@@ -1,5 +1,4 @@
 use logos::Logos;
-use std::convert::Infallible;
 use std::fmt; // to implement the Display trait
 use std::num::ParseIntError;
 
@@ -16,12 +15,6 @@ impl From<ParseIntError> for LexicalError {
     }
 }
 
-impl From<Infallible> for LexicalError {
-    fn from(_: Infallible) -> Self {
-        LexicalError::InvalidToken
-    }
-}
-
 #[derive(Logos, Clone, Debug, PartialEq)]
 #[logos(skip r"[ \t\n\f]+", skip r"#.*\n?", error = LexicalError)]
 pub enum Token {
@@ -30,7 +23,7 @@ pub enum Token {
     #[token("print")]
     KeywordPrint,
 
-    #[regex("[_a-zA-Z][_0-9a-zA-Z]*", |lex| lex.slice().parse())]
+    #[regex("[_a-zA-Z][_0-9a-zA-Z]*", |lex| lex.slice().to_string())]
     Identifier(String),
     #[regex("[1-9][0-9]*", |lex| lex.slice().parse())]
     Integer(i64),

--- a/doc/lexer/src/tokens.rs
+++ b/doc/lexer/src/tokens.rs
@@ -1,0 +1,61 @@
+use logos::Logos;
+use std::convert::Infallible;
+use std::fmt; // to implement the Display trait
+use std::num::ParseIntError;
+
+#[derive(Default, Debug, Clone, PartialEq)]
+pub enum LexicalError {
+    InvalidInteger(ParseIntError),
+    #[default]
+    InvalidToken,
+}
+
+impl From<ParseIntError> for LexicalError {
+    fn from(err: ParseIntError) -> Self {
+        LexicalError::InvalidInteger(err)
+    }
+}
+
+impl From<Infallible> for LexicalError {
+    fn from(_: Infallible) -> Self {
+        LexicalError::InvalidToken
+    }
+}
+
+#[derive(Logos, Clone, Debug, PartialEq)]
+#[logos(skip r"[ \t\n\f]+", skip r"#.*\n?", error = LexicalError)]
+pub enum Token {
+    #[token("var")]
+    KeywordVar,
+    #[token("print")]
+    KeywordPrint,
+
+    #[regex("[_a-zA-Z][_0-9a-zA-Z]*", |lex| lex.slice().parse())]
+    Identifier(String),
+    #[regex("[1-9][0-9]*", |lex| lex.slice().parse())]
+    Integer(i64),
+
+    #[token("(")]
+    LParen,
+    #[token(")")]
+    RParen,
+    #[token("=")]
+    Assign,
+    #[token(";")]
+    Semicolon,
+
+    #[token("+")]
+    OperatorAdd,
+    #[token("-")]
+    OperatorSub,
+    #[token("*")]
+    OperatorMul,
+    #[token("/")]
+    OperatorDiv,
+}
+
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}

--- a/doc/src/lexer_tutorial/005_external_lib.md
+++ b/doc/src/lexer_tutorial/005_external_lib.md
@@ -1,8 +1,7 @@
 # Using an external library
 
-Writing a lexer yourself can be tricky. Fortunately, you can find on
-[crates.io](https://crates.io) many different libraries to generate a lexer for
-you.
+Writing a lexer yourself can be tricky. Fortunately, you can find many
+libraries on [crates.io](https://crates.io) to generate a lexer for you.
 
 In this tutorial, we will use [Logos](https://docs.rs/logos/latest/logos/) to
 build a simple lexer for a toy programming language. Here is an example of what
@@ -41,7 +40,11 @@ pub enum Statement {
 pub enum Expression {
   Integer(i64),
   Variable(String),
-  BinaryOperation { lhs: Box<Expression>, operator: Operator, rhs: Box<Expression> },
+  BinaryOperation {
+    lhs: Box<Expression>,
+    operator: Operator,
+    rhs: Box<Expression>,
+  },
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -256,10 +259,10 @@ pub Statement: Box<ast::Statement> = {
 }
 
 pub Expression: Box<ast::Expression> = {
-  #[precedence(lvl="1")]
+  #[precedence(level="1")]
   Term,
 
-  #[precedence(lvl="2")] #[assoc(side="left")]
+  #[precedence(level="2")] #[assoc(side="left")]
   <lhs:Expression> "*" <rhs:Expression> => {
     Box::new(ast::Expression::BinaryOperation {
       lhs,
@@ -275,7 +278,7 @@ pub Expression: Box<ast::Expression> = {
     })
   },
 
-  #[precedence(lvl="3")] #[assoc(side="left")]
+  #[precedence(level="3")] #[assoc(side="left")]
   <lhs:Expression> "+" <rhs:Expression> => {
     Box::new(ast::Expression::BinaryOperation {
       lhs,
@@ -292,7 +295,7 @@ pub Expression: Box<ast::Expression> = {
   },
 }
 
-pub Term: Box<ast::Expression> => {
+pub Term: Box<ast::Expression> = {
   <val:"int"> => {
     Box::new(ast::Expression::Integer(val))
   },

--- a/doc/src/lexer_tutorial/005_external_lib.md
+++ b/doc/src/lexer_tutorial/005_external_lib.md
@@ -245,16 +245,16 @@ rules to reference the desired token.
 Finally, we can build our rules:
 
 ```rust
-pub Script: Vec<Box<ast::Statement>> = {
+pub Script: Vec<ast::Statement> = {
   <stmts:Statement*> => stmts
 }
 
-pub Statement: Box<ast::Statement> = {
+pub Statement: ast::Statement = {
   "var" <name:"identifier"> "=" <value:Expression> ";" => {
-    Box::new(ast::Statement::Variable { name, value })
+    ast::Statement::Variable { name, value }
   },
   "print" <value:Expression> ";" => {
-    Box::new(ast::Statement::Print { value })
+    ast::Statement::Print { value }
   },
 }
 
@@ -314,7 +314,7 @@ The last step is to run our parser:
 
 ```rust
 let source_code = std::fs::read_to_string("myscript.toy")?;
-let lexer = Lexer::new(&source_code[..]);
+let lexer = Lexer::new(&source_code);
 let parser = ScriptParser::new();
 let ast = parser.parse(lexer)?;
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

I'm interested in addressing #869. Before upgrading the version of logos, I would first like to add a testable version of the logos lexer example. This involves extracting out the example into it's own `doc/lexer` repo(Which is an unfortunate duplication given how documentation is generated). However in doing so I've run across some trivial issues in the documentation that I've addressed.

One part I'm not sure how to address is `the trait bound `Token: __ToTriple` is not satisfied` because `trait `__ToTriple` is not implemented for `Token``. Maybe I'll get around to figuring it out at some point. Until then, I'm leaving this pr here as a first step.(If someone knows the answer or wants to give it a try, feel free to suggest a edit).