### PR TITLE
Switch to_triple to use Result::map_err()

### DIFF
--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -630,14 +630,11 @@ fn emit_to_triple_trait<W: Write>(
             T = T,
             parse_error = parse_error,
         );
-        rust!(rust, "match value {{");
-        rust!(rust, "Ok(v) => Ok(v),");
         rust!(
             rust,
-            "Err(error) => Err({p}lalrpop_util::ParseError::User {{ error }}),",
+            "value.map_err(|error| {p}lalrpop_util::ParseError::User {{ error }})",
             p = grammar.prefix
         );
-        rust!(rust, "}}"); // match
         rust!(rust, "}}");
         rust!(rust, "}}");
     } else {

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -582,7 +582,7 @@ fn emit_to_triple_trait<W: Write>(
     rust!(rust, "{{");
     rust!(
         rust,
-        "fn to_triple(value: Self) -> Result<({L},{T},{L}), {parse_error}>;",
+        "fn to_triple(self) -> Result<({L},{T},{L}), {parse_error}>;",
         L = L,
         T = T,
         parse_error = parse_error,
@@ -603,12 +603,12 @@ fn emit_to_triple_trait<W: Write>(
         rust!(rust, "{{");
         rust!(
             rust,
-            "fn to_triple(value: Self) -> Result<({L},{T},{L}), {parse_error}> {{",
+            "fn to_triple(self) -> Result<({L},{T},{L}), {parse_error}> {{",
             L = L,
             T = T,
             parse_error = parse_error,
         );
-        rust!(rust, "Ok(value)");
+        rust!(rust, "Ok(self)");
         rust!(rust, "}}");
         rust!(rust, "}}");
 
@@ -625,14 +625,14 @@ fn emit_to_triple_trait<W: Write>(
         rust!(rust, "{{");
         rust!(
             rust,
-            "fn to_triple(value: Self) -> Result<({L},{T},{L}), {parse_error}> {{",
+            "fn to_triple(self) -> Result<({L},{T},{L}), {parse_error}> {{",
             L = L,
             T = T,
             parse_error = parse_error,
         );
         rust!(
             rust,
-            "value.map_err(|error| {p}lalrpop_util::ParseError::User {{ error }})",
+            "self.map_err(|error| {p}lalrpop_util::ParseError::User {{ error }})",
             p = grammar.prefix
         );
         rust!(rust, "}}");
@@ -649,11 +649,11 @@ fn emit_to_triple_trait<W: Write>(
         rust!(rust, "{{");
         rust!(
             rust,
-            "fn to_triple(value: Self) -> Result<((),{T},()), {parse_error}> {{",
+            "fn to_triple(self) -> Result<((),{T},()), {parse_error}> {{",
             T = T,
             parse_error = parse_error,
         );
-        rust!(rust, "Ok(((), value, ()))");
+        rust!(rust, "Ok(((), self, ()))");
         rust!(rust, "}}");
         rust!(rust, "}}");
 
@@ -669,11 +669,11 @@ fn emit_to_triple_trait<W: Write>(
         rust!(rust, "{{");
         rust!(
             rust,
-            "fn to_triple(value: Self) -> Result<((),{T},()), {parse_error}> {{",
+            "fn to_triple(self) -> Result<((),{T},()), {parse_error}> {{",
             T = T,
             parse_error = parse_error,
         );
-        rust!(rust, "match value {{");
+        rust!(rust, "match self {{");
         rust!(rust, "Ok(v) => Ok(((), v, ())),");
         rust!(
             rust,

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -38575,9 +38575,6 @@ Ok(value)
 impl<'input, > ___ToTriple<'input, > for Result<(usize, Tok<'input>, usize), tok::Error>
 {
 fn to_triple(value: Self) -> Result<(usize,Tok<'input>,usize), ___lalrpop_util::ParseError<usize, Tok<'input>, tok::Error>> {
-match value {
-Ok(v) => Ok(v),
-Err(error) => Err(___lalrpop_util::ParseError::User { error }),
-}
+value.map_err(|error| ___lalrpop_util::ParseError::User { error })
 }
 }

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -38563,18 +38563,18 @@ ___5,
 
 pub  trait ___ToTriple<'input, >
 {
-fn to_triple(value: Self) -> Result<(usize,Tok<'input>,usize), ___lalrpop_util::ParseError<usize, Tok<'input>, tok::Error>>;
+fn to_triple(self) -> Result<(usize,Tok<'input>,usize), ___lalrpop_util::ParseError<usize, Tok<'input>, tok::Error>>;
 }
 
 impl<'input, > ___ToTriple<'input, > for (usize, Tok<'input>, usize)
 {
-fn to_triple(value: Self) -> Result<(usize,Tok<'input>,usize), ___lalrpop_util::ParseError<usize, Tok<'input>, tok::Error>> {
-Ok(value)
+fn to_triple(self) -> Result<(usize,Tok<'input>,usize), ___lalrpop_util::ParseError<usize, Tok<'input>, tok::Error>> {
+Ok(self)
 }
 }
 impl<'input, > ___ToTriple<'input, > for Result<(usize, Tok<'input>, usize), tok::Error>
 {
-fn to_triple(value: Self) -> Result<(usize,Tok<'input>,usize), ___lalrpop_util::ParseError<usize, Tok<'input>, tok::Error>> {
-value.map_err(|error| ___lalrpop_util::ParseError::User { error })
+fn to_triple(self) -> Result<(usize,Tok<'input>,usize), ___lalrpop_util::ParseError<usize, Tok<'input>, tok::Error>> {
+self.map_err(|error| ___lalrpop_util::ParseError::User { error })
 }
 }


### PR DESCRIPTION
It was open coding the same functionality anyways, so this is just better.

As a side effect, it dodges a new warning in rust 1.82 for unreachable code triggered by the whitespace example

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->