### PR TITLE
Update and fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ to! Here are some tips:
 [advanced setup]: https://lalrpop.github.io/lalrpop/advanced_setup.html
 [cheat sheet]: https://lalrpop.github.io/lalrpop/cheatsheet.html
 [tutorial]: https://lalrpop.github.io/lalrpop/tutorial/index.html
-[LALRPOP]: https://github.com/lalrpop/lalrpop/blob/8034f3dacc4b20581bd10c5cb0b4f9faae778bb5/lalrpop/src/parser/lrgrammar.lalrpop
-[Gluon]: https://github.com/gluon-lang/gluon/blob/d7ce3e81c1fcfdf25cdd6d1abde2b6e376b4bf50/parser/src/grammar.lalrpop
-[RustPython]: https://github.com/RustPython/RustPython/blob/fb5ac9e79bfd5029397652a12883a8cedfa01620/compiler/parser/python.lalrpop
-[Solang]: https://github.com/hyperledger/solang/blob/b867c8a6c7a1ee89d405993abef458fc59e9b0fb/solang-parser/src/solidity.lalrpop
+[LALRPOP]: https://github.com/lalrpop/lalrpop/blob/master/lalrpop/src/parser/lrgrammar.lalrpop
+[Gluon]: https://github.com/gluon-lang/gluon/blob/master/parser/src/grammar.lalrpop
+[RustPython]: https://github.com/RustPython/Parser/blob/main/parser/src/python.lalrpop
+[Solang]: https://github.com/hyperledger/solang/blob/main/solang-parser/src/solidity.lalrpop
 [gitter lobby]: https://gitter.im/lalrpop/Lobby
 [lalrpop-util]: https://docs.rs/lalrpop-util/latest/lalrpop_util/
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ to! Here are some tips:
 - Returning users of LALRPOP may benefit from the [cheat sheet].
 - The [advanced setup] chapter shows how to configure other aspects of LALRPOP's
   preprocessing.
+- docs.rs API documentation for [lalrpop](https://docs.rs/lalrpop/latest/lalrpop/) and [lalrpop-util]
 - If you have any questions join our [gitter lobby].
 
 ### Example Uses
@@ -56,6 +57,7 @@ to! Here are some tips:
 [RustPython]: https://github.com/RustPython/RustPython/blob/fb5ac9e79bfd5029397652a12883a8cedfa01620/compiler/parser/python.lalrpop
 [Solang]: https://github.com/hyperledger/solang/blob/b867c8a6c7a1ee89d405993abef458fc59e9b0fb/solang-parser/src/solidity.lalrpop
 [gitter lobby]: https://gitter.im/lalrpop/Lobby
+[lalrpop-util]: https://docs.rs/lalrpop-util/latest/lalrpop_util/
 
 ### Contributing
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

* Add docs.rs links for our autogenerated API docs
* Fix the example project links to 1. Link to the most recent version instead of a specific commit from years ago 2. Point at the new RustPython location, since they have migrated their parser into a separate repo.