### PR TITLE
Cleanup README include in include_str

### DIFF
--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lalrpop"
 description = "convenient LR(1) parser generator"
-readme = "../README.md"
+readme = "README.md"
 workspace = ".."
 default-run = "lalrpop"
 

--- a/lalrpop/README.md
+++ b/lalrpop/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/lalrpop/src/lib.rs
+++ b/lalrpop/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../../README.md")]
+#![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 // Need this for rusty_peg
 #![recursion_limit = "256"]


### PR DESCRIPTION
When running cargo doc, the include_str command works fine, however, cargo publish relocates the package into target/package, so the relative path to the README is different, causing cargo publish to fail.

External discussion at:

https://github.com/rust-lang/cargo/issues/13309
https://users.rust-lang.org/t/include-str-does-not-work-when-releasing-because-of-changed-pathes/15551/14

The solution suggested in those links is to symlink the top level README inside your package, and then consistently refer to the README in the package.  That README will be copied into the right place during cargo publish.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->