### PR TITLE
Add 'OUT_DIR' to quick start and tutorial

### DIFF
--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -31,10 +31,22 @@ fn main() {
 (If you already have a `build.rs` file, you should be able to just
 call `process_root` in addition to whatever else that file is doing.)
 
-That's it! Note that `process_root` simply uses the default settings, which
-means generated Rust code will reside in `OUT_DIR`, which you can `include!()`.
-If you want to configure how LALRPOP executes, see the
-[advanced setup](advanced_setup.md) section.
+In this case, `process_root` simply uses the default settings, which takes
+files in `src/` ending with the `.lalrpop` extension, and generates
+corresponding Rust source files with the same name in `OUT_DIR`. If you want to
+configure how LALRPOP executes, see the [advanced setup](advanced_setup.md)
+section.
+
+Finally, you can add any of the generated files as modules in your Rust code
+using the [`lalrpop_mod!`][lalrpop_mod] macro. For example, if your grammar is
+called `grammar.lalrpop`, to use the generated `grammar.rs` as a Rust module
+simply called `grammar`, add the following:
+
+```rust
+lalrpop_mod!(grammar)
+```
+
+[lalrpop_mod]: https://docs.rs/lalrpop-util/latest/lalrpop_util/macro.lalrpop_mod.html
 
 #### Running manually
 

--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -3,7 +3,7 @@ For getting started with LALRPOP, it's probably best if you read
 to the syntax of LALRPOP files and so forth.
 
 But if you've done this before, or you're just the impatient sort,
-here is a quick 'cheat sheet' for setting up your project.  First, add
+here is a quick 'cheat sheet' for setting up your project. First, add
 the following lines to your `Cargo.toml`:
 
 ```toml
@@ -31,7 +31,8 @@ fn main() {
 (If you already have a `build.rs` file, you should be able to just
 call `process_root` in addition to whatever else that file is doing.)
 
-That's it! Note that `process_root` simply uses the default settings.
+That's it! Note that `process_root` simply uses the default settings, which
+means generated Rust code will reside in `OUT_DIR`, which you can `include!()`.
 If you want to configure how LALRPOP executes, see the
 [advanced setup](advanced_setup.md) section.
 

--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -37,14 +37,15 @@ corresponding Rust source files with the same name in `OUT_DIR`. If you want to
 configure how LALRPOP executes, see the [advanced setup](advanced_setup.md)
 section.
 
-Finally, you can add any of the generated files as modules in your Rust code
-using the [`lalrpop_mod!`][lalrpop_mod] macro. For example, if your grammar is
-called `grammar.lalrpop`, to use the generated `grammar.rs` as a Rust module
-simply called `grammar`, add the following:
+The [`lalrpop_mod!`][lalrpop_mod] macro generates a wrapper module in your
+crate so that you can use the generated parser from your code. For example,
+if the source grammar is located in `grammar.lalrpop`, adding the following line
+to `lib.rs` will create a corresponding `grammar` submodule (note that you can
+also add this line to a `foo.rs` module definition instead, which will then
+create a submodule `foo::grammar`):
 
 ```rust
-lalrpop_mod!(grammar)
-```
+lalrpop_mod!(grammar);
 
 [lalrpop_mod]: https://docs.rs/lalrpop-util/latest/lalrpop_util/macro.lalrpop_mod.html
 

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -68,12 +68,14 @@ enough to check timestamps and do nothing if the `rs` file is newer than the
 file-system errors occurred.
 
 You can include the generated code somewhere in your Rust code. For example, if
-the source grammar were to be called `grammar.lalrpop`, you could include the
-generated `grammar.rs` file like so:
+the source grammar is in `grammar.lalrpop`, you can add the generated
+`grammar.rs` file as a module using the [`lalrpop_mod!`][lalrpop_mod] macro:
 
 ```rust
-include!(concat!(env!("OUT_DIR"), "/grammar.rs"));
+lalrpop_mod!(grammar);
 ```
+
+[lalrpop_mod]: https://docs.rs/lalrpop-util/latest/lalrpop_util/macro.lalrpop_mod.html
 
 _NOTE:_ On Windows, the necessary APIs are not yet stable, so
 timestamp checking is disabled.

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -61,11 +61,19 @@ fn main() {
 ```
 
 The function `process_root` processes your `src` directory, converting
-all `lalrpop` files into `rs` files. It is smart enough to check
-timestamps and do nothing if the `rs` file is newer than the `lalrpop`
-file, and to mark the generated `rs` file as read-only. It returns an
+all `lalrpop` files into `rs` files, and saving them to `OUT_DIR`. It is smart
+enough to check timestamps and do nothing if the `rs` file is newer than the
+`lalrpop` file, and to mark the generated `rs` file as read-only. It returns an
 `io::Result<()>`, so the `unwrap()` call just asserts that no
 file-system errors occurred.
 
-*NOTE:* On Windows, the necessary APIs are not yet stable, so
+You can include the generated code somewhere in your Rust code. For example, if
+the source grammar were to be called `grammar.lalrpop`, you could include the
+generated `grammar.rs` file like so:
+
+```rust
+include!(concat!(env!("OUT_DIR"), "/grammar.rs"));
+```
+
+_NOTE:_ On Windows, the necessary APIs are not yet stable, so
 timestamp checking is disabled.

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -67,9 +67,12 @@ enough to check timestamps and do nothing if the `rs` file is newer than the
 `io::Result<()>`, so the `unwrap()` call just asserts that no
 file-system errors occurred.
 
-You can include the generated code somewhere in your Rust code. For example, if
-the source grammar is in `grammar.lalrpop`, you can add the generated
-`grammar.rs` file as a module using the [`lalrpop_mod!`][lalrpop_mod] macro:
+The [`lalrpop_mod!`][lalrpop_mod] macro generates a wrapper module in your
+crate so that you can use the generated parser from your code. For example,
+if the source grammar is located in `grammar.lalrpop`, adding the following line
+to `lib.rs` will create a corresponding `grammar` submodule (note that you can
+also add this line to a `foo.rs` module definition instead, which will then
+create a submodule `foo::grammar`):
 
 ```rust
 lalrpop_mod!(grammar);


### PR DESCRIPTION
Tried to make it clearer that the generated files are by default saved to `OUT_DIR`, and gave an example of `include!()`-ing the generated files.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->