### PR TITLE
Fix comment about conflict detection

### DIFF
--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -165,7 +165,7 @@ impl<'grammar, L: LookaheadBuild> Lr<'grammar, L> {
                     .push((item.lookahead.clone(), item.production));
             }
 
-            // check for shift-reduce conflicts (reduce-reduce detected above)
+            // check for conflicts
             conflicts.extend(L::conflicts(&this_state));
 
             // extract a new state


### PR DESCRIPTION
Commit a928c53f668ffc557448266375e94c309d7b8f01 changed the logic to move reduce/reduce detection into the same function with shift/reduce detection, but didn't update the comment

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->