### PR TITLE
Add `no_std` support for `lalrpop-util` crate with `lexer` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ diff = { version = "0.1.12", default-features = false }
 regex = { version = "1.3", default-features = false, features = ["std"] }
 regex-syntax = { version = "0.8.2", default-features = false }
 regex-automata = { version = "0.4", default-features = false, features = [
-        "perf",
+        "perf-inline",
+        "perf-literal-substring",
         "syntax",
         "hybrid",
 ] }

--- a/lalrpop-util/Cargo.toml
+++ b/lalrpop-util/Cargo.toml
@@ -14,9 +14,9 @@ rust-version.workspace = true
 regex-automata = { workspace = true, optional = true }
 
 [features]
-lexer = ["regex-automata/std", "std"]
+lexer = ["regex-automata"]
 unicode = ["regex-automata?/unicode"]
-std = []
+std = ["regex-automata/perf"]
 default = ["std", "unicode"]
 
 [package.metadata.docs.rs]

--- a/lalrpop-util/src/lexer.rs
+++ b/lalrpop-util/src/lexer.rs
@@ -1,4 +1,5 @@
-use std::{fmt, marker::PhantomData};
+use alloc::{fmt, vec::Vec};
+use core::marker::PhantomData;
 
 use crate::ParseError;
 

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -46,7 +46,7 @@ rand = "0.8"
 [features]
 default=["lexer", "unicode", "pico-args"]
 unicode = ["regex/unicode", "regex-syntax/unicode", "lalrpop-util/unicode"]
-lexer = ["lalrpop-util/lexer"]
+lexer = ["lalrpop-util/lexer", "lalrpop-util/std"]
 
 [package.metadata.docs.rs]
 features = ["lexer"]


### PR DESCRIPTION
This unlinks the `lexer` feature from the `std` feature. While expanded `no_std` support is possible in `lalrpop`, this is the key component that prevents using a the lexer within a `no_std` environment.

In order to do this, the `regex-automata` crate needs to have the `perf` feature removed, because it implies the `perf-literal-multisubstring` feature, which implies the `std` feature. To minimize the changes caused by this, the `perf` feature is re-enabled for the `std` feature of the `lalrpop-util` crate.