### PR TITLE
Add a new process_src() public helper to look in the source directory.

### DIFF
--- a/doc/calculator/build.rs
+++ b/doc/calculator/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    lalrpop::process_root().unwrap();
+    lalrpop::process_src().unwrap();
 }

--- a/doc/lexer-modes/build.rs
+++ b/doc/lexer-modes/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    lalrpop::process_root().unwrap();
+    lalrpop::process_src().unwrap();
 }

--- a/doc/lexer/build.rs
+++ b/doc/lexer/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    lalrpop::process_root().unwrap();
+    lalrpop::process_src().unwrap();
 }

--- a/doc/nobol/build.rs
+++ b/doc/nobol/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    lalrpop::process_root().unwrap();
+    lalrpop::process_src().unwrap();
 }

--- a/doc/src/advanced_setup.md
+++ b/doc/src/advanced_setup.md
@@ -5,11 +5,11 @@ like this:
 
 ```rust
 fn main() {
-    lalrpop::process_root().unwrap();
+    lalrpop::process_src().unwrap();
 }
 ```
 
-This `process_root()` call simply applies the default configuration:
+This `process_src()` call simply applies the default configuration:
 so it will transform `.lalrpop` files into `.rs` files *in-place* (in
 your `src` directory), and it will only do so if the `.lalrpop` file
 has actually changed. But you can also use the

--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -26,18 +26,26 @@ file that looks like:
 
 ```rust
 fn main() {
-    lalrpop::process_root().unwrap();
+    lalrpop::process_src().unwrap();
 }
 ```
 
 (If you already have a `build.rs` file, you should be able to just
-call `process_root` in addition to whatever else that file is doing.)
+call `process_src` in addition to whatever else that file is doing.)
 
-In this case, `process_root` simply uses the default settings, which takes
+In this case, `process_src` simply uses the default settings, which takes
 files in `src/` ending with the `.lalrpop` extension, and generates
 corresponding Rust source files with the same name in `OUT_DIR`. If you want to
 configure how LALRPOP executes, see the [advanced setup](advanced_setup.md)
 section.
+
+Some projects, for example those which build multiple crates in the same
+workspace, will not have a top level source directory.  For example, your
+project may have a build.rs at the top level with `foo/src` and `bar/src`
+containing source files for crates `foo` and `bar`, respectively.  In this
+situation, you could either call `process_root()` from the top level build.rs,
+which searches *all* files in the current directory, not just in `./src`, or
+you could modify crate level build.rs files at your discretion.
 
 The [`lalrpop_mod!`][lalrpop_mod] macro generates a wrapper module in your
 crate so that you can use the generated parser from your code. For example,

--- a/doc/whitespace/build.rs
+++ b/doc/whitespace/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    lalrpop::process_root().unwrap();
+    lalrpop::process_src().unwrap();
 }

--- a/lalrpop/src/api/mod.rs
+++ b/lalrpop/src/api/mod.rs
@@ -245,10 +245,21 @@ impl Configuration {
 
 /// Process all files in the current directory, which -- unless you
 /// have changed it -- is typically the root of the crate being compiled.
+/// If your project only builds one crate and your files are in a ./src directory, you should use
+/// `process_src()` instead
 ///
 /// Equivalent to `Configuration::new().process_current_dir()`.
 pub fn process_root() -> Result<(), Box<dyn Error>> {
     Configuration::new().process_current_dir()
+}
+
+/// Process all files in ./src.  In many cargo projects which build only one crate, this is the
+/// normal location for source files.  If you are running lalrpop from a top level build.rs in a
+/// project that builds multiple crates, you may want `process_root()` instead.
+pub fn process_src() -> Result<(), Box<dyn Error>> {
+    Configuration::new()
+        .set_in_dir(Path::new("./src"))
+        .process()
 }
 
 /// Deprecated in favor of `Configuration`.

--- a/lalrpop/src/lib.rs
+++ b/lalrpop/src/lib.rs
@@ -39,5 +39,6 @@ mod test_util;
 pub use crate::api::process_root;
 #[allow(deprecated)]
 pub use crate::api::process_root_unconditionally;
+pub use crate::api::process_src;
 pub use crate::api::Configuration;
 use ascii_canvas::style;


### PR DESCRIPTION
Update the docs to recommend this as the top choice for setting up lalrpop.

Prior to this commit, the book incorrectly stated that `process_root()` looked in `./src`, while the documentation comments in the code correctly identified it as parsing the current directory.  Switching the book to recommend `process_src()` addresses this inconsistency as well.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->