### PR TITLE
TestAll should also error when RecursiveAscent errors in validate

### DIFF
--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -346,7 +346,10 @@ impl Validator<'_> {
             SymbolKind::Error => {
                 let mut algorithm = r::Algorithm::default();
                 read_algorithm(&self.grammar.attributes, &mut algorithm);
-                if algorithm.codegen == r::LrCodeGeneration::RecursiveAscent {
+                if matches!(
+                    algorithm.codegen,
+                    r::LrCodeGeneration::RecursiveAscent | r::LrCodeGeneration::TestAll
+                ) {
                     return_err!(
                         symbol.span,
                         "error recovery is not yet supported by recursive ascent parsers"


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.
-->

I was looking a little into recursive_ascent/LALR support in LALRPOP and noticed the `#[test_all]` option. I believe this to be a superset code generation strategy that does both `#[recursive_ascent]` and `#[LALR]` and then compares the result.


I went and applied this annotation to all of the lalrpop_test grammars. This led to a funky error for the error_recovery_* grammars since it was skipping the validation check that just calling it with `#[recursive_ascent]` would have hit.

Unrelated, but I'm not sure yet why these are algorithm choices are set as annotations in the grammar. I'll have to do more research. I would have thought that this should be a configuration option that is independent from the lalrpop file.