### PR TITLE
Fix version.sh to update lalrpop's lalrpop-util dependency

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -30,6 +30,9 @@ clog --setversion $1
 perl -p -i -e 's/version *= *"[0-9.]+" # LALRPOP/version = "'$1'" # LALRPOP/' \
      $(ls Cargo.toml lalrpop*/Cargo.toml)
 
+perl -p -i -e 's/lalrpop-util(.*)version *= *"'$VERSION'"/lalrpop-util\1version = "'$1'"/' \
+     lalrpop/Cargo.toml
+
 perl -p -i -e 's/version *= *"'$VERSION'"/version = "'$1'"/' \
      $(find doc -name Cargo.toml)
 


### PR DESCRIPTION
This could probably be lumped in the doc case, but that case is a little weird in that it assumes that any dependency with the old version number is a lalrpop dependency.  So if we happened to have some third party dependency on the same version number as the old lalrpop version in the doc examples, the script would update that too.  So rather than propagating that bug into the larger and more impactful lalrpop Cargo.toml handling, just special case it.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->