### PR TITLE
Use our README as a top level docstring

### DIFF
--- a/lalrpop/src/lib.rs
+++ b/lalrpop/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../../README.md")]
+#![warn(missing_docs)]
 // Need this for rusty_peg
 #![recursion_limit = "256"]
 // I hate this lint.


### PR DESCRIPTION
This shows on the homepage of lib.rs, and is currently blank.  The README contains lots of good information and points users at the various documentation sources, so make it more visible to people checking out the crate on docs.rs.

While we're at it, warn about missing docs (which would have caught this omission).

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->