### PR TITLE
Remove blanket allow(clippy::needless_raw_string_hashes)

### DIFF
--- a/lalrpop/src/lr1/build/test.rs
+++ b/lalrpop/src/lr1/build/test.rs
@@ -284,7 +284,6 @@ T: () = {
 fn issue_144() {
     let _tls = Tls::test();
 
-    #[allow(clippy::needless_raw_string_hashes)] // Fix merged for next clippy release, after 1.72
     let grammar = normalized_grammar(
         r##"
 grammar;

--- a/lalrpop/src/lr1/codegen/ascent.rs
+++ b/lalrpop/src/lr1/codegen/ascent.rs
@@ -376,8 +376,10 @@ impl<'ascent, 'grammar, W: Write>
                     .any(|(t, _)| t.contains(&Token::Terminal(terminal.clone())))
         });
 
+        rust!(self.out, "#[allow(clippy::needless_raw_string_hashes)]");
         rust!(self.out, "let {}expected = alloc::vec![", self.prefix);
         for terminal in successful_terminals {
+            // Try to avoid terminals escaping
             rust!(self.out, "r###\"{}\"###.to_string(),", terminal);
         }
         rust!(self.out, "];");

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -162,7 +162,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         rust!(
             self.out,
             "#[allow(explicit_outlives_requirements, non_snake_case, non_camel_case_types, unused_mut, unused_variables, \
-             unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding, clippy::needless_raw_string_hashes)]"
+             unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding)]"
         );
         rust!(self.out, "mod {}parse{} {{", self.prefix, self.start_symbol);
         rust!(self.out, "");

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -1540,6 +1540,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
 
     /// Emit the array of terminal tokens for use in generating error output
     fn emit_terminal_repr_list(&mut self) -> io::Result<()> {
+        rust!(self.out, "#[allow(clippy::needless_raw_string_hashes)]");
         rust!(self.out, "const {}TERMINAL: &[&str] = &[", self.prefix);
         let all_terminals = if self.grammar.uses_error_recovery {
             // Subtract one to exclude the error terminal

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -16,7 +16,7 @@ use self::___lalrpop_util::state_machine as ___state_machine;
 extern crate alloc;
 
 #[rustfmt::skip]
-#[allow(explicit_outlives_requirements, non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding, clippy::needless_raw_string_hashes)]
+#[allow(explicit_outlives_requirements, non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::needless_lifetimes, clippy::type_complexity, clippy::needless_return, clippy::too_many_arguments, clippy::never_loop, clippy::match_single_binding)]
 mod ___parse___Top {
 
 use string_cache::DefaultAtom as Atom;
@@ -3029,6 +3029,7 @@ _ => 65,
 _ => 0,
 }
 }
+#[allow(clippy::needless_raw_string_hashes)]
 const ___TERMINAL: &[&str] = &[
 r###""enum""###,
 r###""extern""###,


### PR DESCRIPTION
This lint was moved by clippy into the pedantic group, so it's allowed by default anyways.

For the sake of users who may warn on it anyways, include it locally on the list of terminals where it's actually relevant.

In our own code base, just drop it, since the lint is allowed.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->