### PR TITLE
Fix quick_start_guide.md

### DIFF
--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -46,6 +46,7 @@ create a submodule `foo::grammar`):
 
 ```rust
 lalrpop_mod!(grammar);
+```
 
 [lalrpop_mod]: https://docs.rs/lalrpop-util/latest/lalrpop_util/macro.lalrpop_mod.html
 


### PR DESCRIPTION
Closes a code block which wasn't previously closed

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->