### PR TITLE
prepend lalrpop_util:: to lalrpop_mod rec call

### DIFF
--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -190,7 +190,7 @@ pub struct ErrorRecovery<L, T, E> {
 #[macro_export]
 macro_rules! lalrpop_mod {
     ($(#[$attr:meta])* $vis:vis $modname:ident) => {
-        lalrpop_mod!($(#[$attr])* $vis $modname, concat!("/", stringify!($modname), ".rs"));
+        lalrpop_util::lalrpop_mod!($(#[$attr])* $vis $modname, concat!("/", stringify!($modname), ".rs"));
     };
 
     ($(#[$attr:meta])* $vis:vis $modname:ident, $source:expr) => {


### PR DESCRIPTION
Usually we write
```rust
use lalrpop_util::lalrpop_mod;

lalrpop_mod!(pub grammar);
```

but if you write
```rust
lalrpop_util::lalrpop_mod!(
    // No parser should have been generated so nothing should be unused
    #[deny(dead_code)]
    cfg
);
```
this will fail with
```sh
error: cannot find macro `lalrpop_mod` in this scope
 --> doc/cfg/src/lib.rs:1:1
  |
1 | / lalrpop_util::lalrpop_mod!(
2 | |     // No parser should have been generated so nothing should be unused
3 | |     #[deny(dead_code)]
4 | |     cfg
5 | | );
  | |_^
  |
  = note: this error originates in the macro `lalrpop_util::lalrpop_mod` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider importing this macro
  |
1 + use lalrpop_util::lalrpop_mod;
  |
```

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->