### PR TITLE
Dry run cargo publish in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,6 +60,15 @@ jobs:
           toolchain: nightly
       - name: Check the minimum possible crate versions
         run: rm Cargo.lock && cargo +nightly build -Zdirect-minimal-versions
+  publish_dry_run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Dry run lalrpop-util (cargo publish)
+        run: cargo publish --dry-run -p lalrpop-util
+      - name: Dry run lalrpop (cargo publish)
+        run: cargo publish --dry-run -p lalrpop
+
   feature_powerset:
     runs-on: ubuntu-latest
     # Don't do expensive test if we're just going to fail on linting


### PR DESCRIPTION
Try to catch publish issues in advance.

Cargo-release is not included in this PR because it has additional
pre-publish checks that I wasn't able to get working in CI.
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->