### PR TITLE
Tok error copy

### DIFF
--- a/lalrpop/src/tok/mod.rs
+++ b/lalrpop/src/tok/mod.rs
@@ -10,13 +10,13 @@ use self::Tok::*;
 #[cfg(test)]
 mod test;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Error {
     pub location: usize,
     pub code: ErrorCode,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ErrorCode {
     UnrecognizedToken,
     UnterminatedEscape,
@@ -830,7 +830,7 @@ fn apply_ascii_char_escape(
         code: UnrecognizedEscape,
     };
 
-    let high = octal.to_digit(8).ok_or(err.clone())? as u8;
+    let high = octal.to_digit(8).ok_or(err)? as u8;
     let low = hex.to_digit(16).ok_or(err)? as u8;
 
     Ok(((high << 4) | low) as char)


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

Just suggesting to remove an unnecessary clone I noticed in #1047 by deriving copy on `Error`/`ErrorCode`.

(Waiting on #1047 first)