### PR TITLE
Windows workflow in github actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,8 +29,10 @@ jobs:
           - true
         include:
           - rust: stable
+            os: ubuntu
             cargo-update: false
           - rust: $MSRV
+            os: ubuntu
             cargo-update: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
         if: matrix.cargo-update
         run: cargo update
       - name: Run tests
-        run: ./tools/ci.sh
+        run: bash ./tools/ci.sh
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,9 +15,12 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
+        os:
+          - ubuntu
+          - windows
         rust:
           - stable
           - beta

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -1098,8 +1098,11 @@ fn verify_lalrpop_generates_itself() {
         .expect("lalrpop run failed")
         .success());
 
-    let actual = fs::read_to_string(grammar_file.with_extension("rs")).unwrap();
-    let expected = fs::read_to_string(copied_grammar_file.with_extension("rs")).unwrap();
+    let mut actual = fs::read_to_string(grammar_file.with_extension("rs")).unwrap();
+    let mut expected = fs::read_to_string(copied_grammar_file.with_extension("rs")).unwrap();
+    // Make the equality check whitespace agnostic(specifically for different line endings)
+    actual.retain(|c| !c.is_whitespace());
+    expected.retain(|c| !c.is_whitespace());
     assert!(
         actual == expected,
         "The snapshot does not match what lalrpop generates now.\n\

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -1075,6 +1075,7 @@ fn generics_issue_417() {
 }
 
 #[test]
+#[cfg(not(target_os = "windows"))] // Windows uses different line endings
 fn verify_lalrpop_generates_itself() {
     let out_dir = "../target";
     let lrgrammar = "lrgrammar.lalrpop";

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -1099,11 +1099,8 @@ fn verify_lalrpop_generates_itself() {
         .expect("lalrpop run failed")
         .success());
 
-    let mut actual = fs::read_to_string(grammar_file.with_extension("rs")).unwrap();
-    let mut expected = fs::read_to_string(copied_grammar_file.with_extension("rs")).unwrap();
-    // Make the equality check whitespace agnostic(specifically for different line endings)
-    actual.retain(|c| !c.is_whitespace());
-    expected.retain(|c| !c.is_whitespace());
+    let actual = fs::read_to_string(grammar_file.with_extension("rs")).unwrap();
+    let expected = fs::read_to_string(copied_grammar_file.with_extension("rs")).unwrap();
     assert!(
         actual == expected,
         "The snapshot does not match what lalrpop generates now.\n\

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -3,9 +3,6 @@
 #![warn(rust_2018_idioms)]
 
 use std::cell::RefCell;
-use std::fs;
-use std::path::Path;
-use std::process::Command;
 
 use lalrpop_util::lalrpop_mod;
 
@@ -1077,6 +1074,10 @@ fn generics_issue_417() {
 #[test]
 #[cfg(not(target_os = "windows"))] // Windows uses different line endings
 fn verify_lalrpop_generates_itself() {
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
+
     let out_dir = "../target";
     let lrgrammar = "lrgrammar.lalrpop";
     let grammar_file = Path::new("../lalrpop/src/parser/").join(lrgrammar);


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

Adding a windows runner took a few more attempts than I would have expected. This change adds the os as part of the matrix of choices for the build job, using both ubuntu-latest and windows-latest. Generally, we can probably keep the rest of the workflows defaulting to ubuntu-latest