### PR TITLE
regression test for non_hash ParseError::User

### DIFF
--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -106,6 +106,7 @@ pub struct MyCustomError(char);
 /// test that exercises locations, spans, and custom errors
 lalrpop_mod_test!(error);
 lalrpop_mod_test!(error_issue_113);
+lalrpop_mod_test!(non_hash_user_error);
 
 /// Test error recovery
 lalrpop_mod_test!(error_recovery);
@@ -1027,6 +1028,11 @@ fn test_mut_name() {
 #[test]
 fn issue_113() {
     assert!(error_issue_113::ItemsParser::new().parse("+").is_err());
+}
+
+#[test]
+fn testing_non_hashable_error() {
+    assert!(non_hash_user_error::ItemsParser::new().parse("+").is_err());
 }
 
 #[test]

--- a/lalrpop-test/src/non_hash_user_error.lalrpop
+++ b/lalrpop-test/src/non_hash_user_error.lalrpop
@@ -1,0 +1,19 @@
+/// This file is based on error_issue_113.lalrpop except the
+/// custom user error has been replaced with a float.
+/// Floating points, because they contain multiple possible Nan values, are not hashable
+/// by default in Rust.
+/// This test is intended to catch any unexpected breaking changes related to
+//Lalrpop requring the error type to be hashable.
+use lalrpop_util::ParseError;
+
+grammar;
+
+extern {
+    type Error = f64;
+}
+
+pub Items: Vec<(usize, usize)> = {
+    => vec![],
+    Items "+" =>? Err(ParseError::User { error: 42.0 }),
+    <v:Items> "-" =>? Ok(v),
+};


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

Mentioned in #1052. I have tried to write out my rational at the top of the test grammar file.

