### PR TITLE
replace thread rng with deterministic and portable seeded generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "rand",
+ "rand_chacha",
  "regex",
  "regex-syntax",
  "sha3",

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -23,7 +23,9 @@ doctest = false
 ascii-canvas = { version = "4.0", default-features = false }
 bit-set = { version = "0.8", default-features = false }
 ena = { version = "0.14", default-features = false }
-itertools = { version = "0.13", default-features = false, features = ["use_std"] }
+itertools = { version = "0.13", default-features = false, features = [
+    "use_std",
+] }
 petgraph = { version = "0.6", default-features = false }
 regex = { workspace = true }
 regex-syntax = { workspace = true }
@@ -42,9 +44,10 @@ lalrpop-util = { path = "../lalrpop-util", version = "0.22.0", default-features 
 [dev-dependencies]
 diff = { workspace = true }
 rand = "0.8"
+rand_chacha = "0.3.1"
 
 [features]
-default=["lexer", "unicode", "pico-args"]
+default = ["lexer", "unicode", "pico-args"]
 unicode = ["regex/unicode", "regex-syntax/unicode", "lalrpop-util/unicode"]
 lexer = ["lalrpop-util/lexer", "lalrpop-util/std"]
 

--- a/lalrpop/src/generate.rs
+++ b/lalrpop/src/generate.rs
@@ -1,7 +1,8 @@
 //! Generate valid parse trees.
 
 use crate::grammar::repr::*;
-use rand::{self, Rng};
+use rand::prelude::*;
+use rand_chacha::rand_core::SeedableRng;
 use std::iter::Iterator;
 
 #[derive(PartialEq, Eq)]
@@ -13,7 +14,7 @@ pub enum ParseTree {
 pub fn random_parse_tree(grammar: &Grammar, symbol: NonterminalString) -> ParseTree {
     let mut gen = Generator {
         grammar,
-        rng: rand::thread_rng(),
+        rng: rand_chacha::ChaCha8Rng::seed_from_u64(0),
         depth: 0,
     };
     loop {
@@ -28,7 +29,7 @@ pub fn random_parse_tree(grammar: &Grammar, symbol: NonterminalString) -> ParseT
 
 struct Generator<'grammar> {
     grammar: &'grammar Grammar,
-    rng: rand::rngs::ThreadRng,
+    rng: rand_chacha::ChaCha8Rng,
     depth: u32,
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

Fixes #994. 

I was looking at Rand's documentation and in https://rust-random.github.io/rand/rand/rngs/struct.StdRng.html they note that while some of their generators are deterministic, they may not be portable(and thus might change over various system updates).

In following their documentation (https://rust-random.github.io/book/guide-seeding.html#a-simple-number), I've pulled in Rand_chacha and I manually seed it.