### PR TITLE
Drop extra space in generated code

### DIFF
--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -573,7 +573,7 @@ fn emit_to_triple_trait<W: Write>(
 
     rust!(
         rust,
-        "{} trait {}ToTriple<{}>",
+        "{}trait {}ToTriple<{}>",
         max_start_nt_visibility,
         grammar.prefix,
         user_type_parameters,

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -39349,7 +39349,7 @@ ___5,
 }
 
 #[allow(clippy::type_complexity, dead_code)]
-pub  trait ___ToTriple<'input, >
+pub trait ___ToTriple<'input, >
 {
 fn to_triple(self) -> Result<(usize,Tok<'input>,usize), ___lalrpop_util::ParseError<usize, Tok<'input>, tok::Error>>;
 }


### PR DESCRIPTION
The visibility Display impl will include a space (if needed - it may be the empty string).  Having an extra space in the trait declaration resulted in two spaces (or a line starting with a single space if the visibility displayed the empty string).

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->