### PR TITLE
Release version 0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "calculator"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "cfg"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-test"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "diff",
  "lalrpop",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "regex-automata",
  "rustversion",
@@ -642,7 +642,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "whitespace"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "lalrpop",
  "lalrpop-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "beef"
@@ -92,9 +92,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "lock_api"
@@ -308,18 +308,18 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "logos"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1ceb190eb9bdeecdd8f1ad6a71d6d632a50905948771718741b5461fb01e13"
+checksum = "1c6b6e02facda28ca5fb8dbe4b152496ba3b1bd5a4b40bb2b1b2d8ad74e0f39b"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
 name = "logos-codegen"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90be66cb7bd40cb5cc2e9cfaf2d1133b04a3d93b72344267715010a466e0915a"
+checksum = "b32eb6b5f26efacd015b000bfc562186472cd9b34bdba3f6b264e2a052676d10"
 dependencies = [
  "beef",
  "fnv",
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "logos-derive"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45154231e8e96586b39494029e58f12f8ffcb5ecf80333a603a13aa205ea8cbd"
+checksum = "3e5d0c5463c911ef55624739fc353238b4e310f0144be1f875dc42fec6bfd5ec"
 dependencies = [
  "logos-codegen",
 ]
@@ -361,9 +361,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "parking_lot"
@@ -421,6 +424,12 @@ name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "ppv-lite86"
@@ -487,18 +496,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -508,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -519,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustversion"
@@ -581,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -608,15 +617,15 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "2"
 repository = "https://github.com/lalrpop/lalrpop"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0 OR MIT"
-version = "0.21.0" # LALRPOP
+version = "0.22.0" # LALRPOP
 edition = "2021"
 # This is (very) soft limit of the minimum supported version.
 # Please update it when lalrpop requires a new feature.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,15 +3,17 @@
 
 #### Breaking changes
 * The `lexer` feature no longer implies the `std` feature.  Now `lexer` is
-  usable in `no_std` environments.
+  usable in `no_std` environments. In `no_std`, ParseError only implements the
+  Error trait in rust 1.81 or later (since core::error was stablized in 1.81).
 
 #### Features
-* Overhaul cfg attributes.  You can now include or omit grammar rules based on
-  cargo features with `not()`, `any()` and `all()` support
+* Overhaul cfg attributes.  You can now include or omit grammar rules and
+  alternatives based on cargo features with `not()`, `any()` and `all()` support
 
 #### Bugfixes
 * Improvements to error message reporting to improve clarity and suppress extra noise
 * `lalrpop_mod!()` now handles imports correctly
+* Reenable some warnings on user code for custom lexers
 
 <a name="0.21.0"></a>
 ## 0.21.0 (2024-05-30)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,18 @@
+<a name="0.22.0"></a>
+## 0.22.0  (2024-09-26)
+
+#### Breaking changes
+* The `lexer` feature no longer implies the `std` feature.  Now `lexer` is
+  usable in `no_std` environments.
+
+#### Features
+* Overhaul cfg attributes.  You can now include or omit grammar rules based on
+  cargo features with `not()`, `any()` and `all()` support
+
+#### Bugfixes
+* Improvements to error message reporting to improve clarity and suppress extra noise
+* `lalrpop_mod!()` now handles imports correctly
+
 <a name="0.21.0"></a>
 ## 0.21.0 (2024-05-30)
 

--- a/doc/calculator/Cargo.toml
+++ b/doc/calculator/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "calculator"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 workspace = "../.." # <-- We added this and everything after!
 edition = "2021"
 
 [build-dependencies]
-lalrpop = { version = "0.21.0", path = "../../lalrpop" }
+lalrpop = { version = "0.22.0", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.21.0", path = "../../lalrpop-util", features = [
+lalrpop-util = { version = "0.22.0", path = "../../lalrpop-util", features = [
     "lexer",
     "unicode",
 ] }

--- a/doc/cfg/Cargo.toml
+++ b/doc/cfg/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "cfg"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Mathis Brossier <mathis.brossier@gmail.com>"]
 workspace = "../.." # <-- We added this and everything after!
 edition = "2021"
 
 [build-dependencies]
-lalrpop = { version = "0.21.0", path = "../../lalrpop" }
+lalrpop = { version = "0.22.0", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.21.0", path = "../../lalrpop-util", features = [
+lalrpop-util = { version = "0.22.0", path = "../../lalrpop-util", features = [
     "lexer",
 ] }
 

--- a/doc/lexer-modes/Cargo.toml
+++ b/doc/lexer-modes/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Neal H. Walfield <neal@sequoia-pgp.org>"]
 
 [build-dependencies]
-lalrpop = { version = "0.21.0", path = "../../lalrpop" }
+lalrpop = { version = "0.22.0", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.21.0", path = "../../lalrpop-util" }
+lalrpop-util = { version = "0.22.0", path = "../../lalrpop-util" }

--- a/doc/lexer/Cargo.toml
+++ b/doc/lexer/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 authors = ["Patrick LaFontaine <32135464+Pat-Lafon@users.noreply.github.com>"]
 
 [build-dependencies]
-lalrpop = { version = "0.21.0", path = "../../lalrpop" }
+lalrpop = { version = "0.22.0", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.21.0", path = "../../lalrpop-util", features = [
+lalrpop-util = { version = "0.22.0", path = "../../lalrpop-util", features = [
     "unicode",
 ] }
 logos = "0.14.0"

--- a/doc/nobol/Cargo.toml
+++ b/doc/nobol/Cargo.toml
@@ -6,10 +6,10 @@ authors = ["Felix S Klock II <pnkfelix@pnkfx.org>"]
 workspace = "../.." # <-- We added this and everything after!
 
 [build-dependencies]
-lalrpop = { version = "0.21.0", path = "../../lalrpop" }
+lalrpop = { version = "0.22.0", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.21.0", path = "../../lalrpop-util", features = [
+lalrpop-util = { version = "0.22.0", path = "../../lalrpop-util", features = [
     "lexer",
     "unicode",
 ] }

--- a/doc/pascal/lalrpop/Cargo.toml
+++ b/doc/pascal/lalrpop/Cargo.toml
@@ -5,12 +5,12 @@ authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2021"
 
 [build-dependencies]
-lalrpop = { version = "0.21.0", path = "../../../lalrpop" }
+lalrpop = { version = "0.22.0", path = "../../../lalrpop" }
 
 [dependencies]
 pico-args = "0.5"
 
 [dependencies.lalrpop-util]
-version = "0.21.0"
+version = "0.22.0"
 path = "../../../lalrpop-util"
 features = ["lexer"]

--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -11,11 +11,11 @@ the following lines to your `Cargo.toml`:
 ```toml
 # The generated code depends on lalrpop-util.
 [dependencies]
-lalrpop-util = "0.21.0"
+lalrpop-util = "0.22.0"
 
 # Add a build-time dependency on the lalrpop library:
 [build-dependencies]
-lalrpop = "0.21.0"
+lalrpop = "0.22.0"
 # If you are supplying your own external lexer you can disable default features so that the
 # built-in lexer feature is not included
 # lalrpop = { version = "0.21.0", default-features = false }

--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -18,7 +18,7 @@ lalrpop-util = "0.22.0"
 lalrpop = "0.22.0"
 # If you are supplying your own external lexer you can disable default features so that the
 # built-in lexer feature is not included
-# lalrpop = { version = "0.21.0", default-features = false }
+# lalrpop = { version = "0.22.0", default-features = false }
 ```
 
 Next create a [`build.rs`](https://doc.rust-lang.org/cargo/reference/build-scripts.html)

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -31,7 +31,7 @@ authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2021"
 
 [build-dependencies] # <-- We added this and everything after!
-lalrpop = "0.21.0"
+lalrpop = "0.22.0"
 
 [dependencies]
 lalrpop-util = { version = "0.21.0", features = ["lexer", "unicode"] }

--- a/doc/whitespace/Cargo.toml
+++ b/doc/whitespace/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "whitespace"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Mako <jlauve@rsmw.net>"]
 edition = "2021"
 
 [build-dependencies.lalrpop]
-version = "0.21.0"
+version = "0.22.0"
 path = "../../lalrpop"
 
 [dependencies.lalrpop-util]
-version = "0.21.0"
+version = "0.22.0"
 path = "../../lalrpop-util"

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -37,7 +37,7 @@ walkdir = "2.4.0"
 # library, disable it in your project by setting default-features = false.
 pico-args = { version = "0.5", default-features = false, optional = true }
 
-lalrpop-util = { path = "../lalrpop-util", version = "0.21.0", default-features = false }
+lalrpop-util = { path = "../lalrpop-util", version = "0.22.0", default-features = false }
 
 [dev-dependencies]
 diff = { workspace = true }

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -1,4 +1,4 @@
-// auto-generated: "lalrpop 0.21.0"
+// auto-generated: "lalrpop 0.22.0"
 // sha3: f47daa431ba103316047ba86b3c78f39a981940447c550b2a48c2bd30fd64fc7
 use string_cache::DefaultAtom as Atom;
 use crate::grammar::parse_tree::*;


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

For discussion.  In my opinion, I'd like to at a minimum get the following tasks done first:

- [x] Merge #927
- [x] Merge #938 
- [x] Release ascii-canvas to get a release with term 1.0 in it (https://github.com/lalrpop/ascii-canvas/pull/13)
- [x] Update lalrpop to ascii-canvas 4.0 and term 1.0
- [x] Maybe switch `std::error::Error` to `core::error::Error`?  (Issue: `core::error::Error` is rust 1.81, which is the latest stable, so this would require either waiting ~9 weeks, or violating our msrv guideline
- [x] Update our Cargo.lock to the latest
- [x] Merge #959 

Happy to add any other release blockers you all want.  I'm willing to take on all of the above, except the two PRs I mentioned need code reviews from someone else.