### PR TITLE
Use default-features in favor of default_features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ edition = "2021"
 rust-version = "1.70"
 
 [workspace.dependencies]
-diff = { version = "0.1.12", default_features = false }
-regex = { version = "1.3", default_features = false, features = ["std"] }
-regex-syntax = { version = "0.8.2", default_features = false }
-regex-automata = { version = "0.4", default_features = false, features = [
+diff = { version = "0.1.12", default-features = false }
+regex = { version = "1.3", default-features = false, features = ["std"] }
+regex-syntax = { version = "0.8.2", default-features = false }
+regex-automata = { version = "0.4", default-features = false, features = [
         "perf",
         "syntax",
         "hybrid",

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -19,24 +19,24 @@ exclude = ["build.rs"]
 doctest = false
 
 [dependencies]
-ascii-canvas = { version = "3.0", default_features = false }
-bit-set = { version = "0.5.2", default_features = false }
-ena = { version = "0.14", default_features = false }
-itertools = { version = "0.11", default_features = false, features = ["use_std"] }
-petgraph = { version = "0.6", default_features = false }
+ascii-canvas = { version = "3.0", default-features = false }
+bit-set = { version = "0.5.2", default-features = false }
+ena = { version = "0.14", default-features = false }
+itertools = { version = "0.11", default-features = false, features = ["use_std"] }
+petgraph = { version = "0.6", default-features = false }
 regex = { workspace = true }
 regex-syntax = { workspace = true }
-string_cache = { version = "0.8", default_features = false }
-term = { version = "0.7", default_features = false }
+string_cache = { version = "0.8", default-features = false }
+term = { version = "0.7", default-features = false }
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
-unicode-xid = { version = "0.2", default_features = false }
+unicode-xid = { version = "0.2", default-features = false }
 walkdir = "2.4.0"
 
 # This dependency is only needed for binary builds, if you use LALRPOP as
-# library, disable it in your project by setting default_features = false.
-pico-args = { version = "0.5", default_features = false, optional = true }
+# library, disable it in your project by setting default-features = false.
+pico-args = { version = "0.5", default-features = false, optional = true }
 
-lalrpop-util = { path = "../lalrpop-util", version = "0.20.0", default_features = false }
+lalrpop-util = { path = "../lalrpop-util", version = "0.20.0", default-features = false }
 
 [dev-dependencies]
 diff = { workspace = true }


### PR DESCRIPTION
The _ variants of several Cargo fields will be deprecated in the 2024 edition.  Switch to the recommended - variants.

https://github.com/rust-lang/cargo/pull/13783

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->