### PR TITLE
Addressing Rust 2018 edition

### DIFF
--- a/doc/calculator/src/ast.rs
+++ b/doc/calculator/src/ast.rs
@@ -21,7 +21,7 @@ pub enum Opcode {
 }
 
 impl Debug for Expr {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         use self::Expr::*;
         match *self {
             Number(n) => write!(fmt, "{:?}", n),
@@ -32,7 +32,7 @@ impl Debug for Expr {
 }
 
 impl<'input> Debug for ExprSymbol<'input> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         use self::ExprSymbol::*;
         match *self {
             NumSymbol(n) => write!(fmt, "{:?}", n),
@@ -43,7 +43,7 @@ impl<'input> Debug for ExprSymbol<'input> {
 }
 
 impl Debug for Opcode {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         use self::Opcode::*;
         match *self {
             Mul => write!(fmt, "*"),

--- a/doc/lexer/src/tokens.rs
+++ b/doc/lexer/src/tokens.rs
@@ -48,7 +48,7 @@ pub enum Token {
 }
 
 impl fmt::Display for Token {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)
     }
 }

--- a/doc/nobol/src/main.rs
+++ b/doc/nobol/src/main.rs
@@ -123,7 +123,7 @@ fn main() {
 }
 
 /// Simplified version of `tok::apply_string_escapes` for illustrative purposes.
-pub fn apply_string_escapes(content: &str) -> std::borrow::Cow<str> {
+pub fn apply_string_escapes(content: &str) -> std::borrow::Cow<'_, str> {
     if !content.contains('\\') {
         content.into()
     } else {

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(test), allow(dead_code, unused_imports))]
 #![allow(unused_doc_comments)]
+#![warn(rust_2018_idioms)]
 
 use std::cell::RefCell;
 use std::fs;

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -276,7 +276,7 @@ fn expr_intern_tok_test_err() {
 fn parse_error_map_token_and_location() {
     let expr = "(1+\n(2++3))";
     let result = expr_intern_tok::ExprParser::new().parse(1, expr);
-    let err: lalrpop_util::ParseError<usize, expr_intern_tok::Token, &'static str> =
+    let err: lalrpop_util::ParseError<usize, expr_intern_tok::Token<'_>, &'static str> =
         result.unwrap_err();
 
     let message = err
@@ -908,7 +908,7 @@ fn lexer_generic_test() {
     let input = "2 + 3";
     let lexer = Lexer::new(input);
     let parser = lexer_generic::AdditionParser::new();
-    let result = parser.parse::<Lexer, _, _>(input, lexer);
+    let result = parser.parse::<Lexer<'_>, _, _>(input, lexer);
 
     assert_eq!(Ok(5), result);
 }

--- a/lalrpop-test/src/util/mod.rs
+++ b/lalrpop-test/src/util/mod.rs
@@ -32,7 +32,7 @@ where
 
 pub fn test_loc<R: Debug + Eq, F>(parse_fn: F, input: &str, expected: R)
 where
-    F: FnOnce(Vec<(usize, Tok, usize)>) -> Result<R, ParseError<usize, Tok, &'static str>>,
+    F: FnOnce(Vec<(usize, Tok<'_>, usize)>) -> Result<R, ParseError<usize, Tok<'_>, &'static str>>,
 {
     // create tokens
     let tokens = tok::tokenize(input);
@@ -64,7 +64,7 @@ where
 struct ExpectedDebug<'a>(&'a str);
 
 impl<'a> Debug for ExpectedDebug<'a> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         // Ignore trailing commas in multiline Debug representation.
         // Needed to work around rust-lang/rust#59076.
         let s = self.0.replace(",\n", "\n");

--- a/lalrpop-test/src/util/tok.rs
+++ b/lalrpop-test/src/util/tok.rs
@@ -78,7 +78,7 @@ pub fn tokenize(s: &str) -> Vec<(usize, Tok<'_>, usize)> {
 
 fn take_while<F>(
     slice_start: usize,
-    char_indices: &mut CharIndices,
+    char_indices: &mut CharIndices<'_>,
     f: F,
 ) -> (usize, Option<(usize, char)>)
 where

--- a/lalrpop-util/src/lexer.rs
+++ b/lalrpop-util/src/lexer.rs
@@ -11,7 +11,7 @@ use regex_automata::{Anchored, Input, MatchKind};
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Token<'input>(pub usize, pub &'input str);
 impl<'a> fmt::Display for Token<'a> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         fmt::Display::fmt(self.1, formatter)
     }
 }

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![warn(rust_2018_idioms)]
 
 extern crate alloc;
 

--- a/lalrpop/src/collections/multimap.rs
+++ b/lalrpop/src/collections/multimap.rs
@@ -45,7 +45,7 @@ impl<K: Ord, C: Collection> Multimap<K, C> {
         self.map.get(key)
     }
 
-    pub fn iter(&self) -> btree_map::Iter<K, C> {
+    pub fn iter(&self) -> btree_map::Iter<'_, K, C> {
         self.map.iter()
     }
 

--- a/lalrpop/src/file_text.rs
+++ b/lalrpop/src/file_text.rs
@@ -133,7 +133,7 @@ impl FileText {
 struct Repeat(char, usize);
 
 impl Display for Repeat {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         for _ in 0..self.1 {
             write!(fmt, "{}", self.0)?;
         }

--- a/lalrpop/src/grammar/parse_tree.rs
+++ b/lalrpop/src/grammar/parse_tree.rs
@@ -1177,11 +1177,7 @@ impl Path {
     pub fn option() -> Path {
         Path {
             absolute: false,
-            ids: vec![
-                Atom::from("core"),
-                Atom::from("option"),
-                Atom::from("Option"),
-            ],
+            ids: vec![Atom::from("Option")],
         }
     }
 

--- a/lalrpop/src/grammar/parse_tree.rs
+++ b/lalrpop/src/grammar/parse_tree.rs
@@ -110,7 +110,7 @@ pub enum MatchMapping {
 }
 
 impl Debug for MatchMapping {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
             MatchMapping::Terminal(term) => write!(fmt, "{:?}", term),
             MatchMapping::Skip => write!(fmt, "{{ }}"),
@@ -118,7 +118,7 @@ impl Debug for MatchMapping {
     }
 }
 impl Display for MatchMapping {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
             MatchMapping::Terminal(term) => write!(fmt, "{}", term),
             MatchMapping::Skip => write!(fmt, "{{ }}"),
@@ -731,7 +731,7 @@ impl Name {
 }
 
 impl Display for Visibility {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             Visibility::Pub(Some(ref path)) => write!(fmt, "pub({}) ", path),
             Visibility::Pub(None) => write!(fmt, "pub "),
@@ -742,7 +742,7 @@ impl Display for Visibility {
 }
 
 impl<T: Display> Display for WhereClause<T> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             WhereClause::Lifetime {
                 ref lifetime,
@@ -787,7 +787,7 @@ impl<T: Display> Display for WhereClause<T> {
 }
 
 impl<T: Display> Display for TypeBound<T> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             TypeBound::Lifetime(ref l) => write!(fmt, "{}", l),
             TypeBound::Fn {
@@ -857,7 +857,7 @@ impl<T: Display> Display for TypeBound<T> {
 }
 
 impl<T: Display> Display for TypeBoundParameter<T> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             TypeBoundParameter::Lifetime(ref l) => write!(fmt, "{}", l),
             TypeBoundParameter::TypeParameter(ref t) => write!(fmt, "{}", t),
@@ -867,7 +867,7 @@ impl<T: Display> Display for TypeBoundParameter<T> {
 }
 
 impl Display for TerminalString {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             TerminalString::Literal(ref s) => write!(fmt, "{}", s),
             TerminalString::Bare(ref s) => write!(fmt, "{}", s),
@@ -877,25 +877,25 @@ impl Display for TerminalString {
 }
 
 impl Debug for TerminalString {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         Display::fmt(self, fmt)
     }
 }
 
 impl Display for Lifetime {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         Display::fmt(&self.0, fmt)
     }
 }
 
 impl Debug for Lifetime {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         Display::fmt(self, fmt)
     }
 }
 
 impl Display for TerminalLiteral {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             TerminalLiteral::Quoted(ref s) => write!(fmt, "{:?}", s.as_ref()), // the Debug impl adds the `"` and escaping
             TerminalLiteral::Regex(ref s) => write!(fmt, "r#{:?}#", s.as_ref()), // FIXME -- need to determine proper number of #
@@ -904,13 +904,13 @@ impl Display for TerminalLiteral {
 }
 
 impl Debug for TerminalLiteral {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "{}", self)
     }
 }
 
 impl Display for Path {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(
             fmt,
             "{}{}",
@@ -921,25 +921,25 @@ impl Display for Path {
 }
 
 impl Display for NonterminalString {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "{}", self.0)
     }
 }
 
 impl Debug for NonterminalString {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         Display::fmt(self, fmt)
     }
 }
 
 impl Display for Symbol {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         Display::fmt(&self.kind, fmt)
     }
 }
 
 impl Display for SymbolKind {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             SymbolKind::Expr(ref expr) => write!(fmt, "{}", expr),
             SymbolKind::Terminal(ref s) => write!(fmt, "{}", s),
@@ -957,7 +957,7 @@ impl Display for SymbolKind {
 }
 
 impl Display for Name {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         if self.mutable {
             write!(fmt, "mut {}", self.name)
         } else {
@@ -967,13 +967,13 @@ impl Display for Name {
 }
 
 impl Display for RepeatSymbol {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "{}{}", self.symbol, self.op)
     }
 }
 
 impl Display for RepeatOp {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             RepeatOp::Plus => write!(fmt, "+"),
             RepeatOp::Star => write!(fmt, "*"),
@@ -983,7 +983,7 @@ impl Display for RepeatOp {
 }
 
 impl Display for ExprSymbol {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "({})", Sep(" ", &self.symbols))
     }
 }
@@ -1013,13 +1013,13 @@ impl RepeatSymbol {
 }
 
 impl Display for MacroSymbol {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "{}<{}>", self.name, Sep(", ", &self.args))
     }
 }
 
 impl Display for TypeParameter {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             TypeParameter::Lifetime(ref s) => write!(fmt, "{}", s),
             TypeParameter::Id(ref s) => write!(fmt, "{}", s),
@@ -1028,7 +1028,7 @@ impl Display for TypeParameter {
 }
 
 impl Display for TypeRef {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             TypeRef::Tuple(ref types) => write!(fmt, "({})", Sep(", ", types)),
             TypeRef::Slice(ref ty) => write!(fmt, "[{}]", ty),

--- a/lalrpop/src/grammar/pattern.rs
+++ b/lalrpop/src/grammar/pattern.rs
@@ -88,13 +88,13 @@ impl<T> FieldPattern<T> {
 }
 
 impl<T: Display> Display for Pattern<T> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "{}", self.kind)
     }
 }
 
 impl<T: Display> Display for PatternKind<T> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             PatternKind::Path(ref path) => write!(fmt, "{}", path),
             PatternKind::Enum(ref path, ref pats) => write!(fmt, "{}({})", path, Sep(", ", pats)),
@@ -122,7 +122,7 @@ impl<T: Display> Display for PatternKind<T> {
 }
 
 impl<T: Display> Display for FieldPattern<T> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "{}: {}", self.field_name, self.pattern)
     }
 }

--- a/lalrpop/src/grammar/repr.rs
+++ b/lalrpop/src/grammar/repr.rs
@@ -494,7 +494,7 @@ impl Types {
 }
 
 impl Display for WhereClause {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
             WhereClause::Forall { binder, clause } => {
                 write!(fmt, "for<{}> {}", Sep(", ", binder), clause)
@@ -506,13 +506,13 @@ impl Display for WhereClause {
 }
 
 impl Display for Parameter {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "{}: {}", self.name, self.ty)
     }
 }
 
 impl Display for TypeRepr {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             TypeRepr::Tuple(ref types) => write!(fmt, "({})", Sep(", ", types)),
             TypeRepr::Slice(ref ty) => write!(fmt, "[{}]", ty),
@@ -564,13 +564,13 @@ impl Display for TypeRepr {
 }
 
 impl Debug for TypeRepr {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         Display::fmt(self, fmt)
     }
 }
 
 impl Display for NominalTypeRepr {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         if self.types.is_empty() {
             write!(fmt, "{}", self.path)
         } else {
@@ -580,7 +580,7 @@ impl Display for NominalTypeRepr {
 }
 
 impl Debug for NominalTypeRepr {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         Display::fmt(self, fmt)
     }
 }
@@ -615,7 +615,7 @@ impl Symbol {
 }
 
 impl Display for Symbol {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
             Symbol::Nonterminal(id) => write!(fmt, "{}", id),
             Symbol::Terminal(id) => write!(fmt, "{}", id),
@@ -624,7 +624,7 @@ impl Display for Symbol {
 }
 
 impl Debug for Symbol {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         Display::fmt(self, fmt)
     }
 }
@@ -639,7 +639,7 @@ impl From<Symbol> for Box<dyn Content> {
 }
 
 impl Debug for Production {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(
             fmt,
             "{} = {} => {:?};",
@@ -651,7 +651,7 @@ impl Debug for Production {
 }
 
 impl Debug for ActionFnDefn {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "{}", self.to_fn_string("_"))
     }
 }

--- a/lalrpop/src/lexer/dfa/mod.rs
+++ b/lalrpop/src/lexer/dfa/mod.rs
@@ -312,13 +312,13 @@ impl Item {
 }
 
 impl Debug for DfaStateIndex {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "Dfa{}", self.0)
     }
 }
 
 impl Display for DfaStateIndex {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         Debug::fmt(self, fmt)
     }
 }
@@ -336,7 +336,7 @@ impl DfaStateIndex {
 }
 
 impl Debug for Item {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "({:?}:{:?})", self.nfa_index, self.nfa_state)
     }
 }

--- a/lalrpop/src/lexer/nfa/mod.rs
+++ b/lalrpop/src/lexer/nfa/mod.rs
@@ -134,7 +134,7 @@ impl Nfa {
     ///////////////////////////////////////////////////////////////////////////
     // Public methods for querying an Nfa
 
-    pub fn edges<L: EdgeLabel>(&self, from: NfaStateIndex) -> EdgeIterator<L> {
+    pub fn edges<L: EdgeLabel>(&self, from: NfaStateIndex) -> EdgeIterator<'_, L> {
         let vec = L::vec(&self.edges);
         let first = *L::first(&self.states[from.0]);
         EdgeIterator {
@@ -475,7 +475,7 @@ impl EdgeLabel for Test {
     }
 }
 
-pub struct EdgeIterator<'nfa, L: EdgeLabel + 'nfa> {
+pub struct EdgeIterator<'nfa, L: EdgeLabel> {
     edges: &'nfa [Edge<L>],
     from: NfaStateIndex,
     index: usize,
@@ -589,7 +589,7 @@ impl From<ClassBytesRange> for Test {
 }
 
 impl Debug for Test {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), FmtError> {
         match (char::from_u32(self.start()), char::from_u32(self.end())) {
             (Some(start), Some(end)) => {
                 if self.is_char() {
@@ -608,13 +608,13 @@ impl Debug for Test {
 }
 
 impl Debug for NfaStateIndex {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), FmtError> {
         write!(fmt, "Nfa{}", self.0)
     }
 }
 
 impl<L: Debug> Debug for Edge<L> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), FmtError> {
         write!(fmt, "{:?} -{:?}-> {:?}", self.from, self.label, self.to)
     }
 }

--- a/lalrpop/src/lib.rs
+++ b/lalrpop/src/lib.rs
@@ -7,6 +7,7 @@
 //
 // ε shows up in lalrpop/src/lr1/example/test.rs
 #![cfg_attr(test, allow(dead_code, mixed_script_confusables))]
+#![warn(rust_2018_idioms)]
 
 // hoist the modules that define macros up earlier
 #[macro_use]

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -35,9 +35,12 @@ pub fn use_lane_table() -> bool {
 
 pub fn build_lr1_states(grammar: &Grammar, start: NonterminalString) -> Lr1Result<'_> {
     let (method_name, method_fn) = if use_lane_table() {
-        ("lane", build_lane_table_states as ConstructionFunction)
+        ("lane", build_lane_table_states as ConstructionFunction<'_>)
     } else {
-        ("legacy", build_lr1_states_legacy as ConstructionFunction)
+        (
+            "legacy",
+            build_lr1_states_legacy as ConstructionFunction<'_>,
+        )
     };
 
     profile! {

--- a/lalrpop/src/lr1/build/test.rs
+++ b/lalrpop/src/lr1/build/test.rs
@@ -38,7 +38,7 @@ macro_rules! tokens {
 
 fn items<'g>(grammar: &'g Grammar, nonterminal: &str, index: usize, la: Token) -> Lr1Items<'g> {
     let set = TokenSet::from(la);
-    let lr1: Lr<TokenSet> = Lr::new(grammar, nt(nonterminal), set.clone());
+    let lr1: Lr<'_, TokenSet> = Lr::new(grammar, nt(nonterminal), set.clone());
     let items = lr1.transitive_closure(lr1.items(&nt(nonterminal), index, &set));
     items
 }

--- a/lalrpop/src/lr1/build_lalr/mod.rs
+++ b/lalrpop/src/lr1/build_lalr/mod.rs
@@ -47,8 +47,8 @@ pub fn collapse_to_lalr_states<'grammar>(lr_states: &[Lr1State<'grammar>]) -> Lr
     // Now compress them. This vector stores, for each state, the
     // LALR(1) state to which we will remap it.
     let mut remap: Vec<_> = (0..lr_states.len()).map(|_| StateIndex(0)).collect();
-    let mut lalr1_map: Map<Vec<Lr0Item>, StateIndex> = map();
-    let mut lalr1_states: Vec<Lalr1State> = vec![];
+    let mut lalr1_map: Map<Vec<Lr0Item<'_>>, StateIndex> = map();
+    let mut lalr1_states: Vec<Lalr1State<'_>> = vec![];
 
     for (lr1_index, lr1_state) in lr_states.iter().enumerate() {
         let lr0_kernel: Vec<_> = lr1_state

--- a/lalrpop/src/lr1/codegen/ascent.rs
+++ b/lalrpop/src/lr1/codegen/ascent.rs
@@ -567,7 +567,7 @@ impl<'ascent, 'grammar, W: Write>
             )))
             .with_parameters(fn_args)
             .with_return_type(format!(
-                "core::result::Result<(core::option::Option<{}>, {}Nonterminal<{}>), {}>",
+                "Result<(Option<{}>, {}Nonterminal<{}>), {}>",
                 triple_type,
                 self.prefix,
                 Sep(", ", &self.custom.nonterminal_type_params),
@@ -579,7 +579,7 @@ impl<'ascent, 'grammar, W: Write>
 
         rust!(
             self.out,
-            "let mut {}result: (core::option::Option<{}>, {}Nonterminal<{}>);",
+            "let mut {}result: (Option<{}>, {}Nonterminal<{}>);",
             self.prefix,
             triple_type,
             self.prefix,
@@ -627,17 +627,14 @@ impl<'ascent, 'grammar, W: Write>
 
         let mut base_args = vec![format!("{}tokens: &mut {}TOKENS", self.prefix, self.prefix)];
         if !starts_with_terminal {
-            base_args.push(format!(
-                "{}lookahead: core::option::Option<{}>",
-                self.prefix, triple_type,
-            ));
+            base_args.push(format!("{}lookahead: Option<{}>", self.prefix, triple_type,));
         }
 
         // "Optional symbols" may or may not be consumed, so take an
         // `&mut Option`
         let optional_args = (0..optional_prefix.len()).map(|i| {
             format!(
-                "{}sym{}: &mut core::option::Option<{}>",
+                "{}sym{}: &mut Option<{}>",
                 self.prefix,
                 i,
                 self.types
@@ -873,7 +870,7 @@ impl<'ascent, 'grammar, W: Write>
             // this only occurs in the start state
             rust!(
                 self.out,
-                "let {}start: {} = core::default::Default::default();",
+                "let {}start: {} = Default::default();",
                 self.prefix,
                 loc_type,
             );

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -11,7 +11,7 @@ use std::io::{self, Write};
 /// Base struct for various kinds of code generator. The flavor of
 /// code generator is customized by supplying distinct types for `C`
 /// (e.g., `self::ascent::RecursiveAscent`).
-pub struct CodeGenerator<'codegen, 'grammar: 'codegen, W: Write + 'codegen, C> {
+pub struct CodeGenerator<'codegen, 'grammar, W: Write, C> {
     /// the complete grammar
     pub grammar: &'grammar Grammar,
 
@@ -161,7 +161,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         rust!(self.out, "#[rustfmt::skip]");
         rust!(
             self.out,
-            "#[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, \
+            "#[allow(explicit_outlives_requirements, non_snake_case, non_camel_case_types, unused_mut, unused_variables, \
              unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding, clippy::needless_raw_string_hashes)]"
         );
         rust!(self.out, "mod {}parse{} {{", self.prefix, self.start_symbol);

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -42,7 +42,7 @@ enum Comment<'a, T> {
 }
 
 impl<'a, T: fmt::Display> fmt::Display for Comment<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Comment::Goto(ref token, new_state) => {
                 write!(f, " // on {}, goto {}", token, new_state)
@@ -682,7 +682,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
 
     fn write_reduction<'s>(
         custom: &TableDriven<'grammar>,
-        state: &'s Lr1State,
+        state: &'s Lr1State<'_>,
         token: &Token,
     ) -> (i32, Comment<'s, Token>) {
         let reduction = state

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -177,7 +177,7 @@ pub type LrResult<'grammar, L> =
 pub type Lr1Result<'grammar> = LrResult<'grammar, TokenSet>;
 
 impl<'grammar, L: Lookahead> Debug for Item<'grammar, L> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(
             fmt,
             "{} ={} (*){}",
@@ -191,7 +191,7 @@ impl<'grammar, L: Lookahead> Debug for Item<'grammar, L> {
 }
 
 impl Display for Token {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             Token::Eof => write!(fmt, "Eof"),
             Token::Error => write!(fmt, "Error"),
@@ -201,19 +201,19 @@ impl Display for Token {
 }
 
 impl Debug for Token {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "{}", self)
     }
 }
 
 impl Debug for StateIndex {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "S{}", self.0)
     }
 }
 
 impl Display for StateIndex {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "{}", self.0)
     }
 }

--- a/lalrpop/src/lr1/error/mod.rs
+++ b/lalrpop/src/lr1/error/mod.rs
@@ -17,14 +17,14 @@ mod test;
 
 pub fn report_error<E>(
     grammar: &Grammar,
-    error: &Lr1TableConstructionError,
+    error: &Lr1TableConstructionError<'_>,
     reporter: impl FnMut(Message) -> Result<(), E>,
 ) -> Result<(), E> {
     let mut cx = ErrorReportingCx::new(grammar, &error.states, &error.conflicts);
     cx.report_errors(reporter)
 }
 
-struct ErrorReportingCx<'cx, 'grammar: 'cx> {
+struct ErrorReportingCx<'cx, 'grammar> {
     grammar: &'grammar Grammar,
     first_sets: FirstSets,
     states: &'cx [Lr1State<'grammar>],

--- a/lalrpop/src/lr1/example/mod.rs
+++ b/lalrpop/src/lr1/example/mod.rs
@@ -377,7 +377,7 @@ impl Content for ExamplePicture {
 }
 
 impl Debug for ExamplePicture {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         Debug::fmt(&self.example, fmt)
     }
 }

--- a/lalrpop/src/lr1/interpret.rs
+++ b/lalrpop/src/lr1/interpret.rs
@@ -37,7 +37,7 @@ where
     Ok(m.state_stack)
 }
 
-struct Machine<'grammar, L: LookaheadInterpret + 'grammar> {
+struct Machine<'grammar, L: LookaheadInterpret> {
     states: &'grammar [State<'grammar, L>],
     state_stack: Vec<StateIndex>,
     data_stack: Vec<ParseTree>,
@@ -155,13 +155,13 @@ where
 }
 
 impl Debug for ParseTree {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         Display::fmt(self, fmt)
     }
 }
 
 impl Display for ParseTree {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             ParseTree::Nonterminal(ref id, ref trees) => {
                 write!(fmt, "[{}: {}]", id, Sep(", ", trees))

--- a/lalrpop/src/lr1/lane_table/construct/merge.rs
+++ b/lalrpop/src/lr1/lane_table/construct/merge.rs
@@ -14,7 +14,7 @@ use ena::unify::InPlaceUnificationTable;
 /// set of S will be compatible with the reduced context of T2).
 ///
 /// [r]: ../README.md
-pub struct Merge<'m, 'grammar: 'm> {
+pub struct Merge<'m, 'grammar> {
     table: &'m LaneTable<'grammar>,
     states: &'m mut Vec<Lr1State<'grammar>>,
     visited: Set<StateIndex>,

--- a/lalrpop/src/lr1/lane_table/lane/mod.rs
+++ b/lalrpop/src/lr1/lane_table/lane/mod.rs
@@ -10,7 +10,7 @@ use crate::lr1::state_graph::StateGraph;
 
 use super::table::{ConflictIndex, LaneTable};
 
-pub struct LaneTracer<'trace, 'grammar: 'trace, L: Lookahead + 'trace> {
+pub struct LaneTracer<'trace, 'grammar, L: Lookahead> {
     states: &'trace [State<'grammar, L>],
     first_sets: &'trace FirstSets,
     state_graph: &'trace StateGraph,

--- a/lalrpop/src/lr1/lane_table/table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/table/mod.rs
@@ -43,7 +43,7 @@ pub struct LaneTable<'grammar> {
 }
 
 impl<'grammar> LaneTable<'grammar> {
-    pub fn new(grammar: &'grammar Grammar, conflicts: usize) -> LaneTable {
+    pub fn new(grammar: &'grammar Grammar, conflicts: usize) -> LaneTable<'_> {
         LaneTable {
             _grammar: grammar,
             conflicts,
@@ -148,7 +148,7 @@ impl<'grammar> LaneTable<'grammar> {
 }
 
 impl<'grammar> Debug for LaneTable<'grammar> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let indices: Set<StateIndex> = self
             .lookaheads
             .keys()

--- a/lalrpop/src/lr1/lane_table/test.rs
+++ b/lalrpop/src/lr1/lane_table/test.rs
@@ -36,7 +36,7 @@ fn nt(t: &str) -> NonterminalString {
     NonterminalString(Atom::from(t))
 }
 
-fn traverse(states: &[Lr0State], tokens: &[&str]) -> StateIndex {
+fn traverse(states: &[Lr0State<'_>], tokens: &[&str]) -> StateIndex {
     interpret::interpret_partial(states, tokens.iter().map(|&s| term(s)))
         .unwrap()
         .pop()

--- a/lalrpop/src/lr1/lookahead.rs
+++ b/lalrpop/src/lr1/lookahead.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Error, Formatter};
 use std::hash::Hash;
 
 pub trait Lookahead: Clone + Debug + Eq + Ord + Hash + Collection<Item = Self> {
-    fn fmt_as_item_suffix(&self, fmt: &mut Formatter) -> Result<(), Error>;
+    fn fmt_as_item_suffix(&self, fmt: &mut Formatter<'_>) -> Result<(), Error>;
 
     fn conflicts<'grammar>(this_state: &State<'grammar, Self>) -> Vec<Conflict<'grammar, Self>>;
 }
@@ -24,7 +24,7 @@ impl Collection for Nil {
 }
 
 impl Lookahead for Nil {
-    fn fmt_as_item_suffix(&self, _fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt_as_item_suffix(&self, _fmt: &mut Formatter<'_>) -> Result<(), Error> {
         Ok(())
     }
 
@@ -74,7 +74,7 @@ pub enum Token {
 }
 
 impl Lookahead for TokenSet {
-    fn fmt_as_item_suffix(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt_as_item_suffix(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, " {:?}", self)
     }
 
@@ -285,7 +285,7 @@ impl<'iter> Iterator for TokenSetIter<'iter> {
 }
 
 impl Debug for TokenSet {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let terminals: Vec<_> = self.iter().collect();
         Debug::fmt(&terminals, fmt)
     }

--- a/lalrpop/src/lr1/mod.rs
+++ b/lalrpop/src/lr1/mod.rs
@@ -45,7 +45,7 @@ pub fn generate_report<'grammar, W: Write + 'grammar>(
 
 /// By packing all states which start a reduction we can generate a smaller goto table as any
 /// states not starting a reduction will not need a row
-fn rewrite_state_indices(grammar: &Grammar, states: &mut [core::Lr1State]) {
+fn rewrite_state_indices(grammar: &Grammar, states: &mut [core::Lr1State<'_>]) {
     let mut start_states = vec![false; states.len()];
     for (index, state) in states.iter_mut().enumerate() {
         debug_assert!(state.index.0 == index);

--- a/lalrpop/src/lr1/report/mod.rs
+++ b/lalrpop/src/lr1/report/mod.rs
@@ -18,7 +18,7 @@ static INDENT_STRING: &str = "    ";
 
 struct ReportGenerator<'report, W>
 where
-    W: Write + 'report,
+    W: Write,
 {
     pub out: &'report mut W,
 }
@@ -393,7 +393,7 @@ where
     m.map(|k| k.display_len()).fold(0, max)
 }
 
-fn get_width_for_gotos<L>(state: &State<L>) -> usize
+fn get_width_for_gotos<L>(state: &State<'_, L>) -> usize
 where
     L: Lookahead,
 {

--- a/lalrpop/src/lr1/state_graph.rs
+++ b/lalrpop/src/lr1/state_graph.rs
@@ -12,7 +12,7 @@ pub struct StateGraph {
 }
 
 impl StateGraph {
-    pub fn new<L>(states: &[State<L>]) -> StateGraph
+    pub fn new<L>(states: &[State<'_, L>]) -> StateGraph
     where
         L: Lookahead,
     {

--- a/lalrpop/src/lr1/trace/mod.rs
+++ b/lalrpop/src/lr1/trace/mod.rs
@@ -8,7 +8,7 @@ mod reduce;
 mod shift;
 mod trace_graph;
 
-pub struct Tracer<'trace, 'grammar: 'trace> {
+pub struct Tracer<'trace, 'grammar> {
     states: &'trace [Lr1State<'grammar>],
     first_sets: &'trace FirstSets,
     state_graph: StateGraph,

--- a/lalrpop/src/lr1/trace/trace_graph/mod.rs
+++ b/lalrpop/src/lr1/trace/trace_graph/mod.rs
@@ -141,13 +141,13 @@ struct TraceGraphEdge<'grammar> {
 }
 
 impl<'grammar> Debug for TraceGraphEdge<'grammar> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "({:?} -{:?}-> {:?})", self.from, self.label, self.to)
     }
 }
 
 impl<'grammar> Debug for TraceGraph<'grammar> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let mut s = fmt.debug_list();
         for (node, &index) in &self.indices {
             for edge in self.graph.edges_directed(index, EdgeDirection::Outgoing) {
@@ -171,12 +171,12 @@ impl<'grammar> Debug for TraceGraph<'grammar> {
 // is found, you can then find the complete list of symbols by calling
 // `symbols_and_cursor` and also get access to the state.
 
-pub struct PathEnumerator<'graph, 'grammar: 'graph> {
+pub struct PathEnumerator<'graph, 'grammar> {
     graph: &'graph TraceGraph<'grammar>,
     stack: Vec<EnumeratorState<'graph, 'grammar>>,
 }
 
-struct EnumeratorState<'graph, 'grammar: 'graph> {
+struct EnumeratorState<'graph, 'grammar> {
     index: NodeIndex,
     symbol_sets: SymbolSets<'grammar>,
     edges: Edges<'graph, SymbolSets<'grammar>, Directed>,
@@ -416,7 +416,7 @@ impl<'graph, 'grammar> Iterator for PathEnumerator<'graph, 'grammar> {
 // Like the path enumerator, but tests for examples with some specific
 // lookahead
 
-pub struct FilteredPathEnumerator<'graph, 'grammar: 'graph> {
+pub struct FilteredPathEnumerator<'graph, 'grammar> {
     base: PathEnumerator<'graph, 'grammar>,
     first_sets: &'graph FirstSets,
     lookahead: TokenSet,

--- a/lalrpop/src/message/message.rs
+++ b/lalrpop/src/message/message.rs
@@ -75,7 +75,7 @@ impl Content for Message {
 }
 
 impl Debug for Message {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         fmt.debug_struct("Message")
             .field("span", &self.span)
             .field("heading", &self.heading)

--- a/lalrpop/src/message/styled.rs
+++ b/lalrpop/src/message/styled.rs
@@ -30,7 +30,7 @@ impl Content for Styled {
 }
 
 impl Debug for Styled {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         fmt.debug_struct("Styled")
             .field("content", &self.content)
             .finish()

--- a/lalrpop/src/normalize/macro_expand/test.rs
+++ b/lalrpop/src/normalize/macro_expand/test.rs
@@ -28,7 +28,7 @@ grammar;
         <v:`(<"Id"> ",")*`> <e:`"Id"?`> => v.into_iter().chain(e.into_iter()).collect();
 
     #[inline]
-    `"Id"?`: core::option::Option<#"Id"#> = {
+    `"Id"?`: Option<#"Id"#> = {
         "Id" => Some(<>),
         => None
     };

--- a/lalrpop/src/normalize/precedence/mod.rs
+++ b/lalrpop/src/normalize/precedence/mod.rs
@@ -303,7 +303,7 @@ fn expand_nonterm(mut nonterm: NonterminalData) -> NormResult<Vec<GrammarItem>> 
 fn replace_nonterm(
     alt: &mut Alternative,
     target: &NonterminalString,
-    subst: Substitution,
+    subst: Substitution<'_>,
     dir: Direction,
 ) {
     replace_symbols(&mut alt.expr.symbols, target, subst, dir);

--- a/lalrpop/src/normalize/resolve/mod.rs
+++ b/lalrpop/src/normalize/resolve/mod.rs
@@ -162,7 +162,7 @@ impl Validator {
 
     fn validate_alternative(
         &self,
-        scope: &ScopeChain,
+        scope: &ScopeChain<'_>,
         alternative: &mut Alternative,
     ) -> NormResult<()> {
         if let Some(ref condition) = alternative.condition {
@@ -186,7 +186,7 @@ impl Validator {
         Ok(())
     }
 
-    fn validate_expr(&self, scope: &ScopeChain, expr: &mut ExprSymbol) -> NormResult<()> {
+    fn validate_expr(&self, scope: &ScopeChain<'_>, expr: &mut ExprSymbol) -> NormResult<()> {
         for symbol in &mut expr.symbols {
             self.validate_symbol(scope, symbol)?;
         }
@@ -194,7 +194,7 @@ impl Validator {
         Ok(())
     }
 
-    fn validate_symbol(&self, scope: &ScopeChain, symbol: &mut Symbol) -> NormResult<()> {
+    fn validate_symbol(&self, scope: &ScopeChain<'_>, symbol: &mut Symbol) -> NormResult<()> {
         match symbol.kind {
             SymbolKind::Expr(ref mut expr) => {
                 self.validate_expr(scope, expr)?;
@@ -261,7 +261,7 @@ impl Validator {
         Ok(())
     }
 
-    fn rewrite_ambiguous_id(&self, scope: &ScopeChain, symbol: &mut Symbol) -> NormResult<()> {
+    fn rewrite_ambiguous_id(&self, scope: &ScopeChain<'_>, symbol: &mut Symbol) -> NormResult<()> {
         let id = if let SymbolKind::AmbiguousId(ref name) = symbol.kind {
             name.clone()
         } else {
@@ -275,7 +275,7 @@ impl Validator {
         Ok(())
     }
 
-    fn validate_id(&self, scope: &ScopeChain, span: Span, id: &Atom) -> NormResult<Def> {
+    fn validate_id(&self, scope: &ScopeChain<'_>, span: Span, id: &Atom) -> NormResult<Def> {
         match scope.def(id) {
             Some(def) => Ok(def),
             None => return_err!(span, "no definition found for `{}`", id),

--- a/lalrpop/src/normalize/tyinfer/mod.rs
+++ b/lalrpop/src/normalize/tyinfer/mod.rs
@@ -232,7 +232,7 @@ impl<'grammar> TypeInferencer<'grammar> {
 
     fn push<F, R>(&mut self, id: &NonterminalString, f: F) -> NormResult<R>
     where
-        F: FnOnce(&mut TypeInferencer) -> NormResult<R>,
+        F: FnOnce(&mut TypeInferencer<'_>) -> NormResult<R>,
     {
         self.stack.push(id.clone());
         let r = f(self);

--- a/lalrpop/src/normalize/tyinfer/test.rs
+++ b/lalrpop/src/normalize/tyinfer/test.rs
@@ -113,7 +113,7 @@ grammar;
     X = Y?;
     Y = "Hi";
 "#,
-        vec![("X", "core::option::Option<Tok>"), ("Y", "Tok")],
+        vec![("X", "Option<Tok>"), ("Y", "Tok")],
     )
 }
 
@@ -129,10 +129,10 @@ grammar;
     Z = "Hi"?;
 "#,
         vec![
-            ("A", "alloc::vec::Vec<core::option::Option<Tok>>"),
+            ("A", "alloc::vec::Vec<Option<Tok>>"),
             ("X", "alloc::vec::Vec<Tok>"),
             ("Y", "alloc::vec::Vec<Tok>"),
-            ("Z", "core::option::Option<Tok>"),
+            ("Z", "Option<Tok>"),
         ],
     )
 }

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -12,11 +12,11 @@ use super::Top;
 extern crate lalrpop_util as ___lalrpop_util;
 #[allow(unused_imports)]
 use self::___lalrpop_util::state_machine as ___state_machine;
-extern crate core;
+#[allow(unused_extern_crates)]
 extern crate alloc;
 
 #[rustfmt::skip]
-#[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding, clippy::needless_raw_string_hashes)]
+#[allow(explicit_outlives_requirements, non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding, clippy::needless_raw_string_hashes)]
 mod ___parse___Top {
 
 use string_cache::DefaultAtom as Atom;
@@ -31,7 +31,7 @@ use super::super::Top;
 extern crate lalrpop_util as ___lalrpop_util;
 #[allow(unused_imports)]
 use self::___lalrpop_util::state_machine as ___state_machine;
-extern crate core;
+#[allow(unused_extern_crates)]
 extern crate alloc;
 use super::___ToTriple;
 #[allow(dead_code)]
@@ -39,13 +39,13 @@ pub(crate) enum ___Symbol<'input>
  {
 Variant0(Tok<'input>),
 Variant1(&'input str),
-Variant2(core::option::Option<Tok<'input>>),
+Variant2(Option<Tok<'input>>),
 Variant3(TypeRef),
-Variant4(core::option::Option<TypeRef>),
+Variant4(Option<TypeRef>),
 Variant5(Vec<TypeBoundParameter<TypeRef>>),
-Variant6(core::option::Option<Vec<TypeBoundParameter<TypeRef>>>),
+Variant6(Option<Vec<TypeBoundParameter<TypeRef>>>),
 Variant7(Condition),
-Variant8(core::option::Option<Condition>),
+Variant8(Option<Condition>),
 Variant9(()),
 Variant10(Alternative),
 Variant11(alloc::vec::Vec<Alternative>),
@@ -78,13 +78,13 @@ Variant37(alloc::vec::Vec<TypeParameter>),
 Variant38(alloc::vec::Vec<TypeRef>),
 Variant39(usize),
 Variant40(ActionKind),
-Variant41(core::option::Option<ActionKind>),
-Variant42(core::option::Option<Alternative>),
+Variant41(Option<ActionKind>),
+Variant42(Option<Alternative>),
 Variant43(Vec<Alternative>),
 Variant44(Annotation),
 Variant45(alloc::vec::Vec<Annotation>),
 Variant46((Atom, String)),
-Variant47(core::option::Option<(Atom, String)>),
+Variant47(Option<(Atom, String)>),
 Variant48(AssociatedType),
 Variant49(alloc::vec::Vec<AssociatedType>),
 Variant50(Vec<Conversion>),
@@ -97,28 +97,28 @@ Variant56(Vec<Symbol>),
 Variant57(Vec<TypeParameter>),
 Variant58(Vec<TypeRef>),
 Variant59(ConditionOp),
-Variant60(core::option::Option<Conversion>),
+Variant60(Option<Conversion>),
 Variant61(EnumToken),
 Variant62(ExprSymbol),
 Variant63(GrammarItem),
-Variant64(core::option::Option<FieldPattern<TypeRef>>),
+Variant64(Option<FieldPattern<TypeRef>>),
 Variant65(Grammar),
 Variant66(alloc::vec::Vec<GrammarItem>),
-Variant67(core::option::Option<Parameter>),
-Variant68(core::option::Option<Vec<Parameter>>),
-Variant69(core::option::Option<Vec<TypeParameter>>),
-Variant70(core::option::Option<WhereClause<TypeRef>>),
-Variant71(core::option::Option<Vec<WhereClause<TypeRef>>>),
-Variant72(core::option::Option<Lifetime>),
+Variant67(Option<Parameter>),
+Variant68(Option<Vec<Parameter>>),
+Variant69(Option<Vec<TypeParameter>>),
+Variant70(Option<WhereClause<TypeRef>>),
+Variant71(Option<Vec<WhereClause<TypeRef>>>),
+Variant72(Option<Lifetime>),
 Variant73(MatchContents),
-Variant74(core::option::Option<MatchItem>),
+Variant74(Option<MatchItem>),
 Variant75(MatchMapping),
 Variant76(TerminalLiteral),
 Variant77(MatchToken),
 Variant78((NonterminalString, Vec<NonterminalString>)),
-Variant79(core::option::Option<NonterminalString>),
+Variant79(Option<NonterminalString>),
 Variant80(Path),
-Variant81(core::option::Option<Pattern<TypeRef>>),
+Variant81(Option<Pattern<TypeRef>>),
 Variant82(PatternKind<TypeRef>),
 Variant83(Vec<Lifetime>),
 Variant84(Vec<TypeBound<TypeRef>>),
@@ -126,12 +126,12 @@ Variant85(TerminalString),
 Variant86(RepeatOp),
 Variant87(String),
 Variant88(alloc::vec::Vec<String>),
-Variant89(core::option::Option<Symbol>),
+Variant89(Option<Symbol>),
 Variant90(SymbolKind),
 Variant91(Top),
-Variant92(core::option::Option<TypeBound<TypeRef>>),
-Variant93(core::option::Option<TypeBoundParameter<TypeRef>>),
-Variant94(core::option::Option<TypeParameter>),
+Variant92(Option<TypeBound<TypeRef>>),
+Variant93(Option<TypeBoundParameter<TypeRef>>),
+Variant94(Option<TypeParameter>),
 Variant95(Visibility),
 }
 const ___ACTION: &[i16] = &[
@@ -8245,6 +8245,248 @@ Some((___l, ___Symbol::Variant26(___v), ___r)) => (___l, ___v, ___r),
 _ => ___symbol_type_mismatch()
 }
 }
+fn ___pop_Variant47<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<(Atom, String)>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant47(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant41<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<ActionKind>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant41(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant42<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<Alternative>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant42(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant8<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<Condition>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant8(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant60<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<Conversion>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant60(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant64<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<FieldPattern<TypeRef>>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant64(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant72<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<Lifetime>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant72(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant74<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<MatchItem>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant74(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant79<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<NonterminalString>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant79(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant67<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<Parameter>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant67(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant81<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<Pattern<TypeRef>>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant81(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant89<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<Symbol>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant89(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant2<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<Tok<'input>>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant2(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant92<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<TypeBound<TypeRef>>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant92(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant93<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<TypeBoundParameter<TypeRef>>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant93(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant94<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<TypeParameter>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant94(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant4<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<TypeRef>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant4(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant68<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<Vec<Parameter>>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant68(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant6<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<Vec<TypeBoundParameter<TypeRef>>>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant6(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant69<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<Vec<TypeParameter>>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant69(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant71<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<Vec<WhereClause<TypeRef>>>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant71(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
+fn ___pop_Variant70<
+  'input,
+>(
+___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
+) -> (usize, Option<WhereClause<TypeRef>>, usize)
+ {
+match ___symbols.pop() {
+Some((___l, ___Symbol::Variant70(___v), ___r)) => (___l, ___v, ___r),
+_ => ___symbol_type_mismatch()
+}
+}
 fn ___pop_Variant16<
   'input,
 >(
@@ -8792,248 +9034,6 @@ ___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
  {
 match ___symbols.pop() {
 Some((___l, ___Symbol::Variant19(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant47<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<(Atom, String)>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant47(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant41<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<ActionKind>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant41(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant42<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<Alternative>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant42(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant8<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<Condition>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant8(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant60<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<Conversion>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant60(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant64<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<FieldPattern<TypeRef>>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant64(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant72<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<Lifetime>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant72(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant74<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<MatchItem>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant74(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant79<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<NonterminalString>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant79(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant67<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<Parameter>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant67(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant81<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<Pattern<TypeRef>>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant81(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant89<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<Symbol>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant89(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant2<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<Tok<'input>>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant2(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant92<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<TypeBound<TypeRef>>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant92(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant93<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<TypeBoundParameter<TypeRef>>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant93(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant94<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<TypeParameter>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant94(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant4<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<TypeRef>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant4(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant68<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<Vec<Parameter>>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant68(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant6<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<Vec<TypeBoundParameter<TypeRef>>>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant6(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant69<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<Vec<TypeParameter>>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant69(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant71<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant71(___v), ___r)) => (___l, ___v, ___r),
-_ => ___symbol_type_mismatch()
-}
-}
-fn ___pop_Variant70<
-  'input,
->(
-___symbols: &mut alloc::vec::Vec<(usize,___Symbol<'input>,usize)>
-) -> (usize, core::option::Option<WhereClause<TypeRef>>, usize)
- {
-match ___symbols.pop() {
-Some((___l, ___Symbol::Variant70(___v), ___r)) => (___l, ___v, ___r),
 _ => ___symbol_type_mismatch()
 }
 }
@@ -18914,9 +18914,9 @@ text: &'input str,
 (_, lo, _): (usize, usize, usize),
 (_, _, _): (usize, Tok<'input>, usize),
 (_, hi, _): (usize, usize, usize),
-(_, tps, _): (usize, core::option::Option<Vec<TypeParameter>>, usize),
-(_, parameters, _): (usize, core::option::Option<Vec<Parameter>>, usize),
-(_, where_clauses, _): (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+(_, tps, _): (usize, Option<Vec<TypeParameter>>, usize),
+(_, parameters, _): (usize, Option<Vec<Parameter>>, usize),
+(_, where_clauses, _): (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 (_, _, _): (usize, Tok<'input>, usize),
 (_, items, _): (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -19075,7 +19075,7 @@ text: &'input str,
 (_, _, _): (usize, Tok<'input>, usize),
 (_, params, _): (usize, Vec<TypeRef>, usize),
 (_, _, _): (usize, Tok<'input>, usize),
-(_, ret, _): (usize, core::option::Option<TypeRef>, usize),
+(_, ret, _): (usize, Option<TypeRef>, usize),
 ) -> TypeBound<TypeRef>
 {
 TypeBound::Fn { forall: f, path: p, parameters: params, ret }
@@ -19089,7 +19089,7 @@ fn ___action18<
 text: &'input str,
 (_, f, _): (usize, Vec<TypeParameter>, usize),
 (_, p, _): (usize, Path, usize),
-(_, params, _): (usize, core::option::Option<Vec<TypeBoundParameter<TypeRef>>>, usize),
+(_, params, _): (usize, Option<Vec<TypeBoundParameter<TypeRef>>>, usize),
 ) -> TypeBound<TypeRef>
 {
 TypeBound::Trait { forall: f, path: p, parameters: params.unwrap_or(vec![]) }
@@ -19288,7 +19288,7 @@ text: &'input str,
 (_, lo, _): (usize, usize, usize),
 (_, n, _): (usize, (NonterminalString, Vec<NonterminalString>), usize),
 (_, hi, _): (usize, usize, usize),
-(_, t, _): (usize, core::option::Option<TypeRef>, usize),
+(_, t, _): (usize, Option<TypeRef>, usize),
 (_, _, _): (usize, Tok<'input>, usize),
 (_, a, _): (usize, Vec<Alternative>, usize),
 ) -> GrammarItem
@@ -19330,7 +19330,7 @@ text: &'input str,
 (_, _, _): (usize, Tok<'input>, usize),
 (_, lo, _): (usize, usize, usize),
 (_, id, _): (usize, Atom, usize),
-(_, arg, _): (usize, core::option::Option<(Atom, String)>, usize),
+(_, arg, _): (usize, Option<(Atom, String)>, usize),
 (_, hi, _): (usize, usize, usize),
 (_, _, _): (usize, Tok<'input>, usize),
 ) -> Annotation
@@ -19401,7 +19401,7 @@ text: &'input str,
 (_, _, _): (usize, Tok<'input>, usize),
 (_, ___0, _): (usize, Vec<Alternative>, usize),
 (_, _, _): (usize, Tok<'input>, usize),
-(_, _, _): (usize, core::option::Option<Tok<'input>>, usize),
+(_, _, _): (usize, Option<Tok<'input>>, usize),
 ) -> Vec<Alternative>
 {
 ___0
@@ -19416,8 +19416,8 @@ text: &'input str,
 (_, ann, _): (usize, alloc::vec::Vec<Annotation>, usize),
 (_, lo, _): (usize, usize, usize),
 (_, s, _): (usize, alloc::vec::Vec<Symbol>, usize),
-(_, c, _): (usize, core::option::Option<Condition>, usize),
-(_, a, _): (usize, core::option::Option<ActionKind>, usize),
+(_, c, _): (usize, Option<Condition>, usize),
+(_, a, _): (usize, Option<ActionKind>, usize),
 (_, hi, _): (usize, usize, usize),
 ) -> Alternative
 {
@@ -19439,7 +19439,7 @@ fn ___action42<
 >(
 text: &'input str,
 (_, lo, _): (usize, usize, usize),
-(_, c, _): (usize, core::option::Option<Condition>, usize),
+(_, c, _): (usize, Option<Condition>, usize),
 (_, a, _): (usize, ActionKind, usize),
 (_, hi, _): (usize, usize, usize),
 ) -> Alternative
@@ -19589,7 +19589,7 @@ fn ___action53<
 text: &'input str,
 (_, lo, _): (usize, usize, usize),
 (_, _, _): (usize, Tok<'input>, usize),
-(_, m, _): (usize, core::option::Option<Tok<'input>>, usize),
+(_, m, _): (usize, Option<Tok<'input>>, usize),
 (_, _, _): (usize, usize, usize),
 (_, l, _): (usize, Atom, usize),
 (_, _, _): (usize, Tok<'input>, usize),
@@ -19858,8 +19858,8 @@ fn ___action73<
 >(
 text: &'input str,
 (_, _, _): (usize, Tok<'input>, usize),
-(_, l, _): (usize, core::option::Option<Lifetime>, usize),
-(_, m, _): (usize, core::option::Option<Tok<'input>>, usize),
+(_, l, _): (usize, Option<Lifetime>, usize),
+(_, m, _): (usize, Option<Tok<'input>>, usize),
 (_, t, _): (usize, TypeRef, usize),
 ) -> TypeRef
 {
@@ -19939,7 +19939,7 @@ text: &'input str,
 (_, _, _): (usize, Tok<'input>, usize),
 (_, parameters, _): (usize, Vec<TypeRef>, usize),
 (_, _, _): (usize, Tok<'input>, usize),
-(_, ret, _): (usize, core::option::Option<TypeRef>, usize),
+(_, ret, _): (usize, Option<TypeRef>, usize),
 ) -> TypeRef
 {
 TypeRef::Fn { forall, path, parameters, ret: ret.map(Box::new) }
@@ -19975,7 +19975,7 @@ fn ___action81<
     'input,
 >(
 text: &'input str,
-(_, a, _): (usize, core::option::Option<Tok<'input>>, usize),
+(_, a, _): (usize, Option<Tok<'input>>, usize),
 (_, h, _): (usize, alloc::vec::Vec<Atom>, usize),
 (_, t, _): (usize, Atom, usize),
 ) -> Path
@@ -20280,7 +20280,7 @@ text: &'input str,
 (_, p, _): (usize, Path, usize),
 (_, _, _): (usize, Tok<'input>, usize),
 (_, a0, _): (usize, alloc::vec::Vec<FieldPattern<TypeRef>>, usize),
-(_, a1, _): (usize, core::option::Option<FieldPattern<TypeRef>>, usize),
+(_, a1, _): (usize, Option<FieldPattern<TypeRef>>, usize),
 (_, _, _): (usize, Tok<'input>, usize),
 ) -> PatternKind<TypeRef>
 {
@@ -20608,7 +20608,7 @@ fn ___action124<
 >(
 text: &'input str,
 (_, ___0, _): (usize, FieldPattern<TypeRef>, usize),
-) -> core::option::Option<FieldPattern<TypeRef>>
+) -> Option<FieldPattern<TypeRef>>
 {
 Some(___0)
 }
@@ -20621,7 +20621,7 @@ fn ___action125<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<FieldPattern<TypeRef>>
+) -> Option<FieldPattern<TypeRef>>
 {
 None
 }
@@ -20671,7 +20671,7 @@ fn ___action129<
 >(
 text: &'input str,
 (_, v0, _): (usize, alloc::vec::Vec<Pattern<TypeRef>>, usize),
-(_, e1, _): (usize, core::option::Option<Pattern<TypeRef>>, usize),
+(_, e1, _): (usize, Option<Pattern<TypeRef>>, usize),
 ) -> Vec<Pattern<TypeRef>>
 {
 v0.into_iter().chain(e1).collect()
@@ -20684,7 +20684,7 @@ fn ___action130<
 >(
 text: &'input str,
 (_, v0, _): (usize, alloc::vec::Vec<Conversion>, usize),
-(_, e1, _): (usize, core::option::Option<Conversion>, usize),
+(_, e1, _): (usize, Option<Conversion>, usize),
 ) -> Vec<Conversion>
 {
 v0.into_iter().chain(e1).collect()
@@ -20697,7 +20697,7 @@ fn ___action131<
 >(
 text: &'input str,
 (_, v0, _): (usize, alloc::vec::Vec<MatchItem>, usize),
-(_, e1, _): (usize, core::option::Option<MatchItem>, usize),
+(_, e1, _): (usize, Option<MatchItem>, usize),
 ) -> Vec<MatchItem>
 {
 v0.into_iter().chain(e1).collect()
@@ -20773,7 +20773,7 @@ fn ___action137<
 >(
 text: &'input str,
 (_, ___0, _): (usize, Tok<'input>, usize),
-) -> core::option::Option<Tok<'input>>
+) -> Option<Tok<'input>>
 {
 Some(___0)
 }
@@ -20786,7 +20786,7 @@ fn ___action138<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<Tok<'input>>
+) -> Option<Tok<'input>>
 {
 None
 }
@@ -20798,7 +20798,7 @@ fn ___action139<
 >(
 text: &'input str,
 (_, v0, _): (usize, alloc::vec::Vec<TypeRef>, usize),
-(_, e1, _): (usize, core::option::Option<TypeRef>, usize),
+(_, e1, _): (usize, Option<TypeRef>, usize),
 ) -> Vec<TypeRef>
 {
 v0.into_iter().chain(e1).collect()
@@ -20811,7 +20811,7 @@ fn ___action140<
 >(
 text: &'input str,
 (_, ___0, _): (usize, Lifetime, usize),
-) -> core::option::Option<Lifetime>
+) -> Option<Lifetime>
 {
 Some(___0)
 }
@@ -20824,7 +20824,7 @@ fn ___action141<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<Lifetime>
+) -> Option<Lifetime>
 {
 None
 }
@@ -20836,7 +20836,7 @@ fn ___action142<
 >(
 text: &'input str,
 (_, v0, _): (usize, alloc::vec::Vec<Symbol>, usize),
-(_, e1, _): (usize, core::option::Option<Symbol>, usize),
+(_, e1, _): (usize, Option<Symbol>, usize),
 ) -> Vec<Symbol>
 {
 v0.into_iter().chain(e1).collect()
@@ -20849,7 +20849,7 @@ fn ___action143<
 >(
 text: &'input str,
 (_, ___0, _): (usize, Tok<'input>, usize),
-) -> core::option::Option<Tok<'input>>
+) -> Option<Tok<'input>>
 {
 Some(___0)
 }
@@ -20862,7 +20862,7 @@ fn ___action144<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<Tok<'input>>
+) -> Option<Tok<'input>>
 {
 None
 }
@@ -20899,7 +20899,7 @@ fn ___action147<
 >(
 text: &'input str,
 (_, ___0, _): (usize, ActionKind, usize),
-) -> core::option::Option<ActionKind>
+) -> Option<ActionKind>
 {
 Some(___0)
 }
@@ -20912,7 +20912,7 @@ fn ___action148<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<ActionKind>
+) -> Option<ActionKind>
 {
 None
 }
@@ -20924,7 +20924,7 @@ fn ___action149<
 >(
 text: &'input str,
 (_, ___0, _): (usize, Condition, usize),
-) -> core::option::Option<Condition>
+) -> Option<Condition>
 {
 Some(___0)
 }
@@ -20937,7 +20937,7 @@ fn ___action150<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<Condition>
+) -> Option<Condition>
 {
 None
 }
@@ -20987,7 +20987,7 @@ fn ___action154<
 >(
 text: &'input str,
 (_, ___0, _): (usize, Tok<'input>, usize),
-) -> core::option::Option<Tok<'input>>
+) -> Option<Tok<'input>>
 {
 Some(___0)
 }
@@ -21000,7 +21000,7 @@ fn ___action155<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<Tok<'input>>
+) -> Option<Tok<'input>>
 {
 None
 }
@@ -21012,7 +21012,7 @@ fn ___action156<
 >(
 text: &'input str,
 (_, v0, _): (usize, alloc::vec::Vec<Alternative>, usize),
-(_, e1, _): (usize, core::option::Option<Alternative>, usize),
+(_, e1, _): (usize, Option<Alternative>, usize),
 ) -> Vec<Alternative>
 {
 v0.into_iter().chain(e1).collect()
@@ -21025,7 +21025,7 @@ fn ___action157<
 >(
 text: &'input str,
 (_, v0, _): (usize, alloc::vec::Vec<NonterminalString>, usize),
-(_, e1, _): (usize, core::option::Option<NonterminalString>, usize),
+(_, e1, _): (usize, Option<NonterminalString>, usize),
 ) -> Vec<NonterminalString>
 {
 v0.into_iter().chain(e1).collect()
@@ -21038,7 +21038,7 @@ fn ___action158<
 >(
 text: &'input str,
 (_, ___0, _): (usize, (Atom, String), usize),
-) -> core::option::Option<(Atom, String)>
+) -> Option<(Atom, String)>
 {
 Some(___0)
 }
@@ -21051,7 +21051,7 @@ fn ___action159<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<(Atom, String)>
+) -> Option<(Atom, String)>
 {
 None
 }
@@ -21063,7 +21063,7 @@ fn ___action160<
 >(
 text: &'input str,
 (_, ___0, _): (usize, TypeRef, usize),
-) -> core::option::Option<TypeRef>
+) -> Option<TypeRef>
 {
 Some(___0)
 }
@@ -21076,7 +21076,7 @@ fn ___action161<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<TypeRef>
+) -> Option<TypeRef>
 {
 None
 }
@@ -21101,7 +21101,7 @@ fn ___action163<
 >(
 text: &'input str,
 (_, v0, _): (usize, alloc::vec::Vec<Parameter>, usize),
-(_, e1, _): (usize, core::option::Option<Parameter>, usize),
+(_, e1, _): (usize, Option<Parameter>, usize),
 ) -> Vec<Parameter>
 {
 v0.into_iter().chain(e1).collect()
@@ -21114,7 +21114,7 @@ fn ___action164<
 >(
 text: &'input str,
 (_, ___0, _): (usize, Vec<TypeBoundParameter<TypeRef>>, usize),
-) -> core::option::Option<Vec<TypeBoundParameter<TypeRef>>>
+) -> Option<Vec<TypeBoundParameter<TypeRef>>>
 {
 Some(___0)
 }
@@ -21127,7 +21127,7 @@ fn ___action165<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<Vec<TypeBoundParameter<TypeRef>>>
+) -> Option<Vec<TypeBoundParameter<TypeRef>>>
 {
 None
 }
@@ -21153,7 +21153,7 @@ fn ___action167<
 >(
 text: &'input str,
 (_, v0, _): (usize, alloc::vec::Vec<TypeBoundParameter<TypeRef>>, usize),
-(_, e1, _): (usize, core::option::Option<TypeBoundParameter<TypeRef>>, usize),
+(_, e1, _): (usize, Option<TypeBoundParameter<TypeRef>>, usize),
 ) -> Vec<TypeBoundParameter<TypeRef>>
 {
 v0.into_iter().chain(e1).collect()
@@ -21166,7 +21166,7 @@ fn ___action168<
 >(
 text: &'input str,
 (_, ___0, _): (usize, TypeRef, usize),
-) -> core::option::Option<TypeRef>
+) -> Option<TypeRef>
 {
 Some(___0)
 }
@@ -21179,7 +21179,7 @@ fn ___action169<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<TypeRef>
+) -> Option<TypeRef>
 {
 None
 }
@@ -21204,7 +21204,7 @@ fn ___action171<
 >(
 text: &'input str,
 (_, v0, _): (usize, alloc::vec::Vec<TypeRef>, usize),
-(_, e1, _): (usize, core::option::Option<TypeRef>, usize),
+(_, e1, _): (usize, Option<TypeRef>, usize),
 ) -> Vec<TypeRef>
 {
 v0.into_iter().chain(e1).collect()
@@ -21217,7 +21217,7 @@ fn ___action172<
 >(
 text: &'input str,
 (_, mut v, _): (usize, alloc::vec::Vec<TypeBound<TypeRef>>, usize),
-(_, e, _): (usize, core::option::Option<TypeBound<TypeRef>>, usize),
+(_, e, _): (usize, Option<TypeBound<TypeRef>>, usize),
 ) -> Vec<TypeBound<TypeRef>>
 {
 match e {
@@ -21245,7 +21245,7 @@ fn ___action174<
 >(
 text: &'input str,
 (_, mut v, _): (usize, alloc::vec::Vec<Lifetime>, usize),
-(_, e, _): (usize, core::option::Option<Lifetime>, usize),
+(_, e, _): (usize, Option<Lifetime>, usize),
 ) -> Vec<Lifetime>
 {
 match e {
@@ -21261,7 +21261,7 @@ fn ___action175<
 >(
 text: &'input str,
 (_, v0, _): (usize, alloc::vec::Vec<WhereClause<TypeRef>>, usize),
-(_, e1, _): (usize, core::option::Option<WhereClause<TypeRef>>, usize),
+(_, e1, _): (usize, Option<WhereClause<TypeRef>>, usize),
 ) -> Vec<WhereClause<TypeRef>>
 {
 v0.into_iter().chain(e1).collect()
@@ -21274,7 +21274,7 @@ fn ___action176<
 >(
 text: &'input str,
 (_, v0, _): (usize, alloc::vec::Vec<TypeParameter>, usize),
-(_, e1, _): (usize, core::option::Option<TypeParameter>, usize),
+(_, e1, _): (usize, Option<TypeParameter>, usize),
 ) -> Vec<TypeParameter>
 {
 v0.into_iter().chain(e1).collect()
@@ -21312,7 +21312,7 @@ fn ___action179<
 >(
 text: &'input str,
 (_, ___0, _): (usize, Vec<WhereClause<TypeRef>>, usize),
-) -> core::option::Option<Vec<WhereClause<TypeRef>>>
+) -> Option<Vec<WhereClause<TypeRef>>>
 {
 Some(___0)
 }
@@ -21325,7 +21325,7 @@ fn ___action180<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<Vec<WhereClause<TypeRef>>>
+) -> Option<Vec<WhereClause<TypeRef>>>
 {
 None
 }
@@ -21337,7 +21337,7 @@ fn ___action181<
 >(
 text: &'input str,
 (_, ___0, _): (usize, Vec<Parameter>, usize),
-) -> core::option::Option<Vec<Parameter>>
+) -> Option<Vec<Parameter>>
 {
 Some(___0)
 }
@@ -21350,7 +21350,7 @@ fn ___action182<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<Vec<Parameter>>
+) -> Option<Vec<Parameter>>
 {
 None
 }
@@ -21362,7 +21362,7 @@ fn ___action183<
 >(
 text: &'input str,
 (_, ___0, _): (usize, Vec<TypeParameter>, usize),
-) -> core::option::Option<Vec<TypeParameter>>
+) -> Option<Vec<TypeParameter>>
 {
 Some(___0)
 }
@@ -21375,7 +21375,7 @@ fn ___action184<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<Vec<TypeParameter>>
+) -> Option<Vec<TypeParameter>>
 {
 None
 }
@@ -21586,7 +21586,7 @@ fn ___action201<
 >(
 text: &'input str,
 (_, ___0, _): (usize, TypeParameter, usize),
-) -> core::option::Option<TypeParameter>
+) -> Option<TypeParameter>
 {
 Some(___0)
 }
@@ -21599,7 +21599,7 @@ fn ___action202<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<TypeParameter>
+) -> Option<TypeParameter>
 {
 None
 }
@@ -21649,7 +21649,7 @@ fn ___action206<
 >(
 text: &'input str,
 (_, ___0, _): (usize, WhereClause<TypeRef>, usize),
-) -> core::option::Option<WhereClause<TypeRef>>
+) -> Option<WhereClause<TypeRef>>
 {
 Some(___0)
 }
@@ -21662,7 +21662,7 @@ fn ___action207<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<WhereClause<TypeRef>>
+) -> Option<WhereClause<TypeRef>>
 {
 None
 }
@@ -21750,7 +21750,7 @@ fn ___action214<
 >(
 text: &'input str,
 (_, ___0, _): (usize, TypeBound<TypeRef>, usize),
-) -> core::option::Option<TypeBound<TypeRef>>
+) -> Option<TypeBound<TypeRef>>
 {
 Some(___0)
 }
@@ -21763,7 +21763,7 @@ fn ___action215<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<TypeBound<TypeRef>>
+) -> Option<TypeBound<TypeRef>>
 {
 None
 }
@@ -21813,7 +21813,7 @@ fn ___action219<
 >(
 text: &'input str,
 (_, ___0, _): (usize, TypeRef, usize),
-) -> core::option::Option<TypeRef>
+) -> Option<TypeRef>
 {
 Some(___0)
 }
@@ -21826,7 +21826,7 @@ fn ___action220<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<TypeRef>
+) -> Option<TypeRef>
 {
 None
 }
@@ -21876,7 +21876,7 @@ fn ___action224<
 >(
 text: &'input str,
 (_, ___0, _): (usize, TypeBoundParameter<TypeRef>, usize),
-) -> core::option::Option<TypeBoundParameter<TypeRef>>
+) -> Option<TypeBoundParameter<TypeRef>>
 {
 Some(___0)
 }
@@ -21889,7 +21889,7 @@ fn ___action225<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<TypeBoundParameter<TypeRef>>
+) -> Option<TypeBoundParameter<TypeRef>>
 {
 None
 }
@@ -21939,7 +21939,7 @@ fn ___action229<
 >(
 text: &'input str,
 (_, ___0, _): (usize, Parameter, usize),
-) -> core::option::Option<Parameter>
+) -> Option<Parameter>
 {
 Some(___0)
 }
@@ -21952,7 +21952,7 @@ fn ___action230<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<Parameter>
+) -> Option<Parameter>
 {
 None
 }
@@ -22002,7 +22002,7 @@ fn ___action234<
 >(
 text: &'input str,
 (_, ___0, _): (usize, NonterminalString, usize),
-) -> core::option::Option<NonterminalString>
+) -> Option<NonterminalString>
 {
 Some(___0)
 }
@@ -22015,7 +22015,7 @@ fn ___action235<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<NonterminalString>
+) -> Option<NonterminalString>
 {
 None
 }
@@ -22065,7 +22065,7 @@ fn ___action239<
 >(
 text: &'input str,
 (_, ___0, _): (usize, Alternative, usize),
-) -> core::option::Option<Alternative>
+) -> Option<Alternative>
 {
 Some(___0)
 }
@@ -22078,7 +22078,7 @@ fn ___action240<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<Alternative>
+) -> Option<Alternative>
 {
 None
 }
@@ -22128,7 +22128,7 @@ fn ___action244<
 >(
 text: &'input str,
 (_, ___0, _): (usize, Symbol, usize),
-) -> core::option::Option<Symbol>
+) -> Option<Symbol>
 {
 Some(___0)
 }
@@ -22141,7 +22141,7 @@ fn ___action245<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<Symbol>
+) -> Option<Symbol>
 {
 None
 }
@@ -22191,7 +22191,7 @@ fn ___action249<
 >(
 text: &'input str,
 (_, ___0, _): (usize, TypeRef, usize),
-) -> core::option::Option<TypeRef>
+) -> Option<TypeRef>
 {
 Some(___0)
 }
@@ -22204,7 +22204,7 @@ fn ___action250<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<TypeRef>
+) -> Option<TypeRef>
 {
 None
 }
@@ -22304,7 +22304,7 @@ fn ___action258<
 >(
 text: &'input str,
 (_, ___0, _): (usize, MatchItem, usize),
-) -> core::option::Option<MatchItem>
+) -> Option<MatchItem>
 {
 Some(___0)
 }
@@ -22317,7 +22317,7 @@ fn ___action259<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<MatchItem>
+) -> Option<MatchItem>
 {
 None
 }
@@ -22367,7 +22367,7 @@ fn ___action263<
 >(
 text: &'input str,
 (_, ___0, _): (usize, Conversion, usize),
-) -> core::option::Option<Conversion>
+) -> Option<Conversion>
 {
 Some(___0)
 }
@@ -22380,7 +22380,7 @@ fn ___action264<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<Conversion>
+) -> Option<Conversion>
 {
 None
 }
@@ -22430,7 +22430,7 @@ fn ___action268<
 >(
 text: &'input str,
 (_, ___0, _): (usize, Pattern<TypeRef>, usize),
-) -> core::option::Option<Pattern<TypeRef>>
+) -> Option<Pattern<TypeRef>>
 {
 Some(___0)
 }
@@ -22443,7 +22443,7 @@ fn ___action269<
 text: &'input str,
 ___lookbehind: &usize,
 ___lookahead: &usize,
-) -> core::option::Option<Pattern<TypeRef>>
+) -> Option<Pattern<TypeRef>>
 {
 None
 }
@@ -23059,7 +23059,7 @@ fn ___action309<
 >(
 text: &'input str,
 ___0: (usize, Tok<'input>, usize),
-___1: (usize, core::option::Option<Lifetime>, usize),
+___1: (usize, Option<Lifetime>, usize),
 ___2: (usize, Tok<'input>, usize),
 ___3: (usize, TypeRef, usize),
 ) -> TypeRef
@@ -23088,7 +23088,7 @@ fn ___action310<
 >(
 text: &'input str,
 ___0: (usize, Tok<'input>, usize),
-___1: (usize, core::option::Option<Lifetime>, usize),
+___1: (usize, Option<Lifetime>, usize),
 ___2: (usize, TypeRef, usize),
 ) -> TypeRef
 {
@@ -23118,7 +23118,7 @@ fn ___action311<
 text: &'input str,
 ___0: (usize, Tok<'input>, usize),
 ___1: (usize, TypeRef, usize),
-) -> core::option::Option<TypeRef>
+) -> Option<TypeRef>
 {
 let ___start0 = ___0.0;
 let ___end0 = ___1.2;
@@ -23283,7 +23283,7 @@ fn ___action316<
 text: &'input str,
 ___0: (usize, Tok<'input>, usize),
 ___1: (usize, TypeRef, usize),
-) -> core::option::Option<TypeRef>
+) -> Option<TypeRef>
 {
 let ___start0 = ___0.0;
 let ___end0 = ___1.2;
@@ -23385,7 +23385,7 @@ text: &'input str,
 ___0: (usize, Tok<'input>, usize),
 ___1: (usize, Vec<TypeBoundParameter<TypeRef>>, usize),
 ___2: (usize, Tok<'input>, usize),
-) -> core::option::Option<Vec<TypeBoundParameter<TypeRef>>>
+) -> Option<Vec<TypeBoundParameter<TypeRef>>>
 {
 let ___start0 = ___0.0;
 let ___end0 = ___2.2;
@@ -23469,7 +23469,7 @@ fn ___action322<
 text: &'input str,
 ___0: (usize, Tok<'input>, usize),
 ___1: (usize, Condition, usize),
-) -> core::option::Option<Condition>
+) -> Option<Condition>
 {
 let ___start0 = ___0.0;
 let ___end0 = ___1.2;
@@ -23497,7 +23497,7 @@ ___1: (usize, usize, usize),
 ___2: (usize, alloc::vec::Vec<Symbol>, usize),
 ___3: (usize, Tok<'input>, usize),
 ___4: (usize, Condition, usize),
-___5: (usize, core::option::Option<ActionKind>, usize),
+___5: (usize, Option<ActionKind>, usize),
 ___6: (usize, usize, usize),
 ) -> Alternative
 {
@@ -23530,7 +23530,7 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<Annotation>, usize),
 ___1: (usize, usize, usize),
 ___2: (usize, alloc::vec::Vec<Symbol>, usize),
-___3: (usize, core::option::Option<ActionKind>, usize),
+___3: (usize, Option<ActionKind>, usize),
 ___4: (usize, usize, usize),
 ) -> Alternative
 {
@@ -23722,7 +23722,7 @@ fn ___action331<
     'input,
 >(
 text: &'input str,
-___0: (usize, core::option::Option<Alternative>, usize),
+___0: (usize, Option<Alternative>, usize),
 ) -> Vec<Alternative>
 {
 let ___start0 = ___0.0;
@@ -23748,7 +23748,7 @@ fn ___action332<
 >(
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<Alternative>, usize),
-___1: (usize, core::option::Option<Alternative>, usize),
+___1: (usize, Option<Alternative>, usize),
 ) -> Vec<Alternative>
 {
 let ___start0 = ___0.0;
@@ -23824,7 +23824,7 @@ fn ___action335<
     'input,
 >(
 text: &'input str,
-___0: (usize, core::option::Option<Conversion>, usize),
+___0: (usize, Option<Conversion>, usize),
 ) -> Vec<Conversion>
 {
 let ___start0 = ___0.0;
@@ -23850,7 +23850,7 @@ fn ___action336<
 >(
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<Conversion>, usize),
-___1: (usize, core::option::Option<Conversion>, usize),
+___1: (usize, Option<Conversion>, usize),
 ) -> Vec<Conversion>
 {
 let ___start0 = ___0.0;
@@ -23928,7 +23928,7 @@ fn ___action339<
 text: &'input str,
 ___0: (usize, Path, usize),
 ___1: (usize, Tok<'input>, usize),
-___2: (usize, core::option::Option<FieldPattern<TypeRef>>, usize),
+___2: (usize, Option<FieldPattern<TypeRef>>, usize),
 ___3: (usize, Tok<'input>, usize),
 ) -> PatternKind<TypeRef>
 {
@@ -23960,7 +23960,7 @@ text: &'input str,
 ___0: (usize, Path, usize),
 ___1: (usize, Tok<'input>, usize),
 ___2: (usize, alloc::vec::Vec<FieldPattern<TypeRef>>, usize),
-___3: (usize, core::option::Option<FieldPattern<TypeRef>>, usize),
+___3: (usize, Option<FieldPattern<TypeRef>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> PatternKind<TypeRef>
 {
@@ -24102,7 +24102,7 @@ fn ___action345<
     'input,
 >(
 text: &'input str,
-___0: (usize, core::option::Option<Parameter>, usize),
+___0: (usize, Option<Parameter>, usize),
 ) -> Vec<Parameter>
 {
 let ___start0 = ___0.0;
@@ -24128,7 +24128,7 @@ fn ___action346<
 >(
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<Parameter>, usize),
-___1: (usize, core::option::Option<Parameter>, usize),
+___1: (usize, Option<Parameter>, usize),
 ) -> Vec<Parameter>
 {
 let ___start0 = ___0.0;
@@ -24204,7 +24204,7 @@ fn ___action349<
     'input,
 >(
 text: &'input str,
-___0: (usize, core::option::Option<WhereClause<TypeRef>>, usize),
+___0: (usize, Option<WhereClause<TypeRef>>, usize),
 ) -> Vec<WhereClause<TypeRef>>
 {
 let ___start0 = ___0.0;
@@ -24230,7 +24230,7 @@ fn ___action350<
 >(
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<WhereClause<TypeRef>>, usize),
-___1: (usize, core::option::Option<WhereClause<TypeRef>>, usize),
+___1: (usize, Option<WhereClause<TypeRef>>, usize),
 ) -> Vec<WhereClause<TypeRef>>
 {
 let ___start0 = ___0.0;
@@ -24462,7 +24462,7 @@ fn ___action359<
     'input,
 >(
 text: &'input str,
-___0: (usize, core::option::Option<Lifetime>, usize),
+___0: (usize, Option<Lifetime>, usize),
 ) -> Vec<Lifetime>
 {
 let ___start0 = ___0.0;
@@ -24488,7 +24488,7 @@ fn ___action360<
 >(
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<Lifetime>, usize),
-___1: (usize, core::option::Option<Lifetime>, usize),
+___1: (usize, Option<Lifetime>, usize),
 ) -> Vec<Lifetime>
 {
 let ___start0 = ___0.0;
@@ -24564,7 +24564,7 @@ fn ___action363<
     'input,
 >(
 text: &'input str,
-___0: (usize, core::option::Option<MatchItem>, usize),
+___0: (usize, Option<MatchItem>, usize),
 ) -> Vec<MatchItem>
 {
 let ___start0 = ___0.0;
@@ -24590,7 +24590,7 @@ fn ___action364<
 >(
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<MatchItem>, usize),
-___1: (usize, core::option::Option<MatchItem>, usize),
+___1: (usize, Option<MatchItem>, usize),
 ) -> Vec<MatchItem>
 {
 let ___start0 = ___0.0;
@@ -24666,7 +24666,7 @@ fn ___action367<
     'input,
 >(
 text: &'input str,
-___0: (usize, core::option::Option<NonterminalString>, usize),
+___0: (usize, Option<NonterminalString>, usize),
 ) -> Vec<NonterminalString>
 {
 let ___start0 = ___0.0;
@@ -24692,7 +24692,7 @@ fn ___action368<
 >(
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<NonterminalString>, usize),
-___1: (usize, core::option::Option<NonterminalString>, usize),
+___1: (usize, Option<NonterminalString>, usize),
 ) -> Vec<NonterminalString>
 {
 let ___start0 = ___0.0;
@@ -24768,7 +24768,7 @@ fn ___action371<
     'input,
 >(
 text: &'input str,
-___0: (usize, core::option::Option<Pattern<TypeRef>>, usize),
+___0: (usize, Option<Pattern<TypeRef>>, usize),
 ) -> Vec<Pattern<TypeRef>>
 {
 let ___start0 = ___0.0;
@@ -24794,7 +24794,7 @@ fn ___action372<
 >(
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<Pattern<TypeRef>>, usize),
-___1: (usize, core::option::Option<Pattern<TypeRef>>, usize),
+___1: (usize, Option<Pattern<TypeRef>>, usize),
 ) -> Vec<Pattern<TypeRef>>
 {
 let ___start0 = ___0.0;
@@ -24870,7 +24870,7 @@ fn ___action375<
     'input,
 >(
 text: &'input str,
-___0: (usize, core::option::Option<Symbol>, usize),
+___0: (usize, Option<Symbol>, usize),
 ) -> Vec<Symbol>
 {
 let ___start0 = ___0.0;
@@ -24896,7 +24896,7 @@ fn ___action376<
 >(
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<Symbol>, usize),
-___1: (usize, core::option::Option<Symbol>, usize),
+___1: (usize, Option<Symbol>, usize),
 ) -> Vec<Symbol>
 {
 let ___start0 = ___0.0;
@@ -24972,7 +24972,7 @@ fn ___action379<
     'input,
 >(
 text: &'input str,
-___0: (usize, core::option::Option<TypeBound<TypeRef>>, usize),
+___0: (usize, Option<TypeBound<TypeRef>>, usize),
 ) -> Vec<TypeBound<TypeRef>>
 {
 let ___start0 = ___0.0;
@@ -24998,7 +24998,7 @@ fn ___action380<
 >(
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<TypeBound<TypeRef>>, usize),
-___1: (usize, core::option::Option<TypeBound<TypeRef>>, usize),
+___1: (usize, Option<TypeBound<TypeRef>>, usize),
 ) -> Vec<TypeBound<TypeRef>>
 {
 let ___start0 = ___0.0;
@@ -25074,7 +25074,7 @@ fn ___action383<
     'input,
 >(
 text: &'input str,
-___0: (usize, core::option::Option<TypeBoundParameter<TypeRef>>, usize),
+___0: (usize, Option<TypeBoundParameter<TypeRef>>, usize),
 ) -> Vec<TypeBoundParameter<TypeRef>>
 {
 let ___start0 = ___0.0;
@@ -25100,7 +25100,7 @@ fn ___action384<
 >(
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<TypeBoundParameter<TypeRef>>, usize),
-___1: (usize, core::option::Option<TypeBoundParameter<TypeRef>>, usize),
+___1: (usize, Option<TypeBoundParameter<TypeRef>>, usize),
 ) -> Vec<TypeBoundParameter<TypeRef>>
 {
 let ___start0 = ___0.0;
@@ -25176,7 +25176,7 @@ fn ___action387<
     'input,
 >(
 text: &'input str,
-___0: (usize, core::option::Option<TypeParameter>, usize),
+___0: (usize, Option<TypeParameter>, usize),
 ) -> Vec<TypeParameter>
 {
 let ___start0 = ___0.0;
@@ -25202,7 +25202,7 @@ fn ___action388<
 >(
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<TypeParameter>, usize),
-___1: (usize, core::option::Option<TypeParameter>, usize),
+___1: (usize, Option<TypeParameter>, usize),
 ) -> Vec<TypeParameter>
 {
 let ___start0 = ___0.0;
@@ -25278,7 +25278,7 @@ fn ___action391<
     'input,
 >(
 text: &'input str,
-___0: (usize, core::option::Option<TypeRef>, usize),
+___0: (usize, Option<TypeRef>, usize),
 ) -> Vec<TypeRef>
 {
 let ___start0 = ___0.0;
@@ -25304,7 +25304,7 @@ fn ___action392<
 >(
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<TypeRef>, usize),
-___1: (usize, core::option::Option<TypeRef>, usize),
+___1: (usize, Option<TypeRef>, usize),
 ) -> Vec<TypeRef>
 {
 let ___start0 = ___0.0;
@@ -25380,7 +25380,7 @@ fn ___action395<
     'input,
 >(
 text: &'input str,
-___0: (usize, core::option::Option<TypeRef>, usize),
+___0: (usize, Option<TypeRef>, usize),
 ) -> Vec<TypeRef>
 {
 let ___start0 = ___0.0;
@@ -25406,7 +25406,7 @@ fn ___action396<
 >(
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<TypeRef>, usize),
-___1: (usize, core::option::Option<TypeRef>, usize),
+___1: (usize, Option<TypeRef>, usize),
 ) -> Vec<TypeRef>
 {
 let ___start0 = ___0.0;
@@ -25434,7 +25434,7 @@ ___0: (usize, alloc::vec::Vec<Annotation>, usize),
 ___1: (usize, alloc::vec::Vec<Symbol>, usize),
 ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Condition, usize),
-___4: (usize, core::option::Option<ActionKind>, usize),
+___4: (usize, Option<ActionKind>, usize),
 ___5: (usize, usize, usize),
 ) -> Alternative
 {
@@ -25467,7 +25467,7 @@ fn ___action398<
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<Annotation>, usize),
 ___1: (usize, alloc::vec::Vec<Symbol>, usize),
-___2: (usize, core::option::Option<ActionKind>, usize),
+___2: (usize, Option<ActionKind>, usize),
 ___3: (usize, usize, usize),
 ) -> Alternative
 {
@@ -25557,7 +25557,7 @@ text: &'input str,
 ___0: (usize, Tok<'input>, usize),
 ___1: (usize, Tok<'input>, usize),
 ___2: (usize, Atom, usize),
-___3: (usize, core::option::Option<(Atom, String)>, usize),
+___3: (usize, Option<(Atom, String)>, usize),
 ___4: (usize, usize, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Annotation
@@ -25834,9 +25834,9 @@ ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
 ___4: (usize, usize, usize),
-___5: (usize, core::option::Option<Vec<TypeParameter>>, usize),
-___6: (usize, core::option::Option<Vec<Parameter>>, usize),
-___7: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___5: (usize, Option<Vec<TypeParameter>>, usize),
+___6: (usize, Option<Vec<Parameter>>, usize),
+___7: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___8: (usize, Tok<'input>, usize),
 ___9: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -26300,7 +26300,7 @@ ___0: (usize, alloc::vec::Vec<Annotation>, usize),
 ___1: (usize, alloc::vec::Vec<Symbol>, usize),
 ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Condition, usize),
-___4: (usize, core::option::Option<ActionKind>, usize),
+___4: (usize, Option<ActionKind>, usize),
 ) -> Alternative
 {
 let ___start0 = ___4.2;
@@ -26331,7 +26331,7 @@ fn ___action424<
 text: &'input str,
 ___0: (usize, alloc::vec::Vec<Annotation>, usize),
 ___1: (usize, alloc::vec::Vec<Symbol>, usize),
-___2: (usize, core::option::Option<ActionKind>, usize),
+___2: (usize, Option<ActionKind>, usize),
 ) -> Alternative
 {
 let ___start0 = ___2.2;
@@ -26415,7 +26415,7 @@ text: &'input str,
 ___0: (usize, Tok<'input>, usize),
 ___1: (usize, Tok<'input>, usize),
 ___2: (usize, Atom, usize),
-___3: (usize, core::option::Option<(Atom, String)>, usize),
+___3: (usize, Option<(Atom, String)>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Annotation
 {
@@ -26666,9 +26666,9 @@ ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
-___4: (usize, core::option::Option<Vec<TypeParameter>>, usize),
-___5: (usize, core::option::Option<Vec<Parameter>>, usize),
-___6: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___4: (usize, Option<Vec<TypeParameter>>, usize),
+___5: (usize, Option<Vec<Parameter>>, usize),
+___6: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___7: (usize, Tok<'input>, usize),
 ___8: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -27496,9 +27496,9 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, Tok<'input>, usize),
-___3: (usize, core::option::Option<Vec<TypeParameter>>, usize),
-___4: (usize, core::option::Option<Vec<Parameter>>, usize),
-___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___3: (usize, Option<Vec<TypeParameter>>, usize),
+___4: (usize, Option<Vec<Parameter>>, usize),
+___5: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -27536,9 +27536,9 @@ ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
-___4: (usize, core::option::Option<Vec<TypeParameter>>, usize),
-___5: (usize, core::option::Option<Vec<Parameter>>, usize),
-___6: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___4: (usize, Option<Vec<TypeParameter>>, usize),
+___5: (usize, Option<Vec<Parameter>>, usize),
+___6: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___7: (usize, Tok<'input>, usize),
 ___8: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -28688,9 +28688,9 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, Tok<'input>, usize),
-___3: (usize, core::option::Option<Vec<TypeParameter>>, usize),
-___4: (usize, core::option::Option<Vec<Parameter>>, usize),
-___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___3: (usize, Option<Vec<TypeParameter>>, usize),
+___4: (usize, Option<Vec<Parameter>>, usize),
+___5: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
@@ -28725,9 +28725,9 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, Tok<'input>, usize),
-___3: (usize, core::option::Option<Vec<TypeParameter>>, usize),
-___4: (usize, core::option::Option<Vec<Parameter>>, usize),
-___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___3: (usize, Option<Vec<TypeParameter>>, usize),
+___4: (usize, Option<Vec<Parameter>>, usize),
+___5: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -28763,9 +28763,9 @@ ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
-___4: (usize, core::option::Option<Vec<TypeParameter>>, usize),
-___5: (usize, core::option::Option<Vec<Parameter>>, usize),
-___6: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___4: (usize, Option<Vec<TypeParameter>>, usize),
+___5: (usize, Option<Vec<Parameter>>, usize),
+___6: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___7: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
@@ -28802,9 +28802,9 @@ ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
-___4: (usize, core::option::Option<Vec<TypeParameter>>, usize),
-___5: (usize, core::option::Option<Vec<Parameter>>, usize),
-___6: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___4: (usize, Option<Vec<TypeParameter>>, usize),
+___5: (usize, Option<Vec<Parameter>>, usize),
+___6: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___7: (usize, Tok<'input>, usize),
 ___8: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -28938,9 +28938,9 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, Tok<'input>, usize),
-___3: (usize, core::option::Option<Vec<TypeParameter>>, usize),
+___3: (usize, Option<Vec<TypeParameter>>, usize),
 ___4: (usize, Vec<Parameter>, usize),
-___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___5: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
@@ -28973,8 +28973,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, Tok<'input>, usize),
-___3: (usize, core::option::Option<Vec<TypeParameter>>, usize),
-___4: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___3: (usize, Option<Vec<TypeParameter>>, usize),
+___4: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
@@ -29008,9 +29008,9 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, Tok<'input>, usize),
-___3: (usize, core::option::Option<Vec<TypeParameter>>, usize),
+___3: (usize, Option<Vec<TypeParameter>>, usize),
 ___4: (usize, Vec<Parameter>, usize),
-___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___5: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -29045,8 +29045,8 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, Tok<'input>, usize),
-___3: (usize, core::option::Option<Vec<TypeParameter>>, usize),
-___4: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___3: (usize, Option<Vec<TypeParameter>>, usize),
+___4: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -29083,9 +29083,9 @@ ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
-___4: (usize, core::option::Option<Vec<TypeParameter>>, usize),
+___4: (usize, Option<Vec<TypeParameter>>, usize),
 ___5: (usize, Vec<Parameter>, usize),
-___6: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___6: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___7: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
@@ -29120,8 +29120,8 @@ ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
-___4: (usize, core::option::Option<Vec<TypeParameter>>, usize),
-___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___4: (usize, Option<Vec<TypeParameter>>, usize),
+___5: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
@@ -29157,9 +29157,9 @@ ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
-___4: (usize, core::option::Option<Vec<TypeParameter>>, usize),
+___4: (usize, Option<Vec<TypeParameter>>, usize),
 ___5: (usize, Vec<Parameter>, usize),
-___6: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___6: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___7: (usize, Tok<'input>, usize),
 ___8: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -29196,8 +29196,8 @@ ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
-___4: (usize, core::option::Option<Vec<TypeParameter>>, usize),
-___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___4: (usize, Option<Vec<TypeParameter>>, usize),
+___5: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -29236,7 +29236,7 @@ ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Vec<TypeParameter>, usize),
 ___4: (usize, Vec<Parameter>, usize),
-___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___5: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
@@ -29270,7 +29270,7 @@ ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Vec<Parameter>, usize),
-___4: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___4: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
@@ -29305,7 +29305,7 @@ ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Vec<TypeParameter>, usize),
-___4: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___4: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
@@ -29337,7 +29337,7 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, Tok<'input>, usize),
-___3: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___3: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
@@ -29372,7 +29372,7 @@ ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Vec<TypeParameter>, usize),
 ___4: (usize, Vec<Parameter>, usize),
-___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___5: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -29408,7 +29408,7 @@ ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Vec<Parameter>, usize),
-___4: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___4: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -29445,7 +29445,7 @@ ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, Tok<'input>, usize),
 ___3: (usize, Vec<TypeParameter>, usize),
-___4: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___4: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -29479,7 +29479,7 @@ text: &'input str,
 ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, Tok<'input>, usize),
-___3: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___3: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___4: (usize, Tok<'input>, usize),
 ___5: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -29517,7 +29517,7 @@ ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
 ___4: (usize, Vec<TypeParameter>, usize),
 ___5: (usize, Vec<Parameter>, usize),
-___6: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___6: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___7: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
@@ -29553,7 +29553,7 @@ ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
 ___4: (usize, Vec<Parameter>, usize),
-___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___5: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
@@ -29590,7 +29590,7 @@ ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
 ___4: (usize, Vec<TypeParameter>, usize),
-___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___5: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
@@ -29624,7 +29624,7 @@ ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
-___4: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___4: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ) -> Grammar
 {
@@ -29661,7 +29661,7 @@ ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
 ___4: (usize, Vec<TypeParameter>, usize),
 ___5: (usize, Vec<Parameter>, usize),
-___6: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___6: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___7: (usize, Tok<'input>, usize),
 ___8: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -29699,7 +29699,7 @@ ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
 ___4: (usize, Vec<Parameter>, usize),
-___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___5: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -29738,7 +29738,7 @@ ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
 ___4: (usize, Vec<TypeParameter>, usize),
-___5: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___5: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___6: (usize, Tok<'input>, usize),
 ___7: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar
@@ -29774,7 +29774,7 @@ ___0: (usize, alloc::vec::Vec<String>, usize),
 ___1: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ___2: (usize, alloc::vec::Vec<Annotation>, usize),
 ___3: (usize, Tok<'input>, usize),
-___4: (usize, core::option::Option<Vec<WhereClause<TypeRef>>>, usize),
+___4: (usize, Option<Vec<WhereClause<TypeRef>>>, usize),
 ___5: (usize, Tok<'input>, usize),
 ___6: (usize, alloc::vec::Vec<GrammarItem>, usize),
 ) -> Grammar

--- a/lalrpop/src/rust/mod.rs
+++ b/lalrpop/src/rust/mod.rs
@@ -192,7 +192,7 @@ impl<W: Write> RustWrite<W> {
     }
 }
 
-pub struct FnHeader<'me, W: Write + 'me> {
+pub struct FnHeader<'me, W: Write> {
     write: &'me mut RustWrite<W>,
     visibility: &'me Visibility,
     name: String,

--- a/lalrpop/src/rust/mod.rs
+++ b/lalrpop/src/rust/mod.rs
@@ -185,7 +185,8 @@ impl<W: Write> RustWrite<W> {
             "use self::{p}lalrpop_util::state_machine as {p}state_machine;",
             p = prefix,
         );
-        rust!(self, "extern crate core;");
+        // //https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html#an-exception
+        rust!(self, "#[allow(unused_extern_crates)]");
         rust!(self, "extern crate alloc;");
 
         Ok(())

--- a/lalrpop/src/rust/mod.rs
+++ b/lalrpop/src/rust/mod.rs
@@ -185,7 +185,7 @@ impl<W: Write> RustWrite<W> {
             "use self::{p}lalrpop_util::state_machine as {p}state_machine;",
             p = prefix,
         );
-        // //https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html#an-exception
+        // https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html#an-exception
         rust!(self, "#[allow(unused_extern_crates)]");
         rust!(self, "extern crate alloc;");
 

--- a/lalrpop/src/test_util.rs
+++ b/lalrpop/src/test_util.rs
@@ -12,7 +12,7 @@ thread_local! {
 struct ExpectedDebug<'a>(&'a str);
 
 impl<'a> Debug for ExpectedDebug<'a> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         // Ignore trailing commas in multiline Debug representation.
         // Needed to work around rust-lang/rust#59076.
         let s = self.0.replace(",\n", "\n");

--- a/lalrpop/src/tok/mod.rs
+++ b/lalrpop/src/tok/mod.rs
@@ -813,7 +813,7 @@ fn is_identifier_continue(c: char) -> bool {
 /// representation to the text it represents. The `idx0` argument should be the
 /// position in the input stream of the first character of `text`, the position
 /// after the opening double-quote.
-pub fn apply_string_escapes(code: &str, idx0: usize) -> Result<Cow<str>, Error> {
+pub fn apply_string_escapes(code: &str, idx0: usize) -> Result<Cow<'_, str>, Error> {
     if !code.contains('\\') {
         Ok(code.into())
     } else {

--- a/lalrpop/src/tok/test.rs
+++ b/lalrpop/src/tok/test.rs
@@ -8,7 +8,7 @@ enum Expectation<'a> {
 
 use self::Expectation::*;
 
-fn gen_test(input: &str, expected: Vec<(&str, Expectation)>) {
+fn gen_test(input: &str, expected: Vec<(&str, Expectation<'_>)>) {
     // use $ to signal EOL because it can be replaced with a single space
     // for spans, and because it applies also to r#XXX# style strings:
     let input = input.replace('$', "\n");
@@ -37,7 +37,7 @@ fn gen_test(input: &str, expected: Vec<(&str, Expectation)>) {
     assert_eq!(None, tokenizer.nth(len));
 }
 
-fn test(input: &str, expected: Vec<(&str, Tok)>) {
+fn test(input: &str, expected: Vec<(&str, Tok<'_>)>) {
     let generic_expected = expected
         .into_iter()
         .map(|(span, tok)| (span, ExpectTok(tok)))

--- a/lalrpop/src/util.rs
+++ b/lalrpop/src/util.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Error, Formatter};
 pub struct Sep<S>(pub &'static str, pub S);
 
 impl<'a, S: Display> Display for Sep<&'a Vec<S>> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let &Sep(sep, vec) = self;
         let mut elems = vec.iter();
         if let Some(elem) = elems.next() {
@@ -19,7 +19,7 @@ impl<'a, S: Display> Display for Sep<&'a Vec<S>> {
 pub struct Escape<S>(pub S);
 
 impl<S: Display> Display for Escape<S> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let tmp = format!("{}", self.0);
         for c in tmp.chars() {
             match c {
@@ -35,7 +35,7 @@ impl<S: Display> Display for Escape<S> {
 pub struct Prefix<S>(pub &'static str, pub S);
 
 impl<'a, S: Display> Display for Prefix<&'a [S]> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let &Prefix(prefix, vec) = self;
         for elem in vec.iter() {
             write!(fmt, "{}{}", prefix, elem)?;


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.
-->

I'm trying to do a final pass on anything that needs migrating from the previous editions. It doesn't seem like there was anything for rust 2021 but there were still lingering lifetime lints and such for rust 2018. Related to #465 and #515 I think.

What makes this work is `#![warn(rust_2018_idioms)]` which checks for code using the pre-2018 patterns. This also catches lints in the generated code when enabled for `lalrpop-test` as far as I can tell. Of course we also catch lints in the lalrpop grammar itself which is representative.

I did allow `explicit_outlives_requirements` in the generated code because that only seemed to trigger in a couple of cases and it wasn't clear if there was a simple fix.