### PR TITLE
Clean up new nightly dead code warnings

### DIFF
--- a/lalrpop/src/grammar/repr.rs
+++ b/lalrpop/src/grammar/repr.rs
@@ -54,7 +54,6 @@ pub struct Grammar {
     pub action_fn_defns: Vec<ActionFnDefn>,
     pub terminals: TerminalSet,
     pub nonterminals: Map<NonterminalString, NonterminalData>,
-    pub token_span: Span,
     pub conversions: Map<TerminalString, Pattern<TypeRepr>>,
     pub types: Types,
     pub module_attributes: Vec<String>,

--- a/lalrpop/src/grammar/repr.rs
+++ b/lalrpop/src/grammar/repr.rs
@@ -85,7 +85,6 @@ pub struct TerminalSet {
 
 #[derive(Clone, Debug)]
 pub struct NonterminalData {
-    pub name: NonterminalString,
     pub visibility: Visibility,
     pub span: Span,
     pub annotations: Vec<Annotation>,

--- a/lalrpop/src/normalize/lower/mod.rs
+++ b/lalrpop/src/normalize/lower/mod.rs
@@ -49,7 +49,6 @@ impl<'s> LowerState<'s> {
         let start_symbols = self.synthesize_start_symbols(&grammar);
 
         let mut uses = vec![];
-        let mut token_span = None;
         let internal_token_path = Path {
             absolute: false,
             ids: vec![Atom::from("Token")],
@@ -68,7 +67,6 @@ impl<'s> LowerState<'s> {
                 }
 
                 pt::GrammarItem::InternToken(data) => {
-                    token_span = Some(grammar.span);
                     let span = grammar.span;
                     let input_str = r::TypeRepr::Ref {
                         lifetime: Some(Lifetime::input()),
@@ -109,7 +107,6 @@ impl<'s> LowerState<'s> {
 
                 pt::GrammarItem::ExternToken(data) => {
                     if let Some(enum_token) = data.enum_token {
-                        token_span = Some(enum_token.type_span);
                         self.conversions
                             .extend(enum_token.conversions.iter().map(|conversion| {
                                 (
@@ -199,7 +196,6 @@ impl<'s> LowerState<'s> {
             nonterminals: self.nonterminals,
             conversions: self.conversions.into_iter().collect(),
             types: self.types,
-            token_span: token_span.unwrap(),
             type_parameters: grammar.type_parameters,
             parameters,
             where_clauses,

--- a/lalrpop/src/normalize/lower/mod.rs
+++ b/lalrpop/src/normalize/lower/mod.rs
@@ -137,7 +137,6 @@ impl<'s> LowerState<'s> {
                     self.nonterminals.insert(
                         nt_name.clone(),
                         r::NonterminalData {
-                            name: nt_name.clone(),
                             visibility: nt.visibility.clone(),
                             annotations: nt.annotations,
                             span: nt.span,
@@ -246,7 +245,6 @@ impl<'s> LowerState<'s> {
                 self.nonterminals.insert(
                     fake_name.clone(),
                     r::NonterminalData {
-                        name: fake_name.clone(),
                         visibility: nt.visibility.clone(),
                         annotations: vec![],
                         span: nt.span,

--- a/lalrpop/src/parser/mod.rs
+++ b/lalrpop/src/parser/mod.rs
@@ -13,6 +13,13 @@ mod lrgrammar;
 #[cfg(test)]
 mod test;
 
+// The TypeRef and GrammarWhereClauses variants have data that is only read under cfg(test) (the
+// parse_type_ref() and parse_where_clauses() functions lower in this file).  Those functions use
+// the parser!() macro, which expects all variants to have a single data field.  They are set in
+// the parser.  So to have those fields only in the test configuration requires changes at multiple
+// code points across several files to define both a cfg(test) variant and a cfg(not(test))
+// variant, reducing readability.
+#[allow(dead_code)]
 pub enum Top {
     Grammar(Grammar),
     Pattern(Pattern<TypeRef>),


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

Nightly on rust 1.80 has expanded some of the dead_code checking to hit a few cases that weren't hit before.  Clean those up.

