### PR TITLE
Support ASCII escape codes in string literals

### DIFF
--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -326,8 +326,9 @@ pub fn report_parse_error<E>(
             let string = match error.code {
                 tok::ErrorCode::UnrecognizedToken => "unrecognized token",
                 tok::ErrorCode::UnterminatedEscape => "unterminated escape; missing '`'?",
+                tok::ErrorCode::UnterminatedAsciiEscape => "unterminated ascii escape; missing second digit?",
                 tok::ErrorCode::UnrecognizedEscape => {
-                    "unrecognized escape; only \\n, \\r, \\t, \\\" and \\\\ are recognized"
+                    "unrecognized escape; only \\n, \\r, \\t, \\0, \\\", \\\\, and \\x## are recognized"
                 }
                 tok::ErrorCode::UnterminatedStringLiteral => {
                     "unterminated string literal; missing `\"`?"


### PR DESCRIPTION
This PR adds support for the `\0` and `\x##` escape sequences in standard string literals. Use the format described by the Rust reference (https://doc.rust-lang.org/stable/reference/tokens.html#character-literals); disallowing 8-bit characters and truncated escape sequences.

Supporting the `\x` escape code allows matching terminals that contain nonprintable ASCII characters without resorting to a regex string.