### PR TITLE
Support for cfg test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,9 @@ jobs:
       - name: Run rustfmt check
         run: cargo fmt --all -- --check
       - name: Run clippy
-        run: cargo clippy --all --all-targets -- -D warnings
+        run: cargo clippy --all --all-targets --exclude lexer -- -D warnings
+      - name: Run clippy on lexer separately
+        run: export CARGO_CFG_TEST=true && cargo clippy --all-targets --manifest-path doc/lexer/Cargo.toml -- -D warnings
   min_version:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,4 +77,4 @@ jobs:
       - run: cargo build --bin lalrpop --features pico-args
       - name: Run feature powerset check
         # test with minimal amount of features plus a few extra on regex/regex-syntax
-        run: cargo hack test --workspace --feature-powerset --exclude-features pico-args,default --optional-deps
+        run: export CARGO_CFG_TEST=true && cargo hack test --workspace --feature-powerset --exclude-features pico-args,default --optional-deps

--- a/doc/lexer/build.rs
+++ b/doc/lexer/build.rs
@@ -1,3 +1,6 @@
 fn main() {
+    // https://github.com/rust-lang/cargo/issues/4789
+    // println!("cargo::rustc-cfg=test");
+    // std::env::set_var("CARGO_CFG_TEST", "true");
     lalrpop::process_src().unwrap();
 }

--- a/doc/lexer/src/ast.rs
+++ b/doc/lexer/src/ast.rs
@@ -4,9 +4,7 @@ pub enum Statement {
         name: String,
         value: Box<Expression>,
     },
-    #[cfg(not(test))]
     Print { value: Box<Expression> },
-    #[cfg(test)]
     EPrint { value: Box<Expression> },
 }
 

--- a/doc/lexer/src/ast.rs
+++ b/doc/lexer/src/ast.rs
@@ -4,8 +4,12 @@ pub enum Statement {
         name: String,
         value: Box<Expression>,
     },
-    Print { value: Box<Expression> },
-    EPrint { value: Box<Expression> },
+    Print {
+        value: Box<Expression>,
+    },
+    EPrint {
+        value: Box<Expression>,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/doc/lexer/src/ast.rs
+++ b/doc/lexer/src/ast.rs
@@ -4,9 +4,10 @@ pub enum Statement {
         name: String,
         value: Box<Expression>,
     },
-    Print {
-        value: Box<Expression>,
-    },
+    #[cfg(not(test))]
+    Print { value: Box<Expression> },
+    #[cfg(test)]
+    EPrint { value: Box<Expression> },
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/doc/lexer/src/grammar.lalrpop
+++ b/doc/lexer/src/grammar.lalrpop
@@ -11,7 +11,10 @@ extern {
 
   enum Token {
     "var" => Token::KeywordVar,
+    #[cfg(not(test))]
     "print" => Token::KeywordPrint,
+    #[cfg(test)]
+    "eprint" => Token::KeywordPrint,
     "identifier" => Token::Identifier(<String>),
     "int" => Token::Integer(<i64>),
     "(" => Token::LParen,
@@ -37,8 +40,13 @@ pub Statement: ast::Statement = {
   "var" <name:"identifier"> "=" <value:Expression> ";" => {
     ast::Statement::Variable { name, value }
   },
+  #[cfg(not(test))]
   "print" <value:Expression> ";" => {
     ast::Statement::Print { value }
+  },
+  #[cfg(test)]
+  "eprint" <value:Expression> ";" => {
+    ast::Statement::EPrint { value }
   },
 }
 

--- a/doc/lexer/src/grammar.lalrpop
+++ b/doc/lexer/src/grammar.lalrpop
@@ -31,6 +31,10 @@ extern {
   }
 }
 
+#[cfg(test)]
+pub TEST: () = {
+  "(" ")" => ()
+}
 
 pub Script: Vec<ast::Statement> = {
   <stmts:Statement*> => stmts

--- a/doc/lexer/src/main.rs
+++ b/doc/lexer/src/main.rs
@@ -14,6 +14,11 @@ print (a - b);";
 
     println!("{:?}", ast);
 
+    assert!(matches!(ast[0], lexer::ast::Statement::Variable { .. }));
+    assert!(matches!(ast[1], lexer::ast::Statement::Variable { .. }));
+    #[cfg(not(test))]
+    assert!(matches!(ast[2], lexer::ast::Statement::Print { .. }));
+
     #[cfg(feature = "bit")]
     {
         let source_code = "var a = 4;
@@ -27,5 +32,33 @@ print (a << b);";
         let ast = parser.parse(lexer).unwrap();
 
         println!("{:?}", ast);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        use lexer::grammar::ScriptParser;
+        use lexer::lexer::Lexer;
+
+        #[cfg(test)]
+        {
+            let source_code = "var a = 42;
+var b = 23;
+
+# a comment
+print (a - b);";
+
+            let lexer = Lexer::new(source_code);
+            let parser = ScriptParser::new();
+            let ast = parser.parse(lexer).unwrap();
+
+            println!("{:?}", ast);
+
+            assert!(matches!(ast[0], lexer::ast::Statement::Variable { .. }));
+            assert!(matches!(ast[1], lexer::ast::Statement::Variable { .. }));
+            assert!(matches!(ast[2], lexer::ast::Statement::EPrint { .. }));
+        }
     }
 }

--- a/doc/lexer/src/main.rs
+++ b/doc/lexer/src/main.rs
@@ -16,7 +16,6 @@ print (a - b);";
 
     assert!(matches!(ast[0], lexer::ast::Statement::Variable { .. }));
     assert!(matches!(ast[1], lexer::ast::Statement::Variable { .. }));
-    #[cfg(not(test))]
     assert!(matches!(ast[2], lexer::ast::Statement::Print { .. }));
 
     #[cfg(feature = "bit")]

--- a/doc/lexer/src/main.rs
+++ b/doc/lexer/src/main.rs
@@ -59,6 +59,7 @@ print (a - b);";
             assert!(matches!(ast[1], lexer::ast::Statement::Variable { .. }));
             assert!(matches!(ast[2], lexer::ast::Statement::EPrint { .. }));
 
+            #[cfg(test)]
             let _ = lexer::grammar::TESTParser::new();
         }
     }

--- a/doc/lexer/src/main.rs
+++ b/doc/lexer/src/main.rs
@@ -58,6 +58,8 @@ print (a - b);";
             assert!(matches!(ast[0], lexer::ast::Statement::Variable { .. }));
             assert!(matches!(ast[1], lexer::ast::Statement::Variable { .. }));
             assert!(matches!(ast[2], lexer::ast::Statement::EPrint { .. }));
+
+            let _ = lexer::grammar::TESTParser::new();
         }
     }
 }

--- a/lalrpop/src/api/mod.rs
+++ b/lalrpop/src/api/mod.rs
@@ -233,10 +233,15 @@ impl Configuration {
             session.features = Some(
                 env::vars()
                     .filter_map(|(feature_var, _)| {
-                        let prefix = "CARGO_FEATURE_";
-                        feature_var
-                            .strip_prefix(prefix)
-                            .map(|feature| feature.replace('_', "-").to_ascii_lowercase())
+                        if feature_var == "CARGO_CFG_TEST" {
+                            /* panic!("lalrpop does not support the `test` feature"); */
+                            Some("test".to_string())
+                        } else {
+                            let prefix = "CARGO_FEATURE_";
+                            feature_var
+                                .strip_prefix(prefix)
+                                .map(|feature| feature.replace('_', "-").to_ascii_lowercase())
+                        }
                     })
                     .collect(),
             );

--- a/lalrpop/src/api/mod.rs
+++ b/lalrpop/src/api/mod.rs
@@ -234,7 +234,6 @@ impl Configuration {
                 env::vars()
                     .filter_map(|(feature_var, _)| {
                         if feature_var == "CARGO_CFG_TEST" {
-                            /* panic!("lalrpop does not support the `test` feature"); */
                             Some("test".to_string())
                         } else {
                             let prefix = "CARGO_FEATURE_";

--- a/lalrpop/src/normalize/cond_comp/mod.rs
+++ b/lalrpop/src/normalize/cond_comp/mod.rs
@@ -48,6 +48,10 @@ pub fn cfg_active(session: &Session, attrs: &[Attribute]) -> bool {
                 .features
                 .as_ref()
                 .map_or(false, |features| features.contains(feature)),
+            AttributeArg::Empty if attr.id == *"test" => session
+                .features
+                .as_ref()
+                .map_or(false, |features| features.contains("test")),
             _ => false,
         }
     }

--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -432,6 +432,11 @@ impl<'grammar> Validator<'grammar> {
                     }
                     _ => return_err!(attr.id_span, r#"`all` takes at least one argument"#),
                 }
+            } else if attr.id == *"test" {
+                match &attr.arg {
+                    AttributeArg::Empty => Ok(()),
+                    _ => return_err!(attr.id_span, r#"`test` takes no arguments"#),
+                }
             } else {
                 return_err!(attr.id_span, r#"unexpected `cfg` argument `{}`"#, attr.id)
             }

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -6,7 +6,7 @@ export CARGO_INCREMENTAL=0
 export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 cargo build --bin lalrpop --features pico-args
-cargo test --workspace
+export CARGO_CFG_TEST=true && cargo test --workspace
 # Check the documentation examples separately so that the `lexer` feature specified in tests do not
 # leak into them
 cargo check -p calculator


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.
-->

I'm interested to try and close the loop on #681 plus flesh out the cfg support. Hypothetically, there shouldn't be too much to do since `#[cfg(test)]` is already accepted by the lalrpop grammar.

Unfortunately, because of https://github.com/rust-lang/cargo/issues/4789, users probably need to go through the extra step of manually setting the `CARGO_CFG_TEST` flag since this is otherwise not currently exposed to the build script by `cargo test`. One can control all of this flag-setting in the build script, but then you need to signal to the build script when to `std::env::set_var("CARGO_CFG_TEST", "true");`.

I've included a test via the lexer cfg example which depending on whether `cfg(test)` is set, it will produce a `print` or `eprint` in the AST.

@kleinesfilmroellchen might have guidance on what I've missed.

(whoops, I meant to make a personal branch. My bad)