### PR TITLE
Elide needless lifetimes in impls

### DIFF
--- a/doc/calculator/src/ast.rs
+++ b/doc/calculator/src/ast.rs
@@ -31,7 +31,7 @@ impl Debug for Expr {
     }
 }
 
-impl<'input> Debug for ExprSymbol<'input> {
+impl Debug for ExprSymbol<'_> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         use self::ExprSymbol::*;
         match *self {

--- a/doc/lexer-modes/src/lexer.rs
+++ b/doc/lexer-modes/src/lexer.rs
@@ -76,7 +76,7 @@ pub enum Token<'a> {
     LITERAL(&'a [u8]),
 }
 
-impl<'a> fmt::Display for Token<'a> {
+impl fmt::Display for Token<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
     }

--- a/doc/lexer/src/lexer.rs
+++ b/doc/lexer/src/lexer.rs
@@ -18,7 +18,7 @@ impl<'input> Lexer<'input> {
     }
 }
 
-impl<'input> Iterator for Lexer<'input> {
+impl Iterator for Lexer<'_> {
     type Item = Spanned<Token, usize, LexicalError>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/doc/whitespace/src/lexer.rs
+++ b/doc/whitespace/src/lexer.rs
@@ -26,7 +26,7 @@ impl<'input> Lexer<'input> {
     }
 }
 
-impl<'input> Iterator for Lexer<'input> {
+impl Iterator for Lexer<'_> {
     type Item = Spanned<Tok, usize, LexicalError>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/lalrpop-test/src/lexer_generic_lib.rs
+++ b/lalrpop-test/src/lexer_generic_lib.rs
@@ -40,7 +40,7 @@ impl<'i> Lexer<'i> {
 #[derive(Debug, PartialEq)]
 pub struct Error(String);
 
-impl<'i> Iterator for Lexer<'i> {
+impl Iterator for Lexer<'_> {
     type Item = Result<(usize, Token, usize), Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -96,6 +96,6 @@ impl<'i> Iterator for Lexer<'i> {
 }
 
 /// Implement LexerTrait
-impl<'i> LexerTrait for Lexer<'i> {
+impl LexerTrait for Lexer<'_> {
     type Error = Error;
 }

--- a/lalrpop-test/src/util/mod.rs
+++ b/lalrpop-test/src/util/mod.rs
@@ -63,7 +63,7 @@ where
 
 struct ExpectedDebug<'a>(&'a str);
 
-impl<'a> Debug for ExpectedDebug<'a> {
+impl Debug for ExpectedDebug<'_> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         // Ignore trailing commas in multiline Debug representation.
         // Needed to work around rust-lang/rust#59076.

--- a/lalrpop-util/src/lexer.rs
+++ b/lalrpop-util/src/lexer.rs
@@ -11,7 +11,7 @@ use regex_automata::{Anchored, Input, MatchKind};
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Token<'input>(pub usize, pub &'input str);
-impl<'a> fmt::Display for Token<'a> {
+impl fmt::Display for Token<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         fmt::Display::fmt(self.1, formatter)
     }
@@ -79,7 +79,7 @@ pub struct Matcher<'input, 'builder, E> {
     _marker: PhantomData<fn() -> E>,
 }
 
-impl<'input, 'builder, E> Iterator for Matcher<'input, 'builder, E> {
+impl<'input, E> Iterator for Matcher<'input, '_, E> {
     type Item = Result<(usize, Token<'input>, usize), ParseError<usize, Token<'input>, E>>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/lalrpop/src/lexer/dfa/mod.rs
+++ b/lalrpop/src/lexer/dfa/mod.rs
@@ -118,7 +118,7 @@ struct Item {
 
 const START: DfaStateIndex = DfaStateIndex(0);
 
-impl<'nfa> DfaBuilder<'nfa> {
+impl DfaBuilder<'_> {
     fn build(&self) -> Result<Dfa, DfaConstructionError> {
         let mut kernel_set = KernelSet::new();
         let mut states = vec![];

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -300,7 +300,7 @@ impl<'grammar, L: LookaheadBuild> Kernel<'grammar, L> {
     }
 }
 
-impl<'grammar, L: LookaheadBuild> kernel_set::Kernel for Kernel<'grammar, L> {
+impl<L: LookaheadBuild> kernel_set::Kernel for Kernel<'_, L> {
     type Index = StateIndex;
 
     fn index(c: usize) -> StateIndex {

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -41,7 +41,7 @@ enum Comment<'a, T> {
     Reduce(T, &'a Production),
 }
 
-impl<'a, T: fmt::Display> fmt::Display for Comment<'a, T> {
+impl<T: fmt::Display> fmt::Display for Comment<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Comment::Goto(ref token, new_state) => {

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -176,7 +176,7 @@ pub type LrResult<'grammar, L> =
     Result<Vec<State<'grammar, L>>, TableConstructionError<'grammar, L>>;
 pub type Lr1Result<'grammar> = LrResult<'grammar, TokenSet>;
 
-impl<'grammar, L: Lookahead> Debug for Item<'grammar, L> {
+impl<L: Lookahead> Debug for Item<'_, L> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(
             fmt,
@@ -315,7 +315,7 @@ pub struct SymbolSets<'grammar> {
     pub suffix: &'grammar [Symbol],       // first [E, F], second []
 }
 
-impl<'grammar> SymbolSets<'grammar> {
+impl SymbolSets<'_> {
     pub fn new() -> Self {
         SymbolSets {
             prefix: &[],

--- a/lalrpop/src/lr1/lane_table/construct/merge.rs
+++ b/lalrpop/src/lr1/lane_table/construct/merge.rs
@@ -192,7 +192,7 @@ struct ContextSets<'m> {
     unify: &'m mut InPlaceUnificationTable<StateSet>,
 }
 
-impl<'m> ContextSets<'m> {
+impl ContextSets<'_> {
     fn context_set(&mut self, state: StateIndex) -> ContextSet {
         let state_set = self.state_sets[&state];
         self.unify.probe_value(state_set)

--- a/lalrpop/src/lr1/lane_table/table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/table/mod.rs
@@ -42,7 +42,7 @@ pub struct LaneTable<'grammar> {
     successors: Multimap<StateIndex, Set<StateIndex>>,
 }
 
-impl<'grammar> LaneTable<'grammar> {
+impl LaneTable<'_> {
     pub fn new(grammar: &Grammar, conflicts: usize) -> LaneTable<'_> {
         LaneTable {
             _grammar: grammar,
@@ -147,7 +147,7 @@ impl<'grammar> LaneTable<'grammar> {
     }
 }
 
-impl<'grammar> Debug for LaneTable<'grammar> {
+impl Debug for LaneTable<'_> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let indices: Set<StateIndex> = self
             .lookaheads

--- a/lalrpop/src/lr1/lookahead.rs
+++ b/lalrpop/src/lr1/lookahead.rs
@@ -266,7 +266,7 @@ pub struct TokenSetIter<'iter> {
     bit_set: bit_set::Iter<'iter, u32>,
 }
 
-impl<'iter> Iterator for TokenSetIter<'iter> {
+impl Iterator for TokenSetIter<'_> {
     type Item = Token;
 
     fn next(&mut self) -> Option<Token> {

--- a/lalrpop/src/lr1/report/mod.rs
+++ b/lalrpop/src/lr1/report/mod.rs
@@ -373,13 +373,13 @@ trait HasDisplayLen {
     fn display_len(&self) -> usize;
 }
 
-impl<'a> HasDisplayLen for &'a TerminalString {
+impl HasDisplayLen for &TerminalString {
     fn display_len(&self) -> usize {
         TerminalString::display_len(self)
     }
 }
 
-impl<'a> HasDisplayLen for &'a NonterminalString {
+impl HasDisplayLen for &NonterminalString {
     fn display_len(&self) -> usize {
         self.len()
     }

--- a/lalrpop/src/lr1/trace/reduce/mod.rs
+++ b/lalrpop/src/lr1/trace/reduce/mod.rs
@@ -7,7 +7,7 @@ use super::Tracer;
 #[cfg(test)]
 mod test;
 
-impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
+impl<'grammar> Tracer<'_, 'grammar> {
     pub fn backtrace_reduce(
         mut self,
         item_state: StateIndex,

--- a/lalrpop/src/lr1/trace/shift/mod.rs
+++ b/lalrpop/src/lr1/trace/shift/mod.rs
@@ -35,7 +35,7 @@ mod test;
 /// Ultimately this "trace" is best represented as a DAG. The problem
 /// is that some of those nonterminals could, for example, be
 /// optional.
-impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
+impl<'grammar> Tracer<'_, 'grammar> {
     pub fn backtrace_shift(
         mut self,
         item_state: StateIndex,

--- a/lalrpop/src/lr1/trace/trace_graph/mod.rs
+++ b/lalrpop/src/lr1/trace/trace_graph/mod.rs
@@ -111,7 +111,7 @@ impl<'grammar> TraceGraph<'grammar> {
     }
 }
 
-impl<'grammar> From<NonterminalString> for TraceGraphNode<'grammar> {
+impl From<NonterminalString> for TraceGraphNode<'_> {
     fn from(val: NonterminalString) -> Self {
         TraceGraphNode::Nonterminal(val)
     }
@@ -140,13 +140,13 @@ struct TraceGraphEdge<'grammar> {
     ),
 }
 
-impl<'grammar> Debug for TraceGraphEdge<'grammar> {
+impl Debug for TraceGraphEdge<'_> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "({:?} -{:?}-> {:?})", self.from, self.label, self.to)
     }
 }
 
-impl<'grammar> Debug for TraceGraph<'grammar> {
+impl Debug for TraceGraph<'_> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let mut s = fmt.debug_list();
         for (node, &index) in &self.indices {
@@ -396,7 +396,7 @@ impl<'graph, 'grammar> PathEnumerator<'graph, 'grammar> {
     }
 }
 
-impl<'graph, 'grammar> Iterator for PathEnumerator<'graph, 'grammar> {
+impl Iterator for PathEnumerator<'_, '_> {
     type Item = Example;
 
     fn next(&mut self) -> Option<Example> {
@@ -437,7 +437,7 @@ impl<'graph, 'grammar> FilteredPathEnumerator<'graph, 'grammar> {
     }
 }
 
-impl<'graph, 'grammar> Iterator for FilteredPathEnumerator<'graph, 'grammar> {
+impl Iterator for FilteredPathEnumerator<'_, '_> {
     type Item = Example;
 
     fn next(&mut self) -> Option<Example> {

--- a/lalrpop/src/normalize/inline/mod.rs
+++ b/lalrpop/src/normalize/inline/mod.rs
@@ -83,7 +83,7 @@ struct Inliner<'a> {
     new_action_fn_defns: &'a mut Vec<ActionFnDefn>,
 }
 
-impl<'a> Inliner<'a> {
+impl Inliner<'_> {
     fn inline(&mut self, into_symbols: &[Symbol]) {
         if into_symbols.is_empty() {
             // create an action fn for the result of inlining

--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -42,7 +42,7 @@ struct Validator<'grammar> {
     extern_token: Option<&'grammar ExternToken>,
 }
 
-impl<'grammar> Validator<'grammar> {
+impl Validator<'_> {
     fn validate(&self) -> NormResult<()> {
         let allowed_names = [
             Atom::from(LALR),

--- a/lalrpop/src/normalize/resolve/mod.rs
+++ b/lalrpop/src/normalize/resolve/mod.rs
@@ -283,7 +283,7 @@ impl Validator {
     }
 }
 
-impl<'scope> ScopeChain<'scope> {
+impl ScopeChain<'_> {
     fn def(&self, id: &Atom) -> Option<Def> {
         self.identifiers
             .get(id)

--- a/lalrpop/src/normalize/token_check/mod.rs
+++ b/lalrpop/src/normalize/token_check/mod.rs
@@ -211,7 +211,7 @@ impl MatchBlock {
     }
 }
 
-impl<'grammar> Validator<'grammar> {
+impl Validator<'_> {
     fn validate(&mut self) -> NormResult<()> {
         for item in &self.grammar.items {
             match *item {

--- a/lalrpop/src/rust/mod.rs
+++ b/lalrpop/src/rust/mod.rs
@@ -302,7 +302,7 @@ impl ParameterDisplay for String {
     }
 }
 
-impl<'me> ParameterDisplay for &'me repr::Parameter {
+impl ParameterDisplay for &repr::Parameter {
     fn to_parameter_string(self) -> String {
         format!("{}: {}", self.name, self.ty)
     }

--- a/lalrpop/src/util.rs
+++ b/lalrpop/src/util.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Error, Formatter};
 
 pub struct Sep<S>(pub &'static str, pub S);
 
-impl<'a, S: Display> Display for Sep<&'a Vec<S>> {
+impl<S: Display> Display for Sep<&Vec<S>> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let &Sep(sep, vec) = self;
         let mut elems = vec.iter();
@@ -34,7 +34,7 @@ impl<S: Display> Display for Escape<S> {
 
 pub struct Prefix<S>(pub &'static str, pub S);
 
-impl<'a, S: Display> Display for Prefix<&'a [S]> {
+impl<S: Display> Display for Prefix<&[S]> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let &Prefix(prefix, vec) = self;
         for elem in vec.iter() {


### PR DESCRIPTION
Tracking lifetime support in impls was added in recent nightly clippy.

https://github.com/rust-lang/rust-clippy/pull/13286

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->