### PR TITLE
Support `Error` with `std` feature disabled

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,13 +10,16 @@ on:
 permissions:
   contents: read
 
+env:
+  MSRV : "1.70"
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - "1.70"
+          - $MSRV
           - stable
           - beta
           - nightly
@@ -66,7 +69,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-            toolchain: stable
+            toolchain: $MSRV
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       - name: Update

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ name = "lalrpop-util"
 version = "0.21.0"
 dependencies = [
  "regex-automata",
+ "rustversion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ regex-automata = { version = "0.4", default-features = false, features = [
         "syntax",
         "hybrid",
 ] }
+rustversion = { version = "1.0" }

--- a/lalrpop-util/Cargo.toml
+++ b/lalrpop-util/Cargo.toml
@@ -12,6 +12,7 @@ rust-version.workspace = true
 
 [dependencies]
 regex-automata = { workspace = true, optional = true }
+rustversion = { workspace = true }
 
 [features]
 lexer = ["regex-automata"]

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -4,6 +4,8 @@
 extern crate alloc;
 
 use alloc::{string::String, vec::Vec};
+#[cfg(not(feature = "std"))]
+use core::error::Error;
 use core::fmt;
 #[cfg(feature = "std")]
 use std::error::Error;
@@ -148,7 +150,6 @@ impl<L, T, E> From<E> for ParseError<L, T, E> {
     }
 }
 
-#[cfg(feature = "std")]
 impl<L, T, E> Error for ParseError<L, T, E>
 where
     L: fmt::Debug + fmt::Display,

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -4,7 +4,8 @@
 extern crate alloc;
 
 use alloc::{string::String, vec::Vec};
-#[rustversion::attr(since(1.81), cfg(not(feature = "std")))]
+#[rustversion::since(1.81)]
+#[cfg(not(feature = "std"))]
 use core::error::Error;
 use core::fmt;
 #[cfg(feature = "std")]

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 
 use alloc::{string::String, vec::Vec};
-#[cfg(not(feature = "std"))]
+#[rustversion::attr(since(1.81), cfg(not(feature = "std")))]
 use core::error::Error;
 use core::fmt;
 #[cfg(feature = "std")]
@@ -150,6 +150,7 @@ impl<L, T, E> From<E> for ParseError<L, T, E> {
     }
 }
 
+#[cfg_attr(not(feature = "std"), rustversion::since(1.81))]
 impl<L, T, E> Error for ParseError<L, T, E>
 where
     L: fmt::Debug + fmt::Display,


### PR DESCRIPTION
This uses `core::error::Error` instead of `std::error::Error` when the `std` feature is not enabled.

As a result, the MSRV is 1.81 when the `std` feature is not enabled, but unchanged when the `std` feature is enabled.