### PR TITLE
Update to itertools 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 ascii-canvas = { version = "3.0", default-features = false }
 bit-set = { version = "0.5.2", default-features = false }
 ena = { version = "0.14", default-features = false }
-itertools = { version = "0.11", default-features = false, features = ["use_std"] }
+itertools = { version = "0.13", default-features = false, features = ["use_std"] }
 petgraph = { version = "0.6", default-features = false }
 regex = { workspace = true }
 regex-syntax = { workspace = true }

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -601,7 +601,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
                 .map(|k2| state_lookup(k, k2))
                 .enumerate()
                 // Group consecutive indices so we can compress then as a..=b
-                .group_by(|(_, (next_state, _))| *next_state);
+                .chunk_by(|(_, (next_state, _))| *next_state);
             let mut row = Vec::new();
             row.extend(&iter);
 
@@ -622,7 +622,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
                 .drain(..)
                 // We always emit a catch-all for 0 error states (which will never be hit)
                 .filter_map(|(opt, group)| opt.map(|next_state| (next_state, group)))
-                .group_by(|(next_state, _)| *next_state))
+                .chunk_by(|(next_state, _)| *next_state))
                 .into_iter()
                 .enumerate()
                 .map(|(i, (next_state, group_group))| {

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -600,7 +600,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
                 .into_iter()
                 .map(|k2| state_lookup(k, k2))
                 .enumerate()
-                // Group consecutive indices so we can compress then as a..=b
+                // Group consecutive indices so we can compress them as a..=b
                 .chunk_by(|(_, (next_state, _))| *next_state);
             let mut row = Vec::new();
             row.extend(&iter);


### PR DESCRIPTION
Switch deprecated group_by() to chunk_by()

The change in name was made because chunk_by() better implies that the function groups *consecutive* elements (rather than searching through the iterator and funding *all* matching elements).  This raises the question of whether the intention in the original group_by() was correct, since the change was made to avoid subtle bugs around assuming that this grouped all entries rather than consecutive entries.  In the two instances we have of this function call, the first one has a comment specifically calling out a desire to do this consecutively.  In the second, the iterator was previously sorted by the chunking value, making consecutive equivalent to all, so I believe we are free of this potential bug.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->