### PR TITLE
clippy warning about no longer needed import from #944

### DIFF
--- a/doc/calculator/src/main.rs
+++ b/doc/calculator/src/main.rs
@@ -1,5 +1,3 @@
-use lalrpop_util::lalrpop_mod;
-
 macro_rules! lalrpop_mod_doc {
     ($vis:vis $name:ident) => {
         lalrpop_util::lalrpop_mod!(


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->