### PR TITLE
Path sep

### DIFF
--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -183,6 +183,18 @@ mod user_defined_error_visibility;
 
 lalrpop_mod_test!(zero_length_match);
 
+// Using lalrpop mod here to supply the filename path
+lalrpop_mod!(
+    nest_with_path_sep,
+    "nested_directory_grammars/error_issue_1054.rs"
+);
+
+// Using lalrpop mod here to supply the filename path
+lalrpop_mod!(
+    nest_with_path_sep2,
+    "/nested_directory_grammars/error_issue_1054.rs"
+);
+
 /// This constant is here so that some of the generator parsers can
 /// refer to it in order to test `super::` handling in action code.
 const ZERO: i32 = 0;

--- a/lalrpop-test/src/nested_directory_grammars/error_issue_1054.lalrpop
+++ b/lalrpop-test/src/nested_directory_grammars/error_issue_1054.lalrpop
@@ -1,0 +1,5 @@
+grammar;
+
+pub A: String = {
+	"A" => "A".to_string()
+};

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -232,6 +232,20 @@ pub struct ErrorRecovery<L, T, E> {
     pub dropped_tokens: Vec<(L, T, L)>,
 }
 
+#[cfg(not(target_os = "windows"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! path_separator {
+    {} => { "/" }
+}
+
+#[cfg(target_os = "windows")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! path_separator {
+    {} => { "\\" }
+}
+
 /// Define a module using the generated parse from a `.lalrpop` file.
 ///
 /// You have to specify the name of the module and the path of the file
@@ -264,7 +278,7 @@ macro_rules! lalrpop_mod {
         #[allow(clippy::needless_lifetimes)]
         #[allow(clippy::let_unit_value)]
         #[allow(clippy::just_underscores_and_digits)]
-        $(#[$attr])* $vis mod $modname { include!(concat!(env!("OUT_DIR"), $source)); }
+        $(#[$attr])* $vis mod $modname { include!(concat!(env!("OUT_DIR"), lalrpop_util::path_separator!(), $source)); }
     };
 }
 


### PR DESCRIPTION
I didn't see tests for this path of `lalrpop_mod`. It also seems like adding the path separator(which is only marginally tricky because it needs to be a string literal at macro expansion time) is a reasonable paper-cut to fix?