### PR TITLE
Specify optional regex_automata as "dep:".

### DIFF
--- a/lalrpop-util/Cargo.toml
+++ b/lalrpop-util/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 regex-automata = { workspace = true, optional = true }
 
 [features]
-lexer = ["regex-automata"]
+lexer = ["dep:regex-automata"]
 unicode = ["regex-automata?/unicode"]
 std = ["regex-automata/perf"]
 default = ["std", "unicode"]


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies

I recently learned that optional dependencies will be exposed as features unless the are explicitly marked as "dep:" for a another feature.  This means that lalrpop-util has a feature called "regex-automata" currently (see https://docs.rs/crate/lalrpop-util/0.22.0/features), which isn't what we want.  We want to have the dependency optionally when certain other features are enabled, but not expose it directly.

This is technically a breaking change
(https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove). However, it would surprise me if any users use this feature.  In the interest of caution, it might make sense to hold this until we plan a breaking release anyways, since it's low priority.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->