### PR TITLE
Add default-run to lalrpop package specification

### DIFF
--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -5,6 +5,7 @@ readme = "../README.md"
 keywords = ["parser", "generator", "LR", "yacc", "grammar"]
 categories = ["parsing"]
 workspace = ".."
+default-run = "lalrpop"
 
 repository.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This lets us call the lalrpop binary using "cargo run" rather than "cargo run --bin lalrpop".  If we want to call some other binary we can still use --bin (eg "cargo run --bin calculator").

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->