### PR TITLE
Replace `gen` keyword with `generator` instead of `r#gen`

### DIFF
--- a/lalrpop/src/generate.rs
+++ b/lalrpop/src/generate.rs
@@ -15,7 +15,7 @@ pub fn random_parse_tree(
     symbol: NonterminalString,
     rng: &mut rand_chacha::ChaCha8Rng,
 ) -> ParseTree {
-    let mut gen = Generator {
+    let mut generator = Generator {
         grammar,
         rng,
         depth: 0,
@@ -23,10 +23,10 @@ pub fn random_parse_tree(
     loop {
         // sometimes, the random walk overflows the stack, so we have a max, and if
         // it is exceeded, we just try again
-        if let Some(result) = gen.nonterminal(symbol.clone()) {
+        if let Some(result) = generator.nonterminal(symbol.clone()) {
             return result;
         }
-        gen.depth = 0;
+        generator.depth = 0;
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->