### PR TITLE
Kind of unify version.sh regex search

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -27,16 +27,21 @@ echo "Found consistent version $VERSION"
 
 clog --setversion $1
 
-perl -p -i -e 's/version *= *"[0-9.]+" # LALRPOP/version = "'$1'" # LALRPOP/' \
-     $(ls Cargo.toml lalrpop*/Cargo.toml)
+perl -p -i -e 's/lalrpop(.*)= *"'$VERSION'"/lalrpop\1= "'$1'"/' \
+     $(ls Cargo.toml lalrpop*/Cargo.toml) \
+     doc/src/quick_start_guide.md doc/src/tutorial/001_adding_lalrpop.md
 
-perl -p -i -e 's/lalrpop-util(.*)version *= *"'$VERSION'"/lalrpop-util\1version = "'$1'"/' \
-     lalrpop/Cargo.toml
+perl -p -i -e 's/version *= *"'$VERSION'" *# LALRPOP/version = "'$1'" # LALRPOP"/' \
+     $(ls Cargo.toml lalrpop*/Cargo.toml) \
+     doc/src/quick_start_guide.md doc/src/tutorial/001_adding_lalrpop.md
 
+# Leave in special handling for the docs, because this case is a little weird
+# in that we're finding everything with the previous version number and
+# updating it, which may in theory include things that aren't lalrpop.  We
+# don't really want to use the "# LALRPOP" taggging solution used elsewhere
+# because this is examples for people to read and copy, so we just accept that
+# bug here, but don't spread it to the rest of the code base
 perl -p -i -e 's/version *= *"'$VERSION'"/version = "'$1'"/' \
      $(find doc -name Cargo.toml)
-
-perl -p -i -e 's/^lalrpop([\-a-z]*) *= *"[0-9.]+"/lalrpop\1 = "'$1'"/' \
-    doc/src/quick_start_guide.md doc/src/tutorial/001_adding_lalrpop.md
 
 ./update_lrgrammar.sh


### PR DESCRIPTION
This really only removes one special casing situation, but it seems somewhat more comprehensive and covers the comment case that was missed before

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->