### PR TITLE
Silence new clippy lint literal_string_with_formatting_args in codegen

### DIFF
--- a/lalrpop/src/lr1/codegen/mod.rs
+++ b/lalrpop/src/lr1/codegen/mod.rs
@@ -1,3 +1,5 @@
+// In code generation we may output format strings that will be used by the generated code
+#![allow(clippy::literal_string_with_formatting_args)]
 pub mod ascent;
 mod base;
 pub mod parse_table;


### PR DESCRIPTION
This new lint checks if we use format args in string literals that aren't passed to function that handle them like println!().  This makes sense normally, but in code generation contexts, we may be generating code like `rust!(rust, "println!("some format arg {}", arg))` which is a false positive hit for this lint.  There is only one such lint right now, but just blanket silence it in codegen and leave it on for the rest of the codebase, because it doesn't make sense in code generation.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->