### PR TITLE
Fail more quickly when lalrpop does not generate itself

### DIFF
--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -1094,9 +1094,8 @@ fn verify_lalrpop_generates_itself() {
 
     let actual = fs::read_to_string(grammar_file.with_extension("rs")).unwrap();
     let expected = fs::read_to_string(copied_grammar_file.with_extension("rs")).unwrap();
-    util::compare_str(
-        &actual,
-        &expected,
+    assert!(
+        actual == expected,
         "The snapshot does not match what lalrpop generates now.\n\
          Use ./update_lrgrammar.sh to generate a new snapshot of the lrgrammar",
     );


### PR DESCRIPTION
The previous code typically takes several minutes of runtime to fail the verify_lalrpop_generates_itself test if that test fails.  The reason for this is that it is generating a diff output between the source controlled and the generated lrgrammar.rs using the diff library (https://docs.rs/diff/latest/diff/).  The diff library computes a diff using the LCS algorithm, which has a time complexity of O(m*n) (https://rajrajhans.com/2020/11/a-closer-look-at-diff-algorithms/).

Sometimes the diff time will be faster, because the diff library calculates a leading equality portion and a trailing equality portion and discards these before doing LCS on the middle
(https://github.com/utkarshkukreti/diff.rs/blob/4f5fac9898c54abdd59cad5d95dd615e685748d6/src/lib.rs#L53), however since many changes to lrgrammar touch various parts of the file, this often doesn't improve much in our use case.  (Notably the second line of the file is a hash, so a single change near the beginning of the file may exhibit improvement, but a single change near the end is running LCS on nearly the whole file).

The length of lrgrammar.rs is nearly 40k lines, so this O(m*n) calculation has a very noticible effect for changes near the end of lrgrammar.rs.

The generated diff itself is truncated at 100 lines, so may not be comprehensive anyways, and even if it were, the solution is to run ./generate_lrgrammar.sh.  The diff just obscures that recommendation while not typically adding value to the developer.  (And if you really want a diff, you can run ./generate_lrgrammar.sh followed by `git diff`, which will be much faster as `git diff` uses the Myers diff algorithm which is much faster than LCS.)

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->