### PR TITLE
Remove outdated note?

### DIFF
--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -79,6 +79,3 @@ lalrpop_mod!(grammar);
 ```
 
 [lalrpop_mod]: https://docs.rs/lalrpop-util/latest/lalrpop_util/macro.lalrpop_mod.html
-
-_NOTE:_ On Windows, the necessary APIs are not yet stable, so
-timestamp checking is disabled.


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

I saw this note in the docs and it surprised me. I tracked this back to a commit over 9 years ago: 0983cec. In looking through the issue tracker, this might have been fixed as early as 2 weeks later in #30. Regardless, Lalrpop now uses cargo's `rerun-if-changed` directive so this is outside of Lalrpop's scope.