### PR TITLE
Supplement section Error recovery with custom lexer in doc

### DIFF
--- a/doc/src/lexer_tutorial/006_error_recovery_custom_lexer.md
+++ b/doc/src/lexer_tutorial/006_error_recovery_custom_lexer.md
@@ -52,13 +52,24 @@ impl<'input> Iterator for Lexer<'input> {
 and then put a new member into `Token` enum to represent the error token
 (or your custom error type).
 
-```rust
+```diff
 pub enum Token {
     //...
 
     // Dont forget the comma
 +   Error
 }
+```
+
+Also update the extern block in `grammar.lalrpop`.
+
+```diff
+extern {
+      type Location = usize;
+      type Error = LexicalError;
+
+      enum Token {
++         "error" => Token::Error,
 ```
 
 Like NaN is a number in JavaScript, we have now an `Token::Error` which is


### PR DESCRIPTION
Fix #1038. Made it more clear to users that they need to also update the `extern` block in grammar for lexical error `Token::Error` from external lexer. Otherwise the error recovery may not work properly.