### PR TITLE
Added a new calculator example with blocks to demonstrate guards in macro feature.

### DIFF
--- a/doc/calculator/src/calculator3b.lalrpop
+++ b/doc/calculator/src/calculator3b.lalrpop
@@ -1,0 +1,64 @@
+use std::str::FromStr;
+
+grammar;
+
+match {
+    "+",
+    "-",
+    "*",
+    "/",
+    "(",
+    ")",
+    "{",
+    "}",
+    ";",
+    r"[0-9]+",
+    "print",
+
+    // Skip whitespace and comments
+    r"\s*" => { },
+    r"//[^\n\r]*[\n\r]*" => { }, // `// comment`
+    r"/\*([^\*]*\*+[^\*/])*([^\*]*\*+|[^\*])*\*/" => { }, // `/* comment */`
+}
+
+pub Expr = ExprRestricted<"B">;
+ExprNoBlock = ExprRestricted<"">;
+
+// - B: if non-empty, include block expressions
+ExprRestricted<B>: i32 = {
+    <l:ExprRestricted<B>> "+" <r:Factor<"B">> => l + r,
+    <l:ExprRestricted<B>> "-" <r:Factor<"B">> => l - r,
+    Factor<B>,
+};
+
+Factor<B>: i32 = {
+    <l:Factor<B>> "*" <r:Unary<"B">> => l * r,
+    <l:Factor<B>> "/" <r:Unary<"B">> => l / r,
+    Unary<B>,
+};
+
+Unary<B>: i32 = {
+    Term<B>,
+    "-" <e:Term<"B">> => -e,
+}
+
+Term<B>: i32 = {
+    Num,
+    "(" <e:Expr> ")" => e,
+    "print" "(" <e:Expr> ")" => { println!("{}", e); 0 },
+    Block if B != "",
+};
+
+Block: i32 = {
+    "{" <s:Stmt*> <e:ExprNoBlock?> "}" => e.unwrap_or_else(|| s.last().copied().unwrap_or(0)),
+}
+
+Stmt: i32 = {
+    <e:ExprNoBlock> ";" => e,
+    <b:Block> ";"? => b,
+};
+
+Num: i32 = {
+    r"[0-9]+" => i32::from_str(<>).unwrap(),
+};
+

--- a/doc/calculator/src/main.rs
+++ b/doc/calculator/src/main.rs
@@ -68,6 +68,23 @@ fn calculator3() {
     test3!(22 * (44 + 66) / 3);
 }
 
+lalrpop_mod_doc!(pub calculator3b);
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn test3b(src: &str, result: i32) {
+    println!("parsing {}", src);
+    assert_eq!(calculator3b::ExprParser::new().parse(src).unwrap(), result);
+}
+
+#[test]
+fn calculator3b() {
+    test3b("{ 1 }", 1);
+    test3b("{ 1; 2 }", 2);
+    test3b("{ print(1 + 1); 2 }", 2);
+    test3b("{ { 1 } }", 1);
+    test3b("{ { 1 } 2 }", 2);
+}
+
 lalrpop_mod_doc!(pub calculator4);
 mod ast;
 


### PR DESCRIPTION
This PR adds an example of macro guards. It motivates this by adding Rust-style blocks to the calculator, in which expressions are chained by ";". As Rust, it allows to omit the ";" when an expression is a block itself. Doing that DRY can be done using guards in macros. For a more detailed discussion, see #973.  

The new example extends the calculator 3 with the following features:
- block expressions in which expressions can be chained and the last one is returned.
- a print expression that prints a value (to motivate the chaining in the first place).

I am not sure that the number 3b is the right place to add this example, in particular because I am using "*" and "?" macros already.