### PR TITLE
Make clippy happy in generated lookaround action code

### DIFF
--- a/lalrpop/src/build/action.rs
+++ b/lalrpop/src/build/action.rs
@@ -148,6 +148,7 @@ fn emit_lookaround_action_code<W: Write>(
     _defn: &r::ActionFnDefn,
     data: &r::LookaroundActionFnDefn,
 ) -> io::Result<()> {
+    rust!(rust, "#[allow(clippy::needless_lifetimes)]");
     rust.fn_header(
         &r::Visibility::Priv,
         format!("{}action{}", grammar.prefix, index),

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -21381,6 +21381,7 @@ None
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::needless_lifetimes)]
 fn ___action185<
     'input,
 >(
@@ -21393,6 +21394,7 @@ ___lookahead: &usize,
 }
 
 #[allow(unused_variables)]
+#[allow(clippy::needless_lifetimes)]
 fn ___action186<
     'input,
 >(


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->
A missing case of #822