### PR TITLE
Isolate allow(clippy::never_loop) to the part of the code that needs it

### DIFF
--- a/lalrpop/src/lr1/codegen/ascent.rs
+++ b/lalrpop/src/lr1/codegen/ascent.rs
@@ -452,6 +452,8 @@ impl<'ascent, 'grammar, W: Write>
 
         // finally, emit gotos (if relevant)
         if fallthrough && !this_state.gotos.is_empty() {
+            // Sometimes we write loops that unconditionally only loop once
+            rust!(self.out, "#[allow(clippy::never_loop)]");
             rust!(self.out, "loop {{");
 
             // In most states, we know precisely when the top stack

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -162,7 +162,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         rust!(
             self.out,
             "#[allow(explicit_outlives_requirements, non_snake_case, non_camel_case_types, unused_mut, unused_variables, \
-             unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding)]"
+             unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::match_single_binding)]"
         );
         rust!(self.out, "mod {}parse{} {{", self.prefix, self.start_symbol);
         rust!(self.out, "");

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -16,7 +16,7 @@ use self::___lalrpop_util::state_machine as ___state_machine;
 extern crate alloc;
 
 #[rustfmt::skip]
-#[allow(explicit_outlives_requirements, non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding)]
+#[allow(explicit_outlives_requirements, non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::match_single_binding)]
 mod ___parse___Top {
 
 use string_cache::DefaultAtom as Atom;


### PR DESCRIPTION
Recursive ascent parsers sometimes generate loops that return once. Preventing this would needlessly complicate the code generation logic. Previously, we blanket-allowed never_loop because our recursive_ascent tests triggered clippy warnings on that.  Limit this allow to only the part of the code that actually needs it.

This will enable users to see this clippy lint on their action code where applicable.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->