### PR TITLE
Refactor `report_parse_error` in `crate::build`

### DIFF
--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -279,9 +279,9 @@ fn parse_and_normalize_grammar(session: &Session, file_text: &FileText) -> io::R
     }
 }
 
-pub fn report_parse_error<'input, E>(
+pub fn report_parse_error<E>(
     file_text: &FileText,
-    error: parser::ParseError<'input>,
+    error: parser::ParseError<'_>,
     mut reporter: impl FnMut(&FileText, pt::Span, &str, io::Error) -> E,
 ) -> E {
     match error {

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -270,11 +270,7 @@ fn parse_and_normalize_grammar(session: &Session, file_text: &FileText) -> io::R
 
     match normalize::normalize(session, grammar) {
         Ok(grammar) => Ok(grammar),
-        Err(error) => Err(report_error(
-            file_text,
-            error.span,
-            &error.message,
-        ))?,
+        Err(error) => Err(report_error(file_text, error.span, &error.message))?,
     }
 }
 
@@ -358,11 +354,7 @@ pub fn report_parse_error<E>(
     }
 }
 
-fn report_error(
-    file_text: &FileText,
-    span: pt::Span,
-    message: &str,
-) -> io::Error {
+fn report_error(file_text: &FileText, span: pt::Span, message: &str) -> io::Error {
     println!("{} error: {}", file_text.span_str(span), message);
 
     let out = io::stderr();


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

As noted in #1013, this PR aims to abstract error handling. The only file modified in this PR is `src/build/mod.rs`, where parse error reporting has been refactored out of the function `parse_and_normalize_grammar` into a new public function, `report_parse_error`.

The changes are straightforward: the new `report_parse_error` function is implemented in continuation-passing style, as it accepts a callback of type `impl FnMut(&FileText, pt::Span, &str, io::Error) -> E`. This design allows the caller to produce any desired error type.

That said, I wonder if error handling could be better organized. While this approach works well for all the use cases I've encountered, I suspect it’s far from optimal. Any feedback or suggestions would be greatly appreciated.