### PR TITLE
Release 0.20.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "calculator"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-test"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "diff",
  "lalrpop",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "regex-automata",
 ]
@@ -545,7 +545,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "whitespace"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "lalrpop",
  "lalrpop-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 repository = "https://github.com/lalrpop/lalrpop"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0 OR MIT"
-version = "0.20.1" # LALRPOP
+version = "0.20.2"                                # LALRPOP
 edition = "2021"
 # This is (very) soft limit of the minimum supported version.
 # Please update it when lalrpop requires a new feature.
@@ -26,4 +26,8 @@ rust-version = "1.70"
 diff = { version = "0.1.12", default_features = false }
 regex = { version = "1.3", default_features = false, features = ["std"] }
 regex-syntax = { version = "0.8", default_features = false }
-regex-automata = { version = "0.4", default_features = false, features = ["perf", "syntax", "hybrid"] }
+regex-automata = { version = "0.4", default_features = false, features = [
+        "perf",
+        "syntax",
+        "hybrid",
+] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 repository = "https://github.com/lalrpop/lalrpop"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0 OR MIT"
-version = "0.20.2"                                # LALRPOP
+version = "0.20.2" # LALRPOP
 edition = "2021"
 # This is (very) soft limit of the minimum supported version.
 # Please update it when lalrpop requires a new feature.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,5 @@
-<a name="0.20.1"></a>
-## 0.20.1 (2023-10-**)
+<a name="0.20.2"></a>
+## 0.20.2 (2024-02-**)
 
 Special thanks to our newest maintainers, Daniel Burgener and Patrick LaFontaine for helping to coordinate this release.
 
@@ -9,11 +9,16 @@ Special thanks to our newest maintainers, Daniel Burgener and Patrick LaFontaine
 * Better performance with the default lexer using the underlying `regex-automata` crate (thanks to QuarticCat!)
 * Allow the catch-all `_` case for token matching can now be set to a higher precedence in match (thanks to fpoli!)
 * Fewer clippy lints triggered in generated code
+* Lalrpop now traverses symlinks to find .lalrpop files(thanks mbid!)
+* Lalrpop now supports block comments including nestings(thanks seanbright!)
 
 #### Bugfixes
 
 * Lalrpop now uses the ascii-aware space regex when the unicode feature is not enabled (thanks to QuarticCat!)
-* Dangling symlinks in crate no longer cause build failure (thanks to legeana for the report!)
+* Dangling symlinks in crate no longer cause build failure (thanks to legeana
+  for the report!)
+* Unicode is now set as a default feature in lalrpop-util to align with
+  lalrpop's defaults
 
 #### Compatibility note
 
@@ -21,6 +26,11 @@ Special thanks to our newest maintainers, Daniel Burgener and Patrick LaFontaine
 * `process_root_unconditionally` now correctly lints as having been deprecated.
 * Internal types which lead with a `__` and should not be relied upon are no longer publicly exposed (thanks to arnaudgolfouse!)
 * Lalrpop files containing a space in their name now return an error.
+
+<a name="0.20.1"></a>
+## 0.20.1 (2024-02-**)
+
+Yanked
 
 <a name="0.20.0"></a>
 ## 0.20.0 (2023-05-02)

--- a/doc/calculator/Cargo.toml
+++ b/doc/calculator/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
 name = "calculator"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
-workspace = "../.." # <-- We added this and everything after!
+workspace = "../.."                             # <-- We added this and everything after!
 edition = "2021"
 
 [build-dependencies]
-lalrpop = { version = "0.20.1", path = "../../lalrpop" }
+lalrpop = { version = "0.20.2", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.20.1", path = "../../lalrpop-util", features = ["lexer", "unicode"] }
+lalrpop-util = { version = "0.20.2", path = "../../lalrpop-util", features = [
+    "lexer",
+    "unicode",
+] }

--- a/doc/calculator/Cargo.toml
+++ b/doc/calculator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "calculator"
 version = "0.20.2"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
-workspace = "../.."                             # <-- We added this and everything after!
+workspace = "../.." # <-- We added this and everything after!
 edition = "2021"
 
 [build-dependencies]

--- a/doc/nobol/Cargo.toml
+++ b/doc/nobol/Cargo.toml
@@ -3,7 +3,7 @@ name = "nobol"
 version = "0.1.0"
 edition = "2021"
 authors = ["Felix S Klock II <pnkfelix@pnkfx.org>"]
-workspace = "../.."                                 # <-- We added this and everything after!
+workspace = "../.." # <-- We added this and everything after!
 
 [build-dependencies]
 lalrpop = { version = "0.20.2", path = "../../lalrpop" }

--- a/doc/nobol/Cargo.toml
+++ b/doc/nobol/Cargo.toml
@@ -3,10 +3,13 @@ name = "nobol"
 version = "0.1.0"
 edition = "2021"
 authors = ["Felix S Klock II <pnkfelix@pnkfx.org>"]
-workspace = "../.." # <-- We added this and everything after!
+workspace = "../.."                                 # <-- We added this and everything after!
 
 [build-dependencies]
-lalrpop = { version = "0.20.1", path = "../../lalrpop" }
+lalrpop = { version = "0.20.2", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.20.1", path = "../../lalrpop-util", features = ["lexer", "unicode"] }
+lalrpop-util = { version = "0.20.2", path = "../../lalrpop-util", features = [
+    "lexer",
+    "unicode",
+] }

--- a/doc/pascal/lalrpop/Cargo.toml
+++ b/doc/pascal/lalrpop/Cargo.toml
@@ -5,12 +5,12 @@ authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2021"
 
 [build-dependencies]
-lalrpop = { version = "0.20.1", path = "../../../lalrpop" }
+lalrpop = { version = "0.20.2", path = "../../../lalrpop" }
 
 [dependencies]
 pico-args = "0.5"
 
 [dependencies.lalrpop-util]
-version = "0.20.1"
+version = "0.20.2"
 path = "../../../lalrpop-util"
 features = ["lexer"]

--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -9,14 +9,14 @@ the following lines to your `Cargo.toml`:
 ```toml
 # The generated code depends on lalrpop-util.
 [dependencies]
-lalrpop-util = "0.20.1"
+lalrpop-util = "0.20.2"
 
 # Add a build-time dependency on the lalrpop library:
 [build-dependencies]
-lalrpop = "0.20.1"
+lalrpop = "0.20.2"
 # If you are supplying your own external lexer you can disable default features so that the
 # built-in lexer feature is not included
-# lalrpop = { version = "0.20.1", default-features = false }
+# lalrpop = { version = "0.20.2", default-features = false }
 ```
 
 Next create a [`build.rs`](https://doc.rust-lang.org/cargo/reference/build-scripts.html) file

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -31,10 +31,10 @@ authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2021"
 
 [build-dependencies] # <-- We added this and everything after!
-lalrpop = "0.20.1"
+lalrpop = "0.20.2"
 
 [dependencies]
-lalrpop-util = { version = "0.20.1", features = ["lexer", "unicode"] }
+lalrpop-util = { version = "0.20.2", features = ["lexer", "unicode"] }
 ```
 
 Cargo can run [build scripts] as a pre-processing step,

--- a/doc/whitespace/Cargo.toml
+++ b/doc/whitespace/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "whitespace"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Mako <jlauve@rsmw.net>"]
 edition = "2021"
 
 [build-dependencies.lalrpop]
-version = "0.20.1"
+version = "0.20.2"
 path = "../../lalrpop"
 
 [dependencies.lalrpop-util]
-version = "0.20.1"
+version = "0.20.2"
 path = "../../lalrpop-util"

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -1,4 +1,4 @@
-// auto-generated: "lalrpop 0.20.1"
+// auto-generated: "lalrpop 0.20.2"
 // sha3: 41f98a6a8c1305d7ef67ac81e1eb4a8b9450d8a01a72a06b1fc8bb7900055a0b
 use string_cache::DefaultAtom as Atom;
 use crate::grammar::parse_tree::*;


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

As noted in #864 and #848, it's probably safe to cut a new release? There have been a few changes since 0.20.1 but most of them are minor or documentation related. I've noted the new features in the updated release notes as I understand them.