### PR TITLE
Correct doc comment in test all

### DIFF
--- a/lalrpop/src/lr1/codegen/test_all.rs
+++ b/lalrpop/src/lr1/codegen/test_all.rs
@@ -1,6 +1,8 @@
-//! A compiler from an LR(1) table to a [recursive ascent] parser.
+//! Test module for comparing code generation strategies
 //!
-//! [recursive ascent]: https://en.wikipedia.org/wiki/Recursive_ascent_parser
+//! The TestAll code generation strategy uses both parse tables and recursive ascent, and then
+//! compares the parsing return values to ensure they are both identical.  This is for use in the
+//! `lalrpop-test` test suite and not intended for external consumption.
 
 use crate::grammar::repr::{Grammar, NonterminalString, TypeParameter};
 use crate::lr1::core::*;


### PR DESCRIPTION
The previous comment was copy/pasted from recursive ascent.  Update it to describe the purpose of the test all code generation strategy.

Reported by @glyh in #1008.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->