### PR TITLE
Fix error msg `LALROP` to `LALRPOP`

### DIFF
--- a/lalrpop/src/lr1/error/mod.rs
+++ b/lalrpop/src/lr1/error/mod.rs
@@ -365,7 +365,7 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
             .push(nonterminal)
             .punctuated(").")
             .text("For more information, see the section on inlining")
-            .text("in the LALROP manual.")
+            .text("in the LALRPOP manual.")
             .end()
             .end()
             .end()


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

https://github.com/lalrpop/lalrpop/blob/d7daf3ff1f1fe14727e5a034a30f368ec8c7f244/lalrpop/src/lr1/error/mod.rs#L368
