### PR TITLE
Add a new error message for ambiguous reductions to the same nonterminal

### DIFF
--- a/lalrpop/src/file_text.rs
+++ b/lalrpop/src/file_text.rs
@@ -87,14 +87,7 @@ impl FileText {
     }
 
     pub fn span_text(&self, span: pt::Span) -> &str {
-        let (start_line, start_col) = self.line_col(span.0);
-        let (end_line, end_col) = self.line_col(span.1);
-
-        if start_line == end_line {
-            &self.line_text(start_line)[start_col..end_col]
-        } else {
-            todo!()
-        }
+        &self.input_str[span.0..span.1]
     }
 
     pub fn highlight(&self, span: pt::Span, out: &mut dyn Write) -> io::Result<()> {

--- a/lalrpop/src/file_text.rs
+++ b/lalrpop/src/file_text.rs
@@ -58,7 +58,7 @@ impl FileText {
         )
     }
 
-    fn line_col(&self, pos: usize) -> (usize, usize) {
+    pub fn line_col(&self, pos: usize) -> (usize, usize) {
         let num_lines = self.newlines.len();
         let line = (0..num_lines)
             .filter(|&i| self.newlines[i] > pos)

--- a/lalrpop/src/file_text.rs
+++ b/lalrpop/src/file_text.rs
@@ -86,6 +86,17 @@ impl FileText {
         }
     }
 
+    pub fn span_text(&self, span: pt::Span) -> &str {
+        let (start_line, start_col) = self.line_col(span.0);
+        let (end_line, end_col) = self.line_col(span.1);
+
+        if start_line == end_line {
+            &self.line_text(start_line)[start_col..end_col]
+        } else {
+            todo!()
+        }
+    }
+
     pub fn highlight(&self, span: pt::Span, out: &mut dyn Write) -> io::Result<()> {
         let (start_line, start_col) = self.line_col(span.0);
         let (end_line, end_col) = self.line_col(span.1);

--- a/lalrpop/src/lr1/error/mod.rs
+++ b/lalrpop/src/lr1/error/mod.rs
@@ -411,6 +411,11 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
         let styles = ExampleStyles::new();
         let span1_str = file_text.span_text(span1);
         let span2_str = file_text.span_text(span2);
+
+        // Internal lines are 0-indexed, but editors are (always?) 1-indexed
+        let span1_line = file_text.line_col(span1.0).0 + 1;
+        let span2_line = file_text.line_col(span2.0).0 + 1;
+
         MessageBuilder::new(span1)
             .heading()
             .text("Multiple productions for the same reduction")
@@ -422,9 +427,15 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
                 reduce.reductions.first().unwrap().nonterminal
             ))
             .push(reduce.to_symbol_list(reduce.symbols.len(), styles))
-            .wrap_text("They could be reduced using the following production:")
+            .wrap_text(format!(
+                "They could be reduced using the production on line {}:",
+                span1_line
+            ))
             .wrap_text(span1_str)
-            .wrap_text("...or using the following production:")
+            .wrap_text(format!(
+                "...or using the production on line {}:",
+                span2_line
+            ))
             .wrap_text(span2_str)
             .end()
             .end()

--- a/lalrpop/src/lr1/error/test.rs
+++ b/lalrpop/src/lr1/error/test.rs
@@ -201,7 +201,9 @@ fn verify_errors(
     let mut cx = ErrorReportingCx::new(&grammar, &err.states, &err.conflicts);
     let conflicts = super::token_conflicts(&err.conflicts);
     assert_eq!(conflicts.len(), unique_conflicts); // One group of conflicts
-    assert_eq!(conflicts[0].len(), terminal_count); // terminal count
+    for conflict in conflicts {
+        assert_eq!(conflict.len(), terminal_count); // terminal count
+    }
 
     let mut calls = 0;
     let test_report = |message: Message| -> Result<(), ()> {
@@ -214,12 +216,13 @@ fn verify_errors(
             .collect::<Vec<String>>()
             .join("\n")
             .contains(text));
-        assert!(calls < unique_conflicts);
         calls += 1;
+        assert!(calls <= unique_conflicts);
         Ok(())
     };
 
     cx.report_errors(test_report).unwrap();
+    assert_eq!(calls, unique_conflicts);
 }
 
 #[test]


### PR DESCRIPTION
The existing error messages assume that the source of a reduce/reduce conflict is which nonterminal is reduced to.  This is a confusing result if there are two possible reductions to the same nonterminal ("I can reduce to an A, but I can also reduce to an A").  Identical reductions to the same nonterminal are easy to do and can be hard to spot in the presence of macros.

This error message detects when the conflict is for the same nonterminal and helpfully points to the specific rules in that nonterminal that conflict.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->