### PR TITLE
Fix a couple of typos

### DIFF
--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -30,8 +30,8 @@ pub mod state_machine;
 /// For the built-in lexer, the generic parameters default to:
 /// ParseError<usize, lexer::Token<'_>, &'static str>.
 ///
-/// L: the location of the Token where the error occured
-/// T: The token encountered where the error occured
+/// L: the location of the Token where the error occurred
+/// T: The token encountered where the error occurred
 /// E: A custom user-defined error
 ///
 /// L and T are fixed types as listed above for built in lexers, and can be defined to whatever


### PR DESCRIPTION
occured -> occurred

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->