### PR TITLE
Elide unneeded lifetimes in tests

### DIFF
--- a/lalrpop/src/generate.rs
+++ b/lalrpop/src/generate.rs
@@ -34,7 +34,7 @@ struct Generator<'grammar> {
 
 const MAX_DEPTH: u32 = 7000;
 
-impl<'grammar> Generator<'grammar> {
+impl Generator<'_> {
     fn nonterminal(&mut self, nt: NonterminalString) -> Option<ParseTree> {
         if self.depth > MAX_DEPTH {
             return None;

--- a/lalrpop/src/test_util.rs
+++ b/lalrpop/src/test_util.rs
@@ -11,7 +11,7 @@ thread_local! {
 
 struct ExpectedDebug<'a>(&'a str);
 
-impl<'a> Debug for ExpectedDebug<'a> {
+impl Debug for ExpectedDebug<'_> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         // Ignore trailing commas in multiline Debug representation.
         // Needed to work around rust-lang/rust#59076.


### PR DESCRIPTION
Recommended by clippy 1.83.  I missed running with --tests when I did the rest of these.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->