### PR TITLE
Don't run cargo update on msrv or feature-powerset tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         rust:
-          - $MSRV
           - stable
           - beta
           - nightly
@@ -27,6 +26,8 @@ jobs:
           - true
         include:
           - rust: stable
+            cargo-update: false
+          - rust: $MSRV
             cargo-update: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,8 +73,6 @@ jobs:
             toolchain: $MSRV
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
-      - name: Update
-        run: cargo update
       - run: cargo build --bin lalrpop --features pico-args
       - name: Run feature powerset check
         # test with minimal amount of features plus a few extra on regex/regex-syntax


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

This reduces the risk of breakage when a dependency bumps msrv and is consistent with the guidance at https://doc.rust-lang.org/nightly/cargo/reference/rust-version.html