### PR TITLE
Cut a 0.21.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "calculator"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-test"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "diff",
  "lalrpop",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "regex-automata",
 ]
@@ -678,7 +678,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "whitespace"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "lalrpop",
  "lalrpop-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 repository = "https://github.com/lalrpop/lalrpop"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0 OR MIT"
-version = "0.20.2" # LALRPOP
+version = "0.21.0" # LALRPOP
 edition = "2021"
 # This is (very) soft limit of the minimum supported version.
 # Please update it when lalrpop requires a new feature.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,29 @@
+<a name="0.21.0"></a>
+## 0.21.0 (2024-05-30)
+
+Since the last release, a fair number of the commits have been focussed on cleaning
+up and improving LALRPOP's documentation. Shout out to Yudai Takada, George
+White, and Dinu Blanovschi.
+
+#### Bugfixes
+
+* A long-standing bug where LALRPOP would throw a "no entry found for key"
+  exception when trying to handle a particular reduce/reduce conflict has been
+  resolved.
+* LALRPOP will stop expanding macros infinitely during build time via a new
+  `macro_expansion_limit`.
+
+#### Compatibility note
+
+Adding a limit to the number of times that LALRPOP will attempt to expand a
+macro is technically a breaking change. However, the default limit of `200`
+should be more than enough for the grammars we are currently aware of(which
+almost always need a limit of less than 5). This limit is customizable via `Configuration::set_macro_expansion_limit`.
+
+If you have a grammar that uses a significant amount of macro expansion steps,
+we would be very interested in a pr that adds it to the test suite.
+
+
 <a name="0.20.2"></a>
 ## 0.20.2 (2024-02-**)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,14 @@ Since the last release, a fair number of the commits have been focused on cleani
 up and improving LALRPOP's documentation. Shout out to Yudai Takada, George
 White, and Dinu Blanovschi.
 
+#### Features
+
+* LALRPOP now throws an error in more cases where it would previously just write
+  out an error message and exit.
+* `lalrpop::process_src` is now the recommended function to use in `build.rs`
+  files. Previously the documentation incorrectly suggested that
+  `lalrpop::process_root` looked in `./src` instead of `.`
+
 #### Bugfixes
 
 * A long-standing bug where LALRPOP would throw a "no entry found for key"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,7 +1,7 @@
 <a name="0.21.0"></a>
 ## 0.21.0 (2024-05-30)
 
-Since the last release, a fair number of the commits have been focussed on cleaning
+Since the last release, a fair number of the commits have been focused on cleaning
 up and improving LALRPOP's documentation. Shout out to Yudai Takada, George
 White, and Dinu Blanovschi.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,7 +16,7 @@ White, and Dinu Blanovschi.
 
 Adding a limit to the number of times that LALRPOP will attempt to expand a
 macro is technically a breaking change. However, the default limit of `200`
-should be more than enough for the grammars we are currently aware of(which
+should be more than enough for the grammars we are currently aware of (which
 almost always need a limit of less than 5). This limit is customizable via `Configuration::set_macro_expansion_limit`.
 
 If you have a grammar that uses a significant amount of macro expansion steps,

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -20,7 +20,7 @@ should be more than enough for the grammars we are currently aware of(which
 almost always need a limit of less than 5). This limit is customizable via `Configuration::set_macro_expansion_limit`.
 
 If you have a grammar that uses a significant amount of macro expansion steps,
-we would be very interested in a pr that adds it to the test suite.
+we would be very interested in a PR that adds it to the test suite.
 
 
 <a name="0.20.2"></a>

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,8 +8,7 @@ White, and Dinu Blanovschi.
 #### Bugfixes
 
 * A long-standing bug where LALRPOP would throw a "no entry found for key"
-  exception when trying to handle a particular reduce/reduce conflict has been
-  resolved.
+  exception when trying to handle certain grammars has been resolved.
 * LALRPOP will stop expanding macros infinitely during build time via a new
   `macro_expansion_limit`.
 

--- a/doc/calculator/Cargo.toml
+++ b/doc/calculator/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "calculator"
-version = "0.20.2"
+version = "0.21.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 workspace = "../.." # <-- We added this and everything after!
 edition = "2021"
 
 [build-dependencies]
-lalrpop = { version = "0.20.2", path = "../../lalrpop" }
+lalrpop = { version = "0.21.0", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.20.2", path = "../../lalrpop-util", features = [
+lalrpop-util = { version = "0.21.0", path = "../../lalrpop-util", features = [
     "lexer",
     "unicode",
 ] }

--- a/doc/lexer-modes/Cargo.toml
+++ b/doc/lexer-modes/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Neal H. Walfield <neal@sequoia-pgp.org>"]
 
 [build-dependencies]
-lalrpop = { version = "0.20.2", path = "../../lalrpop" }
+lalrpop = { version = "0.21.0", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.20.2", path = "../../lalrpop-util" }
+lalrpop-util = { version = "0.21.0", path = "../../lalrpop-util" }

--- a/doc/lexer/Cargo.toml
+++ b/doc/lexer/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 authors = ["Patrick LaFontaine <32135464+Pat-Lafon@users.noreply.github.com>"]
 
 [build-dependencies]
-lalrpop = { version = "0.20.2", path = "../../lalrpop" }
+lalrpop = { version = "0.21.0", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.20.2", path = "../../lalrpop-util", features = [
+lalrpop-util = { version = "0.21.0", path = "../../lalrpop-util", features = [
     "unicode",
 ] }
 logos = "0.14.0"

--- a/doc/nobol/Cargo.toml
+++ b/doc/nobol/Cargo.toml
@@ -6,10 +6,10 @@ authors = ["Felix S Klock II <pnkfelix@pnkfx.org>"]
 workspace = "../.." # <-- We added this and everything after!
 
 [build-dependencies]
-lalrpop = { version = "0.20.2", path = "../../lalrpop" }
+lalrpop = { version = "0.21.0", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.20.2", path = "../../lalrpop-util", features = [
+lalrpop-util = { version = "0.21.0", path = "../../lalrpop-util", features = [
     "lexer",
     "unicode",
 ] }

--- a/doc/pascal/lalrpop/Cargo.toml
+++ b/doc/pascal/lalrpop/Cargo.toml
@@ -5,12 +5,12 @@ authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2021"
 
 [build-dependencies]
-lalrpop = { version = "0.20.2", path = "../../../lalrpop" }
+lalrpop = { version = "0.21.0", path = "../../../lalrpop" }
 
 [dependencies]
 pico-args = "0.5"
 
 [dependencies.lalrpop-util]
-version = "0.20.2"
+version = "0.21.0"
 path = "../../../lalrpop-util"
 features = ["lexer"]

--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -11,14 +11,14 @@ the following lines to your `Cargo.toml`:
 ```toml
 # The generated code depends on lalrpop-util.
 [dependencies]
-lalrpop-util = "0.20.2"
+lalrpop-util = "0.21.0"
 
 # Add a build-time dependency on the lalrpop library:
 [build-dependencies]
-lalrpop = "0.20.2"
+lalrpop = "0.21.0"
 # If you are supplying your own external lexer you can disable default features so that the
 # built-in lexer feature is not included
-# lalrpop = { version = "0.20.2", default-features = false }
+# lalrpop = { version = "0.21.0", default-features = false }
 ```
 
 Next create a [`build.rs`](https://doc.rust-lang.org/cargo/reference/build-scripts.html)

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -31,10 +31,10 @@ authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2021"
 
 [build-dependencies] # <-- We added this and everything after!
-lalrpop = "0.20.2"
+lalrpop = "0.21.0"
 
 [dependencies]
-lalrpop-util = { version = "0.20.2", features = ["lexer", "unicode"] }
+lalrpop-util = { version = "0.21.0", features = ["lexer", "unicode"] }
 ```
 
 Cargo can run [build scripts] as a pre-processing step,

--- a/doc/whitespace/Cargo.toml
+++ b/doc/whitespace/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "whitespace"
-version = "0.20.2"
+version = "0.21.0"
 authors = ["Mako <jlauve@rsmw.net>"]
 edition = "2021"
 
 [build-dependencies.lalrpop]
-version = "0.20.2"
+version = "0.21.0"
 path = "../../lalrpop"
 
 [dependencies.lalrpop-util]
-version = "0.20.2"
+version = "0.21.0"
 path = "../../lalrpop-util"

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -36,7 +36,7 @@ walkdir = "2.4.0"
 # library, disable it in your project by setting default-features = false.
 pico-args = { version = "0.5", default-features = false, optional = true }
 
-lalrpop-util = { path = "../lalrpop-util", version = "0.20.0", default-features = false }
+lalrpop-util = { path = "../lalrpop-util", version = "0.21.0", default-features = false }
 
 [dev-dependencies]
 diff = { workspace = true }

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -1,4 +1,4 @@
-// auto-generated: "lalrpop 0.20.2"
+// auto-generated: "lalrpop 0.21.0"
 // sha3: 41f98a6a8c1305d7ef67ac81e1eb4a8b9450d8a01a72a06b1fc8bb7900055a0b
 use string_cache::DefaultAtom as Atom;
 use crate::grammar::parse_tree::*;


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.
-->

As has been noted in other issues, there have been two nice bug fixes that probably warrant a new release. We can wait on #901(though I don't think that's a breaking change) to bundle everything together or we can release what we currently have now and then have a point release when #901 gets merged.

Feel free to make any changes to the release notes as needed.