### PR TITLE
Document $attr in lalrpop_mod!

### DIFF
--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -182,7 +182,7 @@ pub struct ErrorRecovery<L, T, E> {
 ///
 /// // define a public module
 /// lalrpop_mod!(pub parser);
-/// 
+///
 /// // specify attribute for the generated module
 /// // to suppress clippy vec_box warnings
 /// lalrpop_mod!(#[allow(clippy::vec_box)] parser);

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -182,6 +182,10 @@ pub struct ErrorRecovery<L, T, E> {
 ///
 /// // define a public module
 /// lalrpop_mod!(pub parser);
+/// 
+/// // specify attribute for the generated module
+/// // to suppress clippy vec_box warnings
+/// lalrpop_mod!(#[allow(clippy::vec_box)] parser);
 /// ```
 
 #[macro_export]

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -183,9 +183,8 @@ pub struct ErrorRecovery<L, T, E> {
 /// // define a public module
 /// lalrpop_mod!(pub parser);
 ///
-/// // specify attribute for the generated module
-/// // to suppress clippy vec_box warnings
-/// lalrpop_mod!(#[allow(clippy::vec_box)] parser);
+/// // specify attributes for the generated module
+/// lalrpop_mod!(#[allow(#[allow(clippy::ptr_arg)]#[rustfmt::skip] parser);
 /// ```
 
 #[macro_export]

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -184,7 +184,7 @@ pub struct ErrorRecovery<L, T, E> {
 /// lalrpop_mod!(pub parser);
 ///
 /// // specify attributes for the generated module
-/// lalrpop_mod!(#[allow(#[allow(clippy::ptr_arg)]#[rustfmt::skip] parser);
+/// lalrpop_mod!(#[allow(clippy::ptr_arg)]#[rustfmt::skip] parser);
 /// ```
 
 #[macro_export]


### PR DESCRIPTION
Resolves #909  

This is a documentation only change. All tests pass on using

```
stable-aarch64-apple-darwin (default)
rustc 1.78.0 (9b00956e5 2024-04-29)
```

To see effect, run `cargo doc` and then look at `./target/doc/lalrpop_util/macro.lalrpop_mod.html`