### PR TITLE
Add doc to handle lexical error in error recovery

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -20,6 +20,7 @@
    - [Writing a custom lexer](lexer_tutorial/003_writing_custom_lexer.md)
    - [Using tokens with references](lexer_tutorial/004_token_references.md)
    - [Using an external library](lexer_tutorial/005_external_lib.md)
+   - [Error recovery with custom lexer](lexer_tutorial/006_error_recovery_custom_lexer.md)
 - [Advanced setup](advanced_setup.md)
    - [Generate in source tree](generate_in_source.md)
    - [Conditional compilation](conditional-compilation.md)

--- a/doc/src/lexer_tutorial/006_error_recovery_custom_lexer.md
+++ b/doc/src/lexer_tutorial/006_error_recovery_custom_lexer.md
@@ -1,0 +1,82 @@
+# Error recovery with custom lexer
+
+Features described in
+[Error recovery](https://lalrpop.github.io/lalrpop/tutorial/008_error_recovery.html)
+works well with the custom lexer, like the lexer built by yourself or Logos. Let's
+also take Logos as an example. However, you need to do a little extra work to make
+it work. In `grammar.lalrpop`, change the signature of `grammar`
+
+```diff
+use lalrpop_util::ErrorRecovery;
+
+- grammar<'err>(errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, &'static str>>);
++ grammar<'err>(errors: &'err mut Vec<ErrorRecovery<usize, Token, LexicalError>>);
+```
+
+Now, everything should work as you wish. But still, there's a little problem here
+that you may encounter. If you try tweaking the toy script in previous chapter,
+with an illegal token to trigger `LexicalError::InvalidToken`, the parser will
+panic at the lexical error
+
+```plaintext
+print (a - $);
+
+// Err(User { error: InvalidToken })
+```
+
+It's caused by the inconsistency in the lexer stream, as lalrpop parser
+always expects a normal token stream. To fix this, you need to add a
+workaround in the lexer part to process the "error recovery" inside
+the lexer, for example
+
+```diff
+impl<'input> Iterator for Lexer<'input> {
+    type Item = Spanned<Token, usize, LexicalError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.token_stream
+        .next()
+-       .map(|(token, span)| Ok((span.start, token?, span.end)))
++       .map(|(token, span)|
++           match token {
++               Ok(token) => Ok((span.start, token, span.end)),
++               Err(_) => Ok((span.start, Token::Error, span.end)),
++               // or specify your lexical error to parse error
++           }
++       )
+    }
+}
+```
+
+and then put a new member into `Token` enum to represent the error token
+(or your custom error type)
+
+```rust
+pub enum Token {
+    //...
+
+    // Dont forget the comma
++   Error
+}
+```
+
+You see, like NaN is a number in JavaScript, we have now an `Token::Error` is
+a token in our lexer. That's something you can do with a custom lexer. And with
+the builtin lexer, you would probably need to exhaust the possible errors in the
+lexer which is a little bit more complicated and ugly.
+
+Also, you might need to custom your own error, turn to fallible actions for details.
+
+```lalrpop
+! => {
+    let error = ErrorRecovery {
+        error: ParseError::User {
+            error: LexicalError::SomeCustomError,
+        },
+        dropped_tokens: Vec::new(), // or specify the dropped tokens
+    };
+    errors.push(error);
+
+    Expression::Error
+}
+```

--- a/doc/src/lexer_tutorial/006_error_recovery_custom_lexer.md
+++ b/doc/src/lexer_tutorial/006_error_recovery_custom_lexer.md
@@ -1,10 +1,12 @@
-# Error recovery with custom lexer
+# Error recovery with a custom lexer
 
 Features described in
 [Error recovery](https://lalrpop.github.io/lalrpop/tutorial/008_error_recovery.html)
-works well with the custom lexer, like the lexer built by yourself or Logos. Let's
-also take Logos as an example. However, you need to do a little extra work to make
-it work. In `grammar.lalrpop`, change the signature of `grammar`
+work well with the custom lexer, however error recovery only supports
+recovering from parser errors - not lexer errors.  This page shows an approach
+to recover from lexer errors.
+
+Enable error recovery:
 
 ```diff
 use lalrpop_util::ErrorRecovery;
@@ -13,10 +15,9 @@ use lalrpop_util::ErrorRecovery;
 + grammar<'err>(errors: &'err mut Vec<ErrorRecovery<usize, Token, LexicalError>>);
 ```
 
-Now, everything should work as you wish. But still, there's a little problem here
-that you may encounter. If you try tweaking the toy script in previous chapter,
-with an illegal token to trigger `LexicalError::InvalidToken`, the parser will
-panic at the lexical error
+Now error recovery will work for parser errors, however if your lexer
+encounters an unexpected token, that's a *lexer* error, not a *parser* error
+so the parser is unable to recover from it.
 
 ```plaintext
 print (a - $);
@@ -49,7 +50,7 @@ impl<'input> Iterator for Lexer<'input> {
 ```
 
 and then put a new member into `Token` enum to represent the error token
-(or your custom error type)
+(or your custom error type).
 
 ```rust
 pub enum Token {
@@ -60,12 +61,14 @@ pub enum Token {
 }
 ```
 
-You see, like NaN is a number in JavaScript, we have now an `Token::Error` is
-a token in our lexer. That's something you can do with a custom lexer. And with
-the builtin lexer, you would probably need to exhaust the possible errors in the
-lexer which is a little bit more complicated and ugly.
+Like NaN is a number in JavaScript, we have now an `Token::Error` which is
+a token in our lexer.  This token can be passed to the parser, but if it is
+not used in the parser grammar, will not parse.  That transforms the lexer
+error into a recoverable parser error allowing you to have error recovery in
+this case.
 
-Also, you might need to custom your own error, turn to fallible actions for details.
+Also, you might need to custom your own error, visit the section on fallible
+actions for details.
 
 ```lalrpop
 ! => {

--- a/doc/src/tutorial/008_error_recovery.md
+++ b/doc/src/tutorial/008_error_recovery.md
@@ -83,9 +83,13 @@ fn calculator7() {
 }
 ```
 
-If you're using a custom lexer, like Logos, you can still use error
-recovery with a little extra work. See error recovery with
-[custom lexer] for more information.
+Error recovery can only handle errors reported at the parser level, not the
+lexer level.  This means that an "InvalidToken" error (or similar from a custom
+lexer) will not be recoverable.  In order to recover from lexer errors, you can
+add an `Error` token to the lexer, and rather than returning a lexer error,
+return a valid `Error` token.  A worked example for [custom lexer]s is
+available in the book.  The same approach will work for the built in lexer as
+well.
 
 [custom lexer]: https://lalrpop.github.io/lalrpop/lexer_tutorial/006_error_recovery_custom_lexer.html
 

--- a/doc/src/tutorial/008_error_recovery.md
+++ b/doc/src/tutorial/008_error_recovery.md
@@ -83,4 +83,10 @@ fn calculator7() {
 }
 ```
 
+If you're using a custom lexer, like Logos, you can still use error
+recovery with a little extra work. See error recovery with
+[custom lexer] for more information.
+
+[custom lexer]: https://lalrpop.github.io/lalrpop/lexer_tutorial/006_error_recovery_custom_lexer.html
+
 [calculator7]: https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/calculator7.lalrpop


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

Follow #992. I found a weird exit of parser when inputing an invalid token to trigger lexical error, where I expected error recovery should work. After discussing with @dburgener, we decide to address this issue temporarily in book. 

Since it's a minor change in user's code, I think it'll be unnecessary to provide an example code here. If needed, I have a copy of the example code on hand. Hope it could help.