### PR TITLE
update doc links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ to! Here are some tips:
 - [RustPython] is Python 3.5+ rewritten in Rust
 - [Solang] is Ethereum Solidity rewritten in Rust
 
-[The LALRPOP book]: http://lalrpop.github.io/lalrpop/
-[quick start guide]: http://lalrpop.github.io/lalrpop/quick_start_guide.html
-[advanced setup]: http://lalrpop.github.io/lalrpop/advanced_setup.html
-[cheat sheet]: http://lalrpop.github.io/lalrpop/cheatsheet.html
-[tutorial]: http://lalrpop.github.io/lalrpop/tutorial/index.html
+[The LALRPOP book]: https://lalrpop.github.io/lalrpop/
+[quick start guide]: https://lalrpop.github.io/lalrpop/quick_start_guide.html
+[advanced setup]: https://lalrpop.github.io/lalrpop/advanced_setup.html
+[cheat sheet]: https://lalrpop.github.io/lalrpop/cheatsheet.html
+[tutorial]: https://lalrpop.github.io/lalrpop/tutorial/index.html
 [LALRPOP]: https://github.com/lalrpop/lalrpop/blob/8034f3dacc4b20581bd10c5cb0b4f9faae778bb5/lalrpop/src/parser/lrgrammar.lalrpop
 [Gluon]: https://github.com/gluon-lang/gluon/blob/d7ce3e81c1fcfdf25cdd6d1abde2b6e376b4bf50/parser/src/grammar.lalrpop
 [RustPython]: https://github.com/RustPython/RustPython/blob/fb5ac9e79bfd5029397652a12883a8cedfa01620/compiler/parser/python.lalrpop


### PR DESCRIPTION
Updating the links in the README from `http://lalrpop.github.io` to `https://lalrpop.github.io`.

They are currently broken because no http->https redirect is configured for the github page.