### PR TITLE
Pin lexer logos dependency to 0.14.2 for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,8 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "logos",
+ "logos-codegen",
+ "logos-derive",
 ]
 
 [[package]]

--- a/doc/lexer/Cargo.toml
+++ b/doc/lexer/Cargo.toml
@@ -13,8 +13,8 @@ lalrpop-util = { version = "0.22.0", path = "../../lalrpop-util", features = [
     "unicode",
 ] }
 logos = "=0.14.2"
-logos-derive = "0.14.2"
-logos-codegen = "0.14.2"
+logos-derive = "=0.14.2"
+logos-codegen = "=0.14.2"
 
 [features]
 default = []

--- a/doc/lexer/Cargo.toml
+++ b/doc/lexer/Cargo.toml
@@ -13,6 +13,8 @@ lalrpop-util = { version = "0.22.0", path = "../../lalrpop-util", features = [
     "unicode",
 ] }
 logos = "=0.14.2"
+logos_derive = "0.14.2"
+logos_codegen = "0.14.2"
 
 [features]
 default = []

--- a/doc/lexer/Cargo.toml
+++ b/doc/lexer/Cargo.toml
@@ -12,7 +12,7 @@ lalrpop = { version = "0.22.0", path = "../../lalrpop" }
 lalrpop-util = { version = "0.22.0", path = "../../lalrpop-util", features = [
     "unicode",
 ] }
-logos = "0.14.0"
+logos = "=0.14.2"
 
 [features]
 default = []

--- a/doc/lexer/Cargo.toml
+++ b/doc/lexer/Cargo.toml
@@ -13,8 +13,8 @@ lalrpop-util = { version = "0.22.0", path = "../../lalrpop-util", features = [
     "unicode",
 ] }
 logos = "=0.14.2"
-logos_derive = "0.14.2"
-logos_codegen = "0.14.2"
+logos-derive = "0.14.2"
+logos-codegen = "0.14.2"
 
 [features]
 default = []


### PR DESCRIPTION
0.14.3 bumps msrv to 1.74, so our CI test for 1.70 build is currently
  failing.

This can be removed once our MSRV moves to 1.74 or later.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->