### PR TITLE
Be more explicit about LALR deprecation in book

### DIFF
--- a/doc/src/advanced_setup.md
+++ b/doc/src/advanced_setup.md
@@ -47,6 +47,9 @@ compilation code expects `build.rs` to be run unconditionally.
 
 ## Using the Legacy LALR Parser
 
+**Note:** LALR support is deprecated and may be removed in a future release.
+If you really need this feature, please file a github issue and let us know.
+
 By default, LALRPOP uses the [lane table][]
 algorithm which is LR(1) but creates much smaller tables. There is no longer
 any clear benefit to using the previous LALR implementation but it is still


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->