### PR TITLE
Run a workspace based dry-run

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,10 +64,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Dry run lalrpop-util (cargo publish)
-        run: cargo publish --dry-run -p lalrpop-util
-      - name: Dry run lalrpop (cargo publish)
-        run: cargo publish --dry-run -p lalrpop
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+      - name: Dry run publish
+        run: cargo +nightly -Z package-workspace publish --dry-run -p lalrpop -p lalrpop-util
 
   feature_powerset:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This avoids the failure where lalrpop-util isn't actually uploaded (because of dry-run) when we try dry-running lalrpop.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->