### PR TITLE
Avoid whitespace between doc comments or attributes and what they apply

### DIFF
--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -186,7 +186,6 @@ pub struct ErrorRecovery<L, T, E> {
 /// // specify attributes for the generated module
 /// lalrpop_mod!(#[allow(clippy::ptr_arg)]#[rustfmt::skip] parser);
 /// ```
-
 #[macro_export]
 macro_rules! lalrpop_mod {
     ($(#[$attr:meta])* $vis:vis $modname:ident) => {

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -524,6 +524,7 @@ fn emit_recursive_ascent(
 
     action::emit_action_code(grammar, &mut rust)?;
 
+    rust!(rust, "");
     rust!(rust, "#[allow(clippy::type_complexity, dead_code)]");
     emit_to_triple_trait(grammar, max_start_nt_visibility, &mut rust)?;
 
@@ -570,7 +571,6 @@ fn emit_to_triple_trait<W: Write>(
     let where_clauses = &grammar.where_clauses;
     let to_triple_where_clauses = Sep(",", where_clauses);
 
-    rust!(rust, "");
     rust!(
         rust,
         "{} trait {}ToTriple<{}>",

--- a/lalrpop/src/lr1/trace/shift/mod.rs
+++ b/lalrpop/src/lr1/trace/shift/mod.rs
@@ -35,7 +35,6 @@ mod test;
 /// Ultimately this "trace" is best represented as a DAG. The problem
 /// is that some of those nonterminals could, for example, be
 /// optional.
-
 impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
     pub fn backtrace_shift(
         mut self,

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -39250,8 +39250,8 @@ ___4,
 ___5,
 )
 }
-#[allow(clippy::type_complexity, dead_code)]
 
+#[allow(clippy::type_complexity, dead_code)]
 pub  trait ___ToTriple<'input, >
 {
 fn to_triple(self) -> Result<(usize,Tok<'input>,usize), ___lalrpop_util::ParseError<usize, Tok<'input>, tok::Error>>;


### PR DESCRIPTION
to

Clippy is concerned that if there's whitespace, we might have intended those comments or attributes to apply to something else

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->