### PR TITLE
Pin home to 0.5.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "bit-set",
  "diff",
  "ena",
+ "home",
  "itertools",
  "lalrpop-util",
  "petgraph",

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -23,6 +23,11 @@ doctest = false
 ascii-canvas = { version = "4.0", default-features = false }
 bit-set = { version = "0.8", default-features = false }
 ena = { version = "0.14", default-features = false }
+# 5.11 is pulled in as a transitive dependency from term which depends on >0.5.5.
+# The MSRV in 5.11 was bumped to 1.81.  Pin this to avoid bumping our MSRV for
+# now.  This can be dropped once our MSRV and the version of home pulled in by
+# term align.
+home = { version = "=0.5.9", default-features = false }
 itertools = { version = "0.13", default-features = false, features = [
     "use_std",
 ] }


### PR DESCRIPTION
This works around the home MSRV bump until a long term solution is available.

See discussion at:

https://github.com/lalrpop/lalrpop/issues/1015
https://github.com/Stebalien/term/pull/123
https://github.com/rust-lang/cargo/pull/13270

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->