### PR TITLE
Turn a few warnings back on when we match token values

### DIFF
--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -756,6 +756,9 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
             .emit()?;
         rust!(self.out, "{{");
 
+        // This match contains user-supplied token names.  Reenable some warnings to help them
+        // catch errors if they've got a bug in their custom lexer implementation
+        rust!(self.out, "#[warn(unused_variables)]");
         rust!(self.out, "match {p}token {{", p = self.prefix);
 
         for (terminal, index) in self.grammar.terminals.all.iter().zip(0..) {

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -3209,6 +3209,7 @@ ___token: &Tok<'input>,
 _: core::marker::PhantomData<(&'input ())>,
 ) -> Option<usize>
 {
+#[warn(unused_variables)]
 match ___token {
 Tok::Enum if true => Some(0),
 Tok::Extern if true => Some(1),


### PR DESCRIPTION
Since these are user-supplied, this can help them diagnose bugs

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->