### PR TITLE
Move the ' ' character in generated typebounds to the second clause

### DIFF
--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -221,10 +221,10 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
                     self.prefix, self.prefix, user_type_parameters,
                 ),
                 format!(
-                    "{}TOKENS: IntoIterator<Item={}TOKEN> {}",
+                    "{}TOKENS: IntoIterator<Item={}TOKEN>{}",
                     self.prefix,
                     self.prefix,
-                    if self.repeatable { "+ Clone" } else { "" }
+                    if self.repeatable { " + Clone" } else { "" }
                 ),
             ];
             parameters = vec![format!("{}tokens0: {}TOKENS", self.prefix, self.prefix)];

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -6349,7 +6349,7 @@ _priv: (),
 pub fn parse<
     'input,
     ___TOKEN: ___ToTriple<'input, >,
-    ___TOKENS: IntoIterator<Item=___TOKEN> ,
+    ___TOKENS: IntoIterator<Item=___TOKEN>,
 >(
 &self,
 text: &'input str,


### PR DESCRIPTION
As suggested by @Pat-Lafon in #889

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->