### PR TITLE
Fully elide lifetimes

### DIFF
--- a/lalrpop/src/lr1/lane_table/table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/table/mod.rs
@@ -43,7 +43,7 @@ pub struct LaneTable<'grammar> {
 }
 
 impl<'grammar> LaneTable<'grammar> {
-    pub fn new(grammar: &'grammar Grammar, conflicts: usize) -> LaneTable<'_> {
+    pub fn new(grammar: &Grammar, conflicts: usize) -> LaneTable<'_> {
         LaneTable {
             _grammar: grammar,
             conflicts,


### PR DESCRIPTION
Clippy 1.83 doesn't like that we specified the lifetime in the argument, but elided it in the return.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->