### PR TITLE
Lint on calls to process::exit()

### DIFF
--- a/lalrpop/src/lib.rs
+++ b/lalrpop/src/lib.rs
@@ -8,6 +8,7 @@
 // ε shows up in lalrpop/src/lr1/example/test.rs
 #![cfg_attr(test, allow(dead_code, mixed_script_confusables))]
 #![warn(rust_2018_idioms)]
+#![deny(clippy::exit)]
 
 // hoist the modules that define macros up earlier
 #[macro_use]


### PR DESCRIPTION
Add an exception for main.rs.  exit() calls are unexpected behavior in a library, where the caller should have control on whether errors are fatal or not.  In binaries, there is no caller and the arguments against exit() are weaker.  In many cases, exit() may still be a control-flow anti-pattern, but exceptions exist, so allow this for everything that's definitely only in a binary context.

Regardless of the allow() in main.rs, the clippy lint contains an exception for exit calls in entrypoint functions, so the existing exit() call, which is in fn main() does not trigger this lint, even without the allow() attribute.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->