### PR TITLE
When encountering naive errors on reduce/reduce conflicts, drop all but

### DIFF
--- a/lalrpop/src/lr1/error/mod.rs
+++ b/lalrpop/src/lr1/error/mod.rs
@@ -95,11 +95,21 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
         mut reporter: impl FnMut(Message) -> Result<(), E>,
     ) -> Result<(), E> {
         for conflict_group in &token_conflicts(self.conflicts) {
-            let (naive_conflicts, better_conflicts): (Vec<_>, Vec<_>) = conflict_group
+            let (mut naive_conflicts, better_conflicts): (Vec<_>, Vec<_>) = conflict_group
                 .iter()
                 .map(|c| (c, self.classify(c)))
                 .partition(|c| matches!(c.1, ConflictClassification::Naive));
             let conflicts = if better_conflicts.is_empty() {
+                // If we have a reduce/reduce conflict, we end up with one conflict per token, but
+                // they're all the same reduce/reduce. We don't have a meaningful way to determine
+                // if some lookahead token will be more valuable to the user, so just take the
+                // first one and drop the rest as redundant
+                if matches!(
+                    naive_conflicts.first().map(|c| &c.0.action),
+                    Some(&Action::Reduce(_))
+                ) {
+                    naive_conflicts.truncate(1);
+                }
                 naive_conflicts
             } else {
                 better_conflicts


### PR DESCRIPTION
the first.

On conflicts, lalrpop tries every possible lookahead token to find good conflict examples.  On shift/reduce conflicts that makes a lot of sense, different lookahead tokens are different conflicts, because the shift is different.  On reduce/reduce conflicts on the other hand, the lookahead is sort of irrelevant.  Hopefully, at least one lookahead produces a good example, so we won't need naive errors at all.  The fact that we only found naive errors means that none of the lookaheads were helpful. So rather than reporting one error message per token, just drop all but the first, since we can't tell what lookahead is more helpful (if we'd found a helpful lookahead, we'd be using that for a better error).

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->