### PR TITLE
Add an example showing how the parser can control the lexer's mode.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "lexer-modes"
+version = "0.1.0"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
         "doc/pascal/lalrpop",
         "doc/whitespace",
         "doc/lexer",
+        "doc/lexer-modes",
         "lalrpop-test",
         "lalrpop-util",
         "lalrpop",

--- a/doc/lexer-modes/Cargo.toml
+++ b/doc/lexer-modes/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "lexer-modes"
+version = "0.1.0"
+edition = "2021"
+authors = ["Neal H. Walfield <neal@sequoia-pgp.org>"]
+
+[build-dependencies]
+lalrpop = { version = "0.20.2", path = "../../lalrpop" }
+
+[dependencies]
+lalrpop-util = { version = "0.20.2", path = "../../lalrpop-util" }

--- a/doc/lexer-modes/build.rs
+++ b/doc/lexer-modes/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    lalrpop::process_root().unwrap();
+}

--- a/doc/lexer-modes/src/grammar.lalrpop
+++ b/doc/lexer-modes/src/grammar.lalrpop
@@ -62,7 +62,7 @@ LiteralCount: () = {
 Decimal: usize = {
     N_0 => 0,
     <x:LeadingDecimalDigit> <y:DecimalDigit*> =>? {
-        let count = std::iter::once(x).chain(y.into_iter())
+        let count = std::iter::once(x).chain(y)
             .map(|t| t.as_bytes()[0] as char)
             .collect::<String>();
         let count = count.parse::<usize>()

--- a/doc/lexer-modes/src/grammar.lalrpop
+++ b/doc/lexer-modes/src/grammar.lalrpop
@@ -1,0 +1,116 @@
+// -*- mode: Rust; -*-
+//
+// This grammar parses a list of `length:value` pairs.
+//
+// In order to parse the `value` part, we have to know the length.
+// The value part can't be parsed by the grammar, but it can be lexed
+// by the lexer.  The complication is that only the grammar can detect
+// that the lexer need to change modes.  So we need some way for the
+// parser to communicate that to the lexer.  This is possible, albeit
+// a bit awkward, using some shared state.
+
+//  When we observe the length, the parser changes the lexer to
+// "literal parsing" mode.  When next called, the lexer returns a
+// token containing the next `n` bytes, and then returns to normal
+// lexing mode.
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::Value;
+use crate::lexer;
+use crate::lexer::LexerMode;
+use crate::lexer::LexicalError;
+
+// Because `mode` has to be `Copy`, we have to pass a reference to the
+// `Rc<RefCell<LexerMode>>`.
+grammar<'input, 'mode>(mode: &'mode Rc<RefCell<LexerMode>>);
+
+// Zero or more whitespace separated values.
+pub List: Vec<Value> = {
+    Whitespace* <ValueWhitespace*>
+};
+
+Whitespace = {
+    SPACE, HTAB, VTAB, CR, LF, FORMFEED,
+};
+
+ValueWhitespace = {
+    <Value> Whitespace*
+}
+
+// A value is of the form: `n:bytes` where `n` is a count and bytes is
+// exactly `n` literal bytes.
+Value: Value = {
+    LiteralCount COLON <literal:LITERAL> => {
+        Value {
+            value: literal.as_bytes().to_vec()
+        }
+    }
+}
+
+// We factor this production out of the Literal production so that we
+// can change the lexer mode after we lex the COLON, but before we lex
+// the literal data.
+LiteralCount: () = {
+    <count:Decimal> => {
+        // Change the lexer to literal parsing.
+        mode.borrow_mut().literal = Some(count);
+    }
+}
+
+// A Number.
+Decimal: usize = {
+    N_0 => 0,
+    <x:LeadingDecimalDigit> <y:DecimalDigit*> =>? {
+        let count = std::iter::once(x).chain(y.into_iter())
+            .map(|t| t.as_bytes()[0] as char)
+            .collect::<String>();
+        let count = count.parse::<usize>()
+            .map_err(|err| {
+                LexicalError::LengthOverflow(
+                    format!("Parsing {}: {}", count, err))
+            })?;
+
+        Ok(count)
+    }
+};
+
+LeadingDecimalDigit = {
+    N_1, N_2, N_3, N_4, N_5, N_6, N_7, N_8, N_9
+};
+
+DecimalDigit = {
+    N_0, N_1, N_2, N_3, N_4, N_5, N_6, N_7, N_8, N_9
+};
+
+extern {
+    type Location = usize;
+    type Error = LexicalError;
+
+    enum lexer::Token<'input> {
+        COLON => lexer::Token::COLON,
+
+        // Whitespace.
+        SPACE => lexer::Token::SPACE,
+        HTAB => lexer::Token::HTAB,
+        VTAB => lexer::Token::VTAB,
+        CR => lexer::Token::CR,
+        LF => lexer::Token::LF,
+        FORMFEED => lexer::Token::FORMFEED,
+
+        // Digits.
+        N_0 => lexer::Token::N_0,
+        N_1 => lexer::Token::N_1,
+        N_2 => lexer::Token::N_2,
+        N_3 => lexer::Token::N_3,
+        N_4 => lexer::Token::N_4,
+        N_5 => lexer::Token::N_5,
+        N_6 => lexer::Token::N_6,
+        N_7 => lexer::Token::N_7,
+        N_8 => lexer::Token::N_8,
+        N_9 => lexer::Token::N_9,
+
+        OTHER => lexer::Token::OTHER(_),
+        LITERAL => lexer::Token::LITERAL(_),
+    }
+}

--- a/doc/lexer-modes/src/lexer.rs
+++ b/doc/lexer-modes/src/lexer.rs
@@ -12,6 +12,12 @@ pub struct LexerMode {
     pub literal: Option<usize>,
 }
 
+impl Default for LexerMode {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LexerMode {
     pub fn new() -> Self {
         Self { literal: None }
@@ -80,27 +86,27 @@ impl<'a> Token<'a> {
     pub fn as_bytes(&self) -> &'a [u8] {
         use self::Token::*;
         match self {
-            COLON => &[':' as u8],
+            COLON => &[b':'],
 
             // Whitespace.
-            SPACE => &[' ' as u8],
-            HTAB => &['\t' as u8],
+            SPACE => &[b' '],
+            HTAB => &[b'\t'],
             VTAB => &[0x0b],
             CR => &[0x0d],
             LF => &[0x0a],
             FORMFEED => &[0x0c],
 
             // Digits.
-            N_0 => &['0' as u8],
-            N_1 => &['1' as u8],
-            N_2 => &['2' as u8],
-            N_3 => &['3' as u8],
-            N_4 => &['4' as u8],
-            N_5 => &['5' as u8],
-            N_6 => &['6' as u8],
-            N_7 => &['7' as u8],
-            N_8 => &['8' as u8],
-            N_9 => &['9' as u8],
+            N_0 => &[b'0'],
+            N_1 => &[b'1'],
+            N_2 => &[b'2'],
+            N_3 => &[b'3'],
+            N_4 => &[b'4'],
+            N_5 => &[b'5'],
+            N_6 => &[b'6'],
+            N_7 => &[b'7'],
+            N_8 => &[b'8'],
+            N_9 => &[b'9'],
 
             OTHER(bytes) => bytes,
 
@@ -154,7 +160,7 @@ impl<'input> Iterator for Lexer<'input> {
         } else {
             // We are in normal mode.  Return the next token.
 
-            match *self.input.get(0)? as char {
+            match *self.input.first()? as char {
                 ':' => (1, COLON),
 
                 // Whitespace.

--- a/doc/lexer-modes/src/lexer.rs
+++ b/doc/lexer-modes/src/lexer.rs
@@ -1,0 +1,199 @@
+use std::cell::RefCell;
+use std::fmt;
+use std::rc::Rc;
+
+/// The lexer's mode.
+///
+/// This is shared between the lexer and the parser.
+#[derive(Debug)]
+pub struct LexerMode {
+    /// If `Some`, the next N characters should be returned as a
+    /// `Literal` token.
+    pub literal: Option<usize>,
+}
+
+impl LexerMode {
+    pub fn new() -> Self {
+        Self { literal: None }
+    }
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum LexicalError {
+    LengthOverflow(String),
+    TruncatedInput(String),
+}
+
+impl fmt::Display for LexicalError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+pub type Spanned<Token, Loc, LexicalError> = Result<(Loc, Token, Loc), LexicalError>;
+
+// The type of the parser's input.
+//
+// The parser iterators over tuples consisting of the token's starting
+// position, the token itself, and the token's ending position.
+pub(crate) type LexerItem<Token, Loc, LexicalError> = Spanned<Token, Loc, LexicalError>;
+
+#[derive(Debug, Clone, PartialEq)]
+#[allow(non_camel_case_types)]
+pub enum Token<'a> {
+    COLON,
+
+    // Whitespace.
+    SPACE,
+    HTAB,
+    VTAB,
+    CR,
+    LF,
+    FORMFEED,
+
+    // Digits.
+    N_0,
+    N_1,
+    N_2,
+    N_3,
+    N_4,
+    N_5,
+    N_6,
+    N_7,
+    N_8,
+    N_9,
+
+    // Other.
+    OTHER(&'a [u8]),
+
+    // Returned when the lexer is in literal mode.
+    LITERAL(&'a [u8]),
+}
+
+impl<'a> fmt::Display for Token<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl<'a> Token<'a> {
+    pub fn as_bytes(&self) -> &'a [u8] {
+        use self::Token::*;
+        match self {
+            COLON => &[':' as u8],
+
+            // Whitespace.
+            SPACE => &[' ' as u8],
+            HTAB => &['\t' as u8],
+            VTAB => &[0x0b],
+            CR => &[0x0d],
+            LF => &[0x0a],
+            FORMFEED => &[0x0c],
+
+            // Digits.
+            N_0 => &['0' as u8],
+            N_1 => &['1' as u8],
+            N_2 => &['2' as u8],
+            N_3 => &['3' as u8],
+            N_4 => &['4' as u8],
+            N_5 => &['5' as u8],
+            N_6 => &['6' as u8],
+            N_7 => &['7' as u8],
+            N_8 => &['8' as u8],
+            N_9 => &['9' as u8],
+
+            OTHER(bytes) => bytes,
+
+            LITERAL(bytes) => bytes,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Lexer<'input> {
+    input: &'input [u8],
+
+    // Offset into the original input.
+    offset: usize,
+
+    // The lexer's mode.  This is behind a `Rc<RefCell>` so that it
+    // is also accessible to the parser.
+    pub mode: Rc<RefCell<LexerMode>>,
+}
+
+impl<'input> Lexer<'input> {
+    pub fn new(input: &'input [u8]) -> Self {
+        Lexer {
+            input,
+            offset: 0,
+            mode: Rc::new(RefCell::new(LexerMode::new())),
+        }
+    }
+}
+
+impl<'input> Iterator for Lexer<'input> {
+    type Item = LexerItem<Token<'input>, usize, LexicalError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        use self::Token::*;
+
+        let mut mode = self.mode.borrow_mut();
+        let (len, token) = if let Some(count) = mode.literal.take() {
+            // We are in literal model: we return the next characters
+            // as-is.
+
+            if self.input.len() < count {
+                return Some(Err(LexicalError::TruncatedInput(format!(
+                    "Expected {} octets, got {}",
+                    count,
+                    self.input.len()
+                ))));
+            } else {
+                (count, LITERAL(&self.input[..count]))
+            }
+        } else {
+            // We are in normal mode.  Return the next token.
+
+            match *self.input.get(0)? as char {
+                ':' => (1, COLON),
+
+                // Whitespace.
+                ' ' => (1, SPACE),
+                '\t' => (1, HTAB),
+                '\u{0b}' => (1, VTAB),
+                '\u{0d}' => (1, CR),
+                '\u{0a}' => (1, LF),
+                '\u{0c}' => (1, FORMFEED),
+
+                // Digits.
+                '0' => (1, N_0),
+                '1' => (1, N_1),
+                '2' => (1, N_2),
+                '3' => (1, N_3),
+                '4' => (1, N_4),
+                '5' => (1, N_5),
+                '6' => (1, N_6),
+                '7' => (1, N_7),
+                '8' => (1, N_8),
+                '9' => (1, N_9),
+
+                // Other.
+                _ => (1, OTHER(&self.input[..1])),
+            }
+        };
+
+        self.input = &self.input[len..];
+
+        let start = self.offset;
+        let end = start + len;
+        self.offset += len;
+
+        Some(Ok((start, token, end)))
+    }
+}
+
+impl<'input> From<&'input [u8]> for Lexer<'input> {
+    fn from(i: &'input [u8]) -> Lexer<'input> {
+        Lexer::new(i)
+    }
+}

--- a/doc/lexer-modes/src/lib.rs
+++ b/doc/lexer-modes/src/lib.rs
@@ -1,0 +1,12 @@
+pub mod lexer;
+
+// A value.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Value {
+    pub value: Vec<u8>,
+}
+
+use lalrpop_util::lalrpop_mod;
+
+lalrpop_mod!(grammar);
+pub use grammar::ListParser;

--- a/doc/lexer-modes/src/main.rs
+++ b/doc/lexer-modes/src/main.rs
@@ -1,0 +1,49 @@
+use std::rc::Rc;
+
+use lexer_modes::lexer::Lexer;
+use lexer_modes::ListParser;
+use lexer_modes::Value;
+
+fn main() {
+    // Values are encoded by a length, a colon, and then the value.
+    // The value doesn't need to be followed by whitespace, but it
+    // may.
+    let input = &b"3:foo5:xyzzy"[..];
+
+    let lexer = Lexer::new(input);
+    let mode = Rc::clone(&lexer.mode);
+
+    let values = ListParser::new().parse(&mode, lexer).unwrap();
+
+    assert_eq!(
+        &values[..],
+        &[
+            Value {
+                value: b"foo".to_vec()
+            },
+            Value {
+                value: b"xyzzy".to_vec()
+            },
+        ][..]
+    );
+
+    // Whitespace can also occur in the value.
+    let input = &b"3:f   5:    y"[..];
+
+    let lexer = Lexer::new(input);
+    let mode = Rc::clone(&lexer.mode);
+
+    let values = ListParser::new().parse(&mode, lexer).unwrap();
+
+    assert_eq!(
+        &values[..],
+        &[
+            Value {
+                value: b"f  ".to_vec()
+            },
+            Value {
+                value: b"    y".to_vec()
+            },
+        ][..]
+    );
+}


### PR DESCRIPTION
In some languages, it is necessary for the parser to control the lexer's mode.  This is possible, but non-obvious.

This commit adds a simple example that shows how to parse the "list of length-value" language in which values are encoded as a length, followed by a colon, and then the literal number of bytes, e.g., `2:hi`.  To parse this, the parser need to tell the lexer to return the next `n` literal bytes when it sees the length prefix.

See #802.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->