### PR TITLE
Insert an empty lookahead in the lane table in reduce conflict states

### DIFF
--- a/lalrpop/src/lr1/lane_table/construct/merge.rs
+++ b/lalrpop/src/lr1/lane_table/construct/merge.rs
@@ -199,6 +199,7 @@ impl<'m> ContextSets<'m> {
     }
 
     fn union(&mut self, source: StateIndex, target: StateIndex) -> bool {
+        debug!("state_sets: {:?}", self.state_sets);
         let set1 = self.state_sets[&source];
         let set2 = self.state_sets[&target];
         let result = self.unify.unify_var_var(set1, set2).is_ok();

--- a/lalrpop/src/lr1/lane_table/lane/mod.rs
+++ b/lalrpop/src/lr1/lane_table/lane/mod.rs
@@ -60,6 +60,7 @@ impl<'trace, 'grammar, L: Lookahead> LaneTracer<'trace, 'grammar, L> {
 
             Action::Reduce(prod) => {
                 let item = Item::lr0(prod, prod.symbols.len());
+                self.table.add_lookahead(state, conflict, &TokenSet::new());
                 self.continue_trace(state, conflict, item, &mut visited_set);
             }
         }
@@ -72,6 +73,7 @@ impl<'trace, 'grammar, L: Lookahead> LaneTracer<'trace, 'grammar, L> {
         item: Lr0Item<'grammar>,
         visited: &mut Set<(StateIndex, Lr0Item<'grammar>)>,
     ) {
+        debug!("continue_trace:  state={:?}, index={:?}", state, item.index);
         if !visited.insert((state, item)) {
             return;
         }


### PR DESCRIPTION
We need to make sure the state in the conflict is in the lane table. All the existing test cases happened to have a shift case in the conflict state, even if the shift wasn't part of the actual conflict. In the event of a conflicting state with only reduce actions, we'll need the lookahead store, so we can check it as a successor of the predecessors we found.

fixes #897

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->