### PR TITLE
Inline format args

### DIFF
--- a/doc/calculator/src/ast.rs
+++ b/doc/calculator/src/ast.rs
@@ -24,8 +24,8 @@ impl Debug for Expr {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         use self::Expr::*;
         match *self {
-            Number(n) => write!(fmt, "{:?}", n),
-            Op(ref l, op, ref r) => write!(fmt, "({:?} {:?} {:?})", l, op, r),
+            Number(n) => write!(fmt, "{n:?}"),
+            Op(ref l, op, ref r) => write!(fmt, "({l:?} {op:?} {r:?})"),
             Error => write!(fmt, "error"),
         }
     }
@@ -35,8 +35,8 @@ impl Debug for ExprSymbol<'_> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         use self::ExprSymbol::*;
         match *self {
-            NumSymbol(n) => write!(fmt, "{:?}", n),
-            Op(ref l, op, ref r) => write!(fmt, "({:?} {:?} {:?})", l, op, r),
+            NumSymbol(n) => write!(fmt, "{n:?}"),
+            Op(ref l, op, ref r) => write!(fmt, "({l:?} {op:?} {r:?})"),
             Error => write!(fmt, "error"),
         }
     }

--- a/doc/calculator/src/main.rs
+++ b/doc/calculator/src/main.rs
@@ -76,7 +76,7 @@ fn calculator4() {
     let expr = calculator4::ExprParser::new()
         .parse("22 * 44 + 66")
         .unwrap();
-    assert_eq!(&format!("{:?}", expr), "((22 * 44) + 66)");
+    assert_eq!(&format!("{expr:?}"), "((22 * 44) + 66)");
 }
 
 lalrpop_mod_doc!(pub calculator5);
@@ -84,27 +84,27 @@ lalrpop_mod_doc!(pub calculator5);
 #[test]
 fn calculator5() {
     let expr = calculator5::ExprsParser::new().parse("").unwrap();
-    assert_eq!(&format!("{:?}", expr), "[]");
+    assert_eq!(&format!("{expr:?}"), "[]");
 
     let expr = calculator5::ExprsParser::new()
         .parse("22 * 44 + 66")
         .unwrap();
-    assert_eq!(&format!("{:?}", expr), "[((22 * 44) + 66)]");
+    assert_eq!(&format!("{expr:?}"), "[((22 * 44) + 66)]");
 
     let expr = calculator5::ExprsParser::new()
         .parse("22 * 44 + 66,")
         .unwrap();
-    assert_eq!(&format!("{:?}", expr), "[((22 * 44) + 66)]");
+    assert_eq!(&format!("{expr:?}"), "[((22 * 44) + 66)]");
 
     let expr = calculator5::ExprsParser::new()
         .parse("22 * 44 + 66, 13*3")
         .unwrap();
-    assert_eq!(&format!("{:?}", expr), "[((22 * 44) + 66), (13 * 3)]");
+    assert_eq!(&format!("{expr:?}"), "[((22 * 44) + 66), (13 * 3)]");
 
     let expr = calculator5::ExprsParser::new()
         .parse("22 * 44 + 66, 13*3,")
         .unwrap();
-    assert_eq!(&format!("{:?}", expr), "[((22 * 44) + 66), (13 * 3)]");
+    assert_eq!(&format!("{expr:?}"), "[((22 * 44) + 66), (13 * 3)]");
 }
 
 lalrpop_mod_doc!(pub calculator6);
@@ -156,17 +156,17 @@ fn calculator7() {
     let expr = calculator7::ExprsParser::new()
         .parse(&mut errors, "22 * + 3")
         .unwrap();
-    assert_eq!(&format!("{:?}", expr), "[((22 * error) + 3)]");
+    assert_eq!(&format!("{expr:?}"), "[((22 * error) + 3)]");
 
     let expr = calculator7::ExprsParser::new()
         .parse(&mut errors, "22 * 44 + 66, *3")
         .unwrap();
-    assert_eq!(&format!("{:?}", expr), "[((22 * 44) + 66), (error * 3)]");
+    assert_eq!(&format!("{expr:?}"), "[((22 * 44) + 66), (error * 3)]");
 
     let expr = calculator7::ExprsParser::new()
         .parse(&mut errors, "*")
         .unwrap();
-    assert_eq!(&format!("{:?}", expr), "[(error * error)]");
+    assert_eq!(&format!("{expr:?}"), "[(error * error)]");
 
     assert_eq!(errors.len(), 4);
 }
@@ -179,7 +179,7 @@ fn calculator8() {
     let expr = calculator8::ExprParser::new()
         .parse(scale, "11 * 22 + 33")
         .unwrap();
-    assert_eq!(&format!("{:?}", expr), "((22 * 44) + 66)");
+    assert_eq!(&format!("{expr:?}"), "((22 * 44) + 66)");
 }
 
 lalrpop_mod_doc!(pub calculator9);
@@ -190,7 +190,7 @@ fn calculator9() {
     let input = "22 * pi + 66";
     let lexer = crate::tok9::Lexer::new(input);
     let expr = calculator9::ExprParser::new().parse(input, lexer).unwrap();
-    assert_eq!(&format!("{:?}", expr), "((\"22\" * \"pi\") + \"66\")");
+    assert_eq!(&format!("{expr:?}"), "((\"22\" * \"pi\") + \"66\")");
 }
 
 #[cfg(not(test))]

--- a/doc/lexer-modes/src/lexer.rs
+++ b/doc/lexer-modes/src/lexer.rs
@@ -32,7 +32,7 @@ pub enum LexicalError {
 
 impl fmt::Display for LexicalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -78,7 +78,7 @@ pub enum Token<'a> {
 
 impl fmt::Display for Token<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/doc/lexer/src/test.rs
+++ b/doc/lexer/src/test.rs
@@ -13,7 +13,7 @@ print (a - b);";
     let parser = ScriptParser::new();
     let ast = parser.parse(lexer).unwrap();
 
-    println!("{:?}", ast);
+    println!("{ast:?}");
 
     #[cfg(feature = "bit")]
     {

--- a/doc/lexer/src/tokens.rs
+++ b/doc/lexer/src/tokens.rs
@@ -53,6 +53,6 @@ pub enum Token {
 
 impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }

--- a/doc/nobol/src/main.rs
+++ b/doc/nobol/src/main.rs
@@ -139,7 +139,7 @@ pub fn apply_string_escapes(content: &str) -> std::borrow::Cow<'_, str> {
                     'n' => '\n',
                     'r' => '\r',
                     't' => '\t',
-                    _ => panic!("unrecognized escape: \\{}", next),
+                    _ => panic!("unrecognized escape: \\{next}"),
                 }
             };
             text.push(the_char);

--- a/doc/pascal/lalrpop/src/main.rs
+++ b/doc/pascal/lalrpop/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
     let args = parse_args(Arguments::from_env()).unwrap();
 
     if args.flag_help {
-        println!("{}", USAGE);
+        println!("{USAGE}");
         return;
     }
 

--- a/doc/whitespace/src/ast.rs
+++ b/doc/whitespace/src/ast.rs
@@ -70,14 +70,14 @@ impl Program {
 
     pub fn dump(&self) {
         for stmt in self.statements.iter() {
-            println!("{:?}", stmt);
+            println!("{stmt:?}");
         }
     }
 
     pub fn interpret(&self) {
         Interpreter::new(self)
             .execute()
-            .unwrap_or_else(|err| println!("{}", err));
+            .unwrap_or_else(|err| println!("{err}"));
     }
 }
 
@@ -103,18 +103,18 @@ impl<'program> Interpreter<'program> {
                 &Stmt::PrintChar => {
                     let top = self.pop()?;
                     let c = num_to_char(top)?;
-                    print!("{}", c);
+                    print!("{c}");
                 }
 
                 &Stmt::Exit => return Ok(()),
 
-                other => return Err(format!("Unimplemented instruction: {:?}", other)),
+                other => return Err(format!("Unimplemented instruction: {other:?}")),
             }
 
             pc += 1;
         }
 
-        Err(format!("Out of instructions! Program counter: {}", pc))
+        Err(format!("Out of instructions! Program counter: {pc}"))
     }
 
     fn pop(&mut self) -> Result<Int, String> {
@@ -127,13 +127,13 @@ impl<'program> Interpreter<'program> {
 
 fn num_to_char(n: Int) -> Result<char, String> {
     if n < 0 {
-        Err(format!("Can't cast negative int to char: {}", n))
+        Err(format!("Can't cast negative int to char: {n}"))
     } else if n > u32::MAX as i64 {
-        Err(format!("Int is too huge to be a char: {}", n))
+        Err(format!("Int is too huge to be a char: {n}"))
     } else {
         match char::from_u32(n as u32) {
             Some(c) => Ok(c),
-            None => Err(format!("Invalid char: {}", n)),
+            None => Err(format!("Invalid char: {n}")),
         }
     }
 }

--- a/doc/whitespace/src/lib.rs
+++ b/doc/whitespace/src/lib.rs
@@ -9,7 +9,7 @@ lalrpop_mod!(pub parser);
 pub fn compile(input: &str) -> Result<ast::Program, String> {
     match parser::ProgramParser::new().parse(lexer::Lexer::new(input)) {
         Ok(s) => Ok(ast::Program::new(s)),
-        Err(e) => Err(format!("{:?}", e)),
+        Err(e) => Err(format!("{e:?}")),
     }
 }
 
@@ -19,6 +19,6 @@ fn parse_simple() {
     let program = parser::ProgramParser::new().parse(input).expect("Oh no");
     match (program.len(), program.first()) {
         (1, Some(&ast::Stmt::Exit)) => (),
-        other => panic!("Well that didn't work: {:?}", other),
+        other => panic!("Well that didn't work: {other:?}"),
     }
 }

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -256,7 +256,7 @@ fn expr_intern_tok_test_err() {
             assert_eq!(location, 15);
         }
         r => {
-            panic!("invalid result {:?}", r);
+            panic!("invalid result {r:?}");
         }
     }
 }
@@ -269,7 +269,7 @@ fn parse_error_map_token_and_location() {
         result.unwrap_err();
 
     let message = err
-        .map_token(|expr_intern_tok::Token(_, t)| format!("TOKEN {}", t))
+        .map_token(|expr_intern_tok::Token(_, t)| format!("TOKEN {t}"))
         .map_location(|offset| format!("line {}", expr[0..offset].lines().count()))
         .to_string();
     assert!(message.contains("Unrecognized token `TOKEN +`"));
@@ -537,7 +537,7 @@ fn error_test1() {
     match util::test_err_gen(|t| error::ItemsParser::new().parse(t), "---+") {
         Err(ParseError::User { error: '+' }) => { /* OK! */ }
         r => {
-            panic!("unexpected response from parser: {:?}", r);
+            panic!("unexpected response from parser: {r:?}");
         }
     }
 }
@@ -679,7 +679,7 @@ fn error_recovery_issue_240() {
     ) {
         Ok(()) => {}
         r => {
-            panic!("unexpected response from parser: {:?}", r);
+            panic!("unexpected response from parser: {r:?}");
         }
     }
 
@@ -717,7 +717,7 @@ fn error_recovery_lalr_loop() {
             assert_eq!((l..r), (0..7)); // we popped everything, so this is the full string
         }
         r => {
-            panic!("unexpected response from parser: {:?}", r);
+            panic!("unexpected response from parser: {r:?}");
         }
     }
 
@@ -757,7 +757,7 @@ fn error_recovery_lock_in() {
             assert_eq!(dropped_tokens, vec![]);
         }
         r => {
-            panic!("unexpected response from parser: {:?}", r);
+            panic!("unexpected response from parser: {r:?}");
         }
     }
 
@@ -963,7 +963,7 @@ fn generics_issue_104_test1() {
 #[test]
 fn where_clause_with_forall_test1() {
     assert!(where_clause_with_forall::TermParser::new()
-        .parse(&mut |s: &str| println!("log: {}", s), "(((((42)))))")
+        .parse(&mut |s: &str| println!("log: {s}"), "(((((42)))))")
         .is_ok());
 }
 
@@ -1058,7 +1058,7 @@ fn error_issue_278() {
             error: "Pretend there was an error",
         }) => { /* OK! */ }
         r => {
-            panic!("unexpected response from parser: {:?}", r);
+            panic!("unexpected response from parser: {r:?}");
         }
     }
 }
@@ -1174,7 +1174,7 @@ fn test_nested_pattern_string_error() {
             assert_eq!(token.1, Tok::String("not matched"));
         }
         _ => {
-            panic!("Unexpected error: {:?}", err);
+            panic!("Unexpected error: {err:?}");
         }
     }
 }

--- a/lalrpop-test/src/loc_issue_90_lib.rs
+++ b/lalrpop-test/src/loc_issue_90_lib.rs
@@ -24,7 +24,7 @@ pub enum Expr<'input> {
 fn loc_issue_90_wonky() {
     //                              0123456789abc
     let result = Expression2Parser::new().parse("wonky * wonky");
-    println!("{:#?}", result);
+    println!("{result:#?}");
     expect_debug(
         result,
         r#"
@@ -58,7 +58,7 @@ Ok(
 #[test]
 fn loc_issue_90_wacky() {
     let result = Expression2Parser::new().parse("wacky");
-    println!("{:#?}", result);
+    println!("{result:#?}");
     expect_debug(
         result,
         r#"
@@ -81,7 +81,7 @@ Ok(
 fn loc_issue_90_wacky_3() {
     //                              0123456789abc
     let result = Expression2Parser::new().parse("wacky * wacky");
-    println!("{:#?}", result);
+    println!("{result:#?}");
     expect_debug(
         result,
         r#"
@@ -115,7 +115,7 @@ Ok(
 #[test]
 fn loc_issue_90_maybe() {
     let result = Expression2Parser::new().parse("& x");
-    println!("{:#?}", result);
+    println!("{result:#?}");
     expect_debug(
         result,
         r#"
@@ -146,7 +146,7 @@ Ok(
 #[test]
 fn loc_issue_90_test1() {
     let result = Expression2Parser::new().parse("x * y");
-    println!("{:#?}", result);
+    println!("{result:#?}");
     expect_debug(
         result,
         r#"
@@ -182,7 +182,7 @@ Ok(
 #[test]
 fn loc_issue_90_test2() {
     let result = Expression2Parser::new().parse("(x*z) * y");
-    println!("{:#?}", result);
+    println!("{result:#?}");
     expect_debug(
         result,
         r#"

--- a/lalrpop-test/src/util/mod.rs
+++ b/lalrpop-test/src/util/mod.rs
@@ -23,10 +23,7 @@ where
     // expect output to be correct
     assert!(
         r == expected,
-        "parsing {:?}, got {:#?}, expected {:#?}",
-        input,
-        r,
-        expected
+        "parsing {input:?}, got {r:#?}, expected {expected:#?}"
     );
 }
 
@@ -43,10 +40,7 @@ where
     // expect output to be correct
     assert!(
         r == expected,
-        "parsing {:?}, got {:#?}, expected {:#?}",
-        input,
-        r,
-        expected
+        "parsing {input:?}, got {r:#?}, expected {expected:#?}"
     );
 }
 
@@ -68,23 +62,23 @@ impl Debug for ExpectedDebug<'_> {
         // Ignore trailing commas in multiline Debug representation.
         // Needed to work around rust-lang/rust#59076.
         let s = self.0.replace(",\n", "\n");
-        write!(fmt, "{}", s)
+        write!(fmt, "{s}")
     }
 }
 
 pub fn expect_debug<D: Debug>(actual: D, expected: &str) {
     compare(
-        ExpectedDebug(&format!("{:#?}", actual)),
+        ExpectedDebug(&format!("{actual:#?}")),
         ExpectedDebug(expected),
     )
 }
 
 pub fn compare<D: Debug, E: Debug>(actual: D, expected: E) {
-    let actual_s = format!("{:?}", actual);
-    let expected_s = format!("{:?}", expected);
+    let actual_s = format!("{actual:?}");
+    let expected_s = format!("{expected:?}");
     if actual_s != expected_s {
-        let actual_s = format!("{:#?}", actual);
-        let expected_s = format!("{:#?}", expected);
+        let actual_s = format!("{actual:#?}");
+        let expected_s = format!("{expected:#?}");
 
         compare_str(&actual_s, &expected_s, "");
     }
@@ -95,9 +89,9 @@ pub fn compare_str(actual: &str, expected: &str, msg: &str) {
         let lines = diff::lines(actual, expected);
         for diff in lines.iter().take(100) {
             match diff {
-                diff::Result::Right(r) => println!("- {}", r),
-                diff::Result::Left(l) => println!("+ {}", l),
-                diff::Result::Both(l, _) if lines.len() < 100 => println!("  {}", l),
+                diff::Result::Right(r) => println!("- {r}"),
+                diff::Result::Left(l) => println!("+ {l}"),
+                diff::Result::Both(l, _) if lines.len() < 100 => println!("  {l}"),
                 _ => (),
             }
         }

--- a/lalrpop-test/src/util/tok.rs
+++ b/lalrpop-test/src/util/tok.rs
@@ -60,7 +60,7 @@ pub fn tokenize(s: &str) -> Vec<(usize, Tok<'_>, usize)> {
                     continue;
                 }
                 _ => {
-                    panic!("invalid character: {:?}", c);
+                    panic!("invalid character: {c:?}");
                 }
             }
         }

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -159,7 +159,7 @@ fn fmt_expected(f: &mut fmt::Formatter<'_>, expected: &[String]) -> fmt::Result 
                 // Last expected message to be written
                 _ => " or",
             };
-            write!(f, "{} {}", sep, e)?;
+            write!(f, "{sep} {e}")?;
         }
     }
     Ok(())
@@ -174,29 +174,25 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::ParseError::*;
         match *self {
-            User { ref error } => write!(f, "{}", error),
-            InvalidToken { ref location } => write!(f, "Invalid token at {}", location),
+            User { ref error } => write!(f, "{error}"),
+            InvalidToken { ref location } => write!(f, "Invalid token at {location}"),
             UnrecognizedEof {
                 ref location,
                 ref expected,
             } => {
-                write!(f, "Unrecognized EOF found at {}", location)?;
+                write!(f, "Unrecognized EOF found at {location}")?;
                 fmt_expected(f, expected)
             }
             UnrecognizedToken {
                 token: (ref start, ref token, ref end),
                 ref expected,
             } => {
-                write!(
-                    f,
-                    "Unrecognized token `{}` found at {}:{}",
-                    token, start, end
-                )?;
+                write!(f, "Unrecognized token `{token}` found at {start}:{end}")?;
                 fmt_expected(f, expected)
             }
             ExtraToken {
                 token: (ref start, ref token, ref end),
-            } => write!(f, "Extra token {} found at {}:{}", token, start, end),
+            } => write!(f, "Extra token {token} found at {start}:{end}"),
         }
     }
 }
@@ -283,7 +279,7 @@ mod tests {
                 .collect(),
         };
         assert_eq!(
-            format!("{}", err),
+            format!("{err}"),
             "Unrecognized token `t0` found at 1:2\n\
              Expected one of t1, t2 or t3"
         );

--- a/lalrpop-util/src/state_machine.rs
+++ b/lalrpop-util/src/state_machine.rs
@@ -515,7 +515,7 @@ where
         match (opt_lookahead, opt_token_index) {
             (Some(l), Some(i)) => NextToken::FoundToken(l, i),
             (None, None) => NextToken::Eof,
-            (l, i) => panic!("lookahead and token_index mismatched: {:?}, {:?}", l, i),
+            (l, i) => panic!("lookahead and token_index mismatched: {l:?}, {i:?}"),
         }
     }
 

--- a/lalrpop/src/build/action.rs
+++ b/lalrpop/src/build/action.rs
@@ -98,7 +98,7 @@ fn emit_user_action_code<W: Write>(
                 .cloned()
                 .map(|t| grammar.types.spanned_type(t)),
         )
-        .map(|(name, ty)| format!("(_, {}, _): {}", name, ty))
+        .map(|(name, ty)| format!("(_, {name}, _): {ty}"))
         .collect();
 
     // If this is a reduce of an empty production, we will

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -160,7 +160,7 @@ fn process_file_into(
             let grammar = parse_and_normalize_grammar(&session, &file_text)?;
             let buffer = emit_recursive_ascent(&session, &grammar, report_file)?;
             let mut output_file = fs::File::create(rs_file)?;
-            writeln!(output_file, "{}", LALRPOP_VERSION_HEADER)?;
+            writeln!(output_file, "{LALRPOP_VERSION_HEADER}")?;
             writeln!(output_file, "{}", hash_file(lalrpop_file)?)?;
             output_file.write_all(&buffer)?;
         }
@@ -290,7 +290,7 @@ pub fn report_parse_error<E>(
             reporter(
                 file_text,
                 pt::Span(location, location),
-                &format!("invalid character `{}`", ch),
+                &format!("invalid character `{ch}`"),
             )
         }
 
@@ -309,7 +309,7 @@ pub fn report_parse_error<E>(
             reporter(
                 file_text,
                 pt::Span(lo, hi),
-                &format!("unexpected token: `{}`", text),
+                &format!("unexpected token: `{text}`"),
             )
         }
 
@@ -318,7 +318,7 @@ pub fn report_parse_error<E>(
             reporter(
                 file_text,
                 pt::Span(lo, hi),
-                &format!("extra token at end of input: `{}`", text),
+                &format!("extra token at end of input: `{text}`"),
             )
         }
 
@@ -569,7 +569,7 @@ fn emit_to_triple_trait<W: Write>(
 
     let mut user_type_parameters = String::new();
     for type_parameter in &grammar.type_parameters {
-        user_type_parameters.push_str(&format!("{}, ", type_parameter));
+        user_type_parameters.push_str(&format!("{type_parameter}, "));
     }
 
     let where_clauses = &grammar.where_clauses;

--- a/lalrpop/src/file_text.rs
+++ b/lalrpop/src/file_text.rs
@@ -100,7 +100,7 @@ impl FileText {
         // span is within one line:
         if start_line == end_line {
             let text = self.line_text(start_line);
-            writeln!(out, "  {}", text)?;
+            writeln!(out, "  {text}")?;
 
             if end_col - start_col <= 1 {
                 writeln!(out, "  {}^", Repeat(' ', start_col))?;
@@ -124,7 +124,7 @@ impl FileText {
                 Repeat('~', max_len - start_col)
             )?;
             for line in &line_strs[..line_strs.len() - 1] {
-                writeln!(out, "| {0:<1$} |", line, max_len)?;
+                writeln!(out, "| {line:<max_len$} |")?;
             }
             writeln!(out, "| {}", line_strs[line_strs.len() - 1])?;
             writeln!(out, "+~{}", Repeat('~', end_col))?;

--- a/lalrpop/src/grammar/parse_tree.rs
+++ b/lalrpop/src/grammar/parse_tree.rs
@@ -112,7 +112,7 @@ pub enum MatchMapping {
 impl Debug for MatchMapping {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
-            MatchMapping::Terminal(term) => write!(fmt, "{:?}", term),
+            MatchMapping::Terminal(term) => write!(fmt, "{term:?}"),
             MatchMapping::Skip => write!(fmt, "{{ }}"),
         }
     }
@@ -120,7 +120,7 @@ impl Debug for MatchMapping {
 impl Display for MatchMapping {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
-            MatchMapping::Terminal(term) => write!(fmt, "{}", term),
+            MatchMapping::Terminal(term) => write!(fmt, "{term}"),
             MatchMapping::Skip => write!(fmt, "{{ }}"),
         }
     }
@@ -738,7 +738,7 @@ impl Symbol {
     }
 
     pub fn canonical_form(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 }
 
@@ -755,9 +755,9 @@ impl Name {
 impl Display for Visibility {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
-            Visibility::Pub(Some(ref path)) => write!(fmt, "pub({}) ", path),
+            Visibility::Pub(Some(ref path)) => write!(fmt, "pub({path}) "),
             Visibility::Pub(None) => write!(fmt, "pub "),
-            Visibility::PubIn(ref path) => write!(fmt, "pub(in {}) ", path),
+            Visibility::PubIn(ref path) => write!(fmt, "pub(in {path}) "),
             Visibility::Priv => Ok(()),
         }
     }
@@ -770,12 +770,12 @@ impl<T: Display> Display for WhereClause<T> {
                 ref lifetime,
                 ref bounds,
             } => {
-                write!(fmt, "{}:", lifetime)?;
+                write!(fmt, "{lifetime}:")?;
                 for (i, b) in bounds.iter().enumerate() {
                     if i != 0 {
                         write!(fmt, " +")?;
                     }
-                    write!(fmt, " {}", b)?;
+                    write!(fmt, " {b}")?;
                 }
                 Ok(())
             }
@@ -790,17 +790,17 @@ impl<T: Display> Display for WhereClause<T> {
                         if i != 0 {
                             write!(fmt, ", ")?;
                         }
-                        write!(fmt, "{}", l)?;
+                        write!(fmt, "{l}")?;
                     }
                     write!(fmt, "> ")?;
                 }
 
-                write!(fmt, "{}: ", ty)?;
+                write!(fmt, "{ty}: ")?;
                 for (i, b) in bounds.iter().enumerate() {
                     if i != 0 {
                         write!(fmt, " +")?;
                     }
-                    write!(fmt, " {}", b)?;
+                    write!(fmt, " {b}")?;
                 }
                 Ok(())
             }
@@ -811,7 +811,7 @@ impl<T: Display> Display for WhereClause<T> {
 impl<T: Display> Display for TypeBound<T> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
-            TypeBound::Lifetime(ref l) => write!(fmt, "{}", l),
+            TypeBound::Lifetime(ref l) => write!(fmt, "{l}"),
             TypeBound::Fn {
                 ref forall,
                 ref path,
@@ -824,22 +824,22 @@ impl<T: Display> Display for TypeBound<T> {
                         if i != 0 {
                             write!(fmt, ", ")?;
                         }
-                        write!(fmt, "{}", l)?;
+                        write!(fmt, "{l}")?;
                     }
                     write!(fmt, "> ")?;
                 }
 
-                write!(fmt, "{}(", path)?;
+                write!(fmt, "{path}(")?;
                 for (i, p) in parameters.iter().enumerate() {
                     if i != 0 {
                         write!(fmt, ", ")?;
                     }
-                    write!(fmt, "{}", p)?;
+                    write!(fmt, "{p}")?;
                 }
                 write!(fmt, ")")?;
 
                 if let Some(ref ret) = *ret {
-                    write!(fmt, " -> {}", ret)?;
+                    write!(fmt, " -> {ret}")?;
                 }
 
                 Ok(())
@@ -855,12 +855,12 @@ impl<T: Display> Display for TypeBound<T> {
                         if i != 0 {
                             write!(fmt, ", ")?;
                         }
-                        write!(fmt, "{}", l)?;
+                        write!(fmt, "{l}")?;
                     }
                     write!(fmt, "> ")?;
                 }
 
-                write!(fmt, "{}", path)?;
+                write!(fmt, "{path}")?;
                 if parameters.is_empty() {
                     return Ok(());
                 }
@@ -870,7 +870,7 @@ impl<T: Display> Display for TypeBound<T> {
                     if i != 0 {
                         write!(fmt, ", ")?;
                     }
-                    write!(fmt, "{}", p)?;
+                    write!(fmt, "{p}")?;
                 }
                 write!(fmt, ">")
             }
@@ -881,9 +881,9 @@ impl<T: Display> Display for TypeBound<T> {
 impl<T: Display> Display for TypeBoundParameter<T> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
-            TypeBoundParameter::Lifetime(ref l) => write!(fmt, "{}", l),
-            TypeBoundParameter::TypeParameter(ref t) => write!(fmt, "{}", t),
-            TypeBoundParameter::Associated(ref id, ref t) => write!(fmt, "{} = {}", id, t),
+            TypeBoundParameter::Lifetime(ref l) => write!(fmt, "{l}"),
+            TypeBoundParameter::TypeParameter(ref t) => write!(fmt, "{t}"),
+            TypeBoundParameter::Associated(ref id, ref t) => write!(fmt, "{id} = {t}"),
         }
     }
 }
@@ -891,8 +891,8 @@ impl<T: Display> Display for TypeBoundParameter<T> {
 impl Display for TerminalString {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
-            TerminalString::Literal(ref s) => write!(fmt, "{}", s),
-            TerminalString::Bare(ref s) => write!(fmt, "{}", s),
+            TerminalString::Literal(ref s) => write!(fmt, "{s}"),
+            TerminalString::Bare(ref s) => write!(fmt, "{s}"),
             TerminalString::Error => write!(fmt, "error"),
         }
     }
@@ -927,7 +927,7 @@ impl Display for TerminalLiteral {
 
 impl Debug for TerminalLiteral {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
-        write!(fmt, "{}", self)
+        write!(fmt, "{self}")
     }
 }
 
@@ -963,14 +963,14 @@ impl Display for Symbol {
 impl Display for SymbolKind {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
-            SymbolKind::Expr(ref expr) => write!(fmt, "{}", expr),
-            SymbolKind::Terminal(ref s) => write!(fmt, "{}", s),
-            SymbolKind::Nonterminal(ref s) => write!(fmt, "{}", s),
-            SymbolKind::AmbiguousId(ref s) => write!(fmt, "{}", s),
-            SymbolKind::Macro(ref m) => write!(fmt, "{}", m),
-            SymbolKind::Repeat(ref r) => write!(fmt, "{}", r),
-            SymbolKind::Choose(ref s) => write!(fmt, "<{}>", s),
-            SymbolKind::Name(ref n, ref s) => write!(fmt, "{}:{}", n, s),
+            SymbolKind::Expr(ref expr) => write!(fmt, "{expr}"),
+            SymbolKind::Terminal(ref s) => write!(fmt, "{s}"),
+            SymbolKind::Nonterminal(ref s) => write!(fmt, "{s}"),
+            SymbolKind::AmbiguousId(ref s) => write!(fmt, "{s}"),
+            SymbolKind::Macro(ref m) => write!(fmt, "{m}"),
+            SymbolKind::Repeat(ref r) => write!(fmt, "{r}"),
+            SymbolKind::Choose(ref s) => write!(fmt, "<{s}>"),
+            SymbolKind::Name(ref n, ref s) => write!(fmt, "{n}:{s}"),
             SymbolKind::Lookahead => write!(fmt, "@L"),
             SymbolKind::Lookbehind => write!(fmt, "@R"),
             SymbolKind::Error => write!(fmt, "error"),
@@ -1018,19 +1018,19 @@ impl ExternToken {
 
 impl ExprSymbol {
     pub fn canonical_form(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 }
 
 impl MacroSymbol {
     pub fn canonical_form(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 }
 
 impl RepeatSymbol {
     pub fn canonical_form(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 }
 
@@ -1043,8 +1043,8 @@ impl Display for MacroSymbol {
 impl Display for TypeParameter {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
-            TypeParameter::Lifetime(ref s) => write!(fmt, "{}", s),
-            TypeParameter::Id(ref s) => write!(fmt, "{}", s),
+            TypeParameter::Lifetime(ref s) => write!(fmt, "{s}"),
+            TypeParameter::Id(ref s) => write!(fmt, "{s}"),
         }
     }
 }
@@ -1053,11 +1053,11 @@ impl Display for TypeRef {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             TypeRef::Tuple(ref types) => write!(fmt, "({})", Sep(", ", types)),
-            TypeRef::Slice(ref ty) => write!(fmt, "[{}]", ty),
+            TypeRef::Slice(ref ty) => write!(fmt, "[{ty}]"),
             TypeRef::Nominal {
                 ref path,
                 ref types,
-            } if types.is_empty() => write!(fmt, "{}", path),
+            } if types.is_empty() => write!(fmt, "{path}"),
             TypeRef::Nominal {
                 ref path,
                 ref types,
@@ -1065,34 +1065,34 @@ impl Display for TypeRef {
             TypeRef::TraitObject {
                 ref path,
                 ref types,
-            } if types.is_empty() => write!(fmt, "dyn {}", path),
+            } if types.is_empty() => write!(fmt, "dyn {path}"),
             TypeRef::TraitObject {
                 ref path,
                 ref types,
             } => write!(fmt, "dyn {}<{}>", path, Sep(", ", types)),
-            TypeRef::Lifetime(ref s) => write!(fmt, "{}", s),
-            TypeRef::Id(ref s) => write!(fmt, "{}", s),
-            TypeRef::OfSymbol(ref s) => write!(fmt, "`{}`", s),
+            TypeRef::Lifetime(ref s) => write!(fmt, "{s}"),
+            TypeRef::Id(ref s) => write!(fmt, "{s}"),
+            TypeRef::OfSymbol(ref s) => write!(fmt, "`{s}`"),
             TypeRef::Ref {
                 lifetime: None,
                 mutable: false,
                 ref referent,
-            } => write!(fmt, "&{}", referent),
+            } => write!(fmt, "&{referent}"),
             TypeRef::Ref {
                 lifetime: Some(ref l),
                 mutable: false,
                 ref referent,
-            } => write!(fmt, "&{} {}", l, referent),
+            } => write!(fmt, "&{l} {referent}"),
             TypeRef::Ref {
                 lifetime: None,
                 mutable: true,
                 ref referent,
-            } => write!(fmt, "&mut {}", referent),
+            } => write!(fmt, "&mut {referent}"),
             TypeRef::Ref {
                 lifetime: Some(ref l),
                 mutable: true,
                 ref referent,
-            } => write!(fmt, "&{} mut {}", l, referent),
+            } => write!(fmt, "&{l} mut {referent}"),
             TypeRef::Fn {
                 ref forall,
                 ref path,
@@ -1105,7 +1105,7 @@ impl Display for TypeRef {
                 }
                 write!(fmt, "{}({})", path, Sep(", ", parameters))?;
                 if let Some(ret) = ret {
-                    write!(fmt, " -> {}", ret)?;
+                    write!(fmt, " -> {ret}")?;
                 }
                 Ok(())
             }

--- a/lalrpop/src/grammar/pattern.rs
+++ b/lalrpop/src/grammar/pattern.rs
@@ -96,13 +96,13 @@ impl<T: Display> Display for Pattern<T> {
 impl<T: Display> Display for PatternKind<T> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
-            PatternKind::Path(ref path) => write!(fmt, "{}", path),
+            PatternKind::Path(ref path) => write!(fmt, "{path}"),
             PatternKind::Enum(ref path, ref pats) => write!(fmt, "{}({})", path, Sep(", ", pats)),
             PatternKind::Struct(ref path, ref fields, false) => {
                 write!(fmt, "{} {{ {} }}", path, Sep(", ", fields))
             }
             PatternKind::Struct(ref path, ref fields, true) if fields.is_empty() => {
-                write!(fmt, "{} {{ .. }}", path)
+                write!(fmt, "{path} {{ .. }}")
             }
             PatternKind::Struct(ref path, ref fields, true) => {
                 write!(fmt, "{} {{ {}, .. }}", path, Sep(", ", fields))
@@ -113,10 +113,10 @@ impl<T: Display> Display for PatternKind<T> {
             }
             PatternKind::Underscore => write!(fmt, "_"),
             PatternKind::DotDot => write!(fmt, ".."),
-            PatternKind::Usize(n) => write!(fmt, "{}", n),
-            PatternKind::Choose(ref ty) => write!(fmt, "{}", ty),
-            PatternKind::CharLiteral(ref c) => write!(fmt, "'{}'", c),
-            PatternKind::String(ref s) => write!(fmt, "{:?}", s),
+            PatternKind::Usize(n) => write!(fmt, "{n}"),
+            PatternKind::Choose(ref ty) => write!(fmt, "{ty}"),
+            PatternKind::CharLiteral(ref c) => write!(fmt, "'{c}'"),
+            PatternKind::String(ref s) => write!(fmt, "{s:?}"),
         }
     }
 }

--- a/lalrpop/src/grammar/repr.rs
+++ b/lalrpop/src/grammar/repr.rs
@@ -298,7 +298,7 @@ impl TypeRepr {
         let fresh_lifetime_name = |type_parameters: &mut Vec<TypeParameter>| {
             // Make a name like `__1`:
             let len = type_parameters.len();
-            let name = Lifetime(Atom::from(format!("'{}{}", prefix, len)));
+            let name = Lifetime(Atom::from(format!("'{prefix}{len}")));
             type_parameters.push(TypeParameter::Lifetime(name.clone()));
             name
         };
@@ -395,7 +395,7 @@ impl Types {
             path: Path {
                 absolute: false,
                 ids: vec![
-                    Atom::from(format!("{}lalrpop_util", prefix)),
+                    Atom::from(format!("{prefix}lalrpop_util")),
                     Atom::from("ParseError"),
                 ],
             },
@@ -405,7 +405,7 @@ impl Types {
             path: Path {
                 absolute: false,
                 ids: vec![
-                    Atom::from(format!("{}lalrpop_util", prefix)),
+                    Atom::from(format!("{prefix}lalrpop_util")),
                     Atom::from("ErrorRecovery"),
                 ],
             },
@@ -498,7 +498,7 @@ impl Display for WhereClause {
                 write!(fmt, "for<{}> {}", Sep(", ", binder), clause)
             }
 
-            WhereClause::Bound { subject, bound } => write!(fmt, "{}: {}", subject, bound),
+            WhereClause::Bound { subject, bound } => write!(fmt, "{subject}: {bound}"),
         }
     }
 }
@@ -513,34 +513,34 @@ impl Display for TypeRepr {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             TypeRepr::Tuple(ref types) => write!(fmt, "({})", Sep(", ", types)),
-            TypeRepr::Slice(ref ty) => write!(fmt, "[{}]", ty),
-            TypeRepr::Nominal(ref data) => write!(fmt, "{}", data),
+            TypeRepr::Slice(ref ty) => write!(fmt, "[{ty}]"),
+            TypeRepr::Nominal(ref data) => write!(fmt, "{data}"),
             TypeRepr::Associated {
                 ref type_parameter,
                 ref id,
-            } => write!(fmt, "{}::{}", type_parameter, id),
-            TypeRepr::Lifetime(ref id) => write!(fmt, "{}", id),
+            } => write!(fmt, "{type_parameter}::{id}"),
+            TypeRepr::Lifetime(ref id) => write!(fmt, "{id}"),
             TypeRepr::Ref {
                 lifetime: None,
                 mutable: false,
                 ref referent,
-            } => write!(fmt, "&{}", referent),
+            } => write!(fmt, "&{referent}"),
             TypeRepr::Ref {
                 lifetime: Some(ref l),
                 mutable: false,
                 ref referent,
-            } => write!(fmt, "&{} {}", l, referent),
+            } => write!(fmt, "&{l} {referent}"),
             TypeRepr::Ref {
                 lifetime: None,
                 mutable: true,
                 ref referent,
-            } => write!(fmt, "&mut {}", referent),
+            } => write!(fmt, "&mut {referent}"),
             TypeRepr::Ref {
                 lifetime: Some(ref l),
                 mutable: true,
                 ref referent,
-            } => write!(fmt, "&{} mut {}", l, referent),
-            TypeRepr::TraitObject(ref data) => write!(fmt, "dyn {}", data),
+            } => write!(fmt, "&{l} mut {referent}"),
+            TypeRepr::TraitObject(ref data) => write!(fmt, "dyn {data}"),
             TypeRepr::Fn {
                 ref forall,
                 ref path,
@@ -553,7 +553,7 @@ impl Display for TypeRepr {
                 }
                 write!(fmt, "{}({})", path, Sep(", ", parameters))?;
                 if let Some(ret) = ret {
-                    write!(fmt, " -> {}", ret)?;
+                    write!(fmt, " -> {ret}")?;
                 }
                 Ok(())
             }
@@ -615,8 +615,8 @@ impl Symbol {
 impl Display for Symbol {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
-            Symbol::Nonterminal(id) => write!(fmt, "{}", id),
-            Symbol::Terminal(id) => write!(fmt, "{}", id),
+            Symbol::Nonterminal(id) => write!(fmt, "{id}"),
+            Symbol::Terminal(id) => write!(fmt, "{id}"),
         }
     }
 }
@@ -659,7 +659,7 @@ impl ActionFnDefn {
         match self.kind {
             ActionFnDefnKind::User(ref data) => data.to_fn_string(self, name),
             ActionFnDefnKind::Inline(ref data) => data.to_fn_string(name),
-            ActionFnDefnKind::Lookaround(ref data) => format!("{:?}", data),
+            ActionFnDefnKind::Lookaround(ref data) => format!("{data:?}"),
         }
     }
 }
@@ -670,7 +670,7 @@ impl UserActionFnDefn {
             .arg_patterns
             .iter()
             .zip(self.arg_types.iter())
-            .map(|(name, ty)| format!("{}: {}", name, ty))
+            .map(|(name, ty)| format!("{name}: {ty}"))
             .collect();
 
         format!(
@@ -689,7 +689,7 @@ impl InlineActionFnDefn {
             .symbols
             .iter()
             .map(|inline_sym| match *inline_sym {
-                InlinedSymbol::Original(ref s) => format!("{}", s),
+                InlinedSymbol::Original(ref s) => format!("{s}"),
                 InlinedSymbol::Inlined(a, ref s) => format!("{:?}({})", a, Sep(", ", s)),
             })
             .collect();

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -40,11 +40,11 @@ pub fn compile<W: Write>(
                 },
             )
         })
-        .map(|(regex, skip)| (format!("{}", regex), skip))
+        .map(|(regex, skip)| (format!("{regex}"), skip))
         .map(|(regex_str, skip)| {
             // create a rust string with text of the regex; the Debug impl
             // will add quotes and escape
-            (format!("{:?}", regex_str), skip)
+            (format!("{regex_str:?}"), skip)
         });
 
     let mut contains_skip = false;

--- a/lalrpop/src/lexer/nfa/mod.rs
+++ b/lalrpop/src/lexer/nfa/mod.rs
@@ -593,12 +593,12 @@ impl Debug for Test {
             (Some(start), Some(end)) => {
                 if self.is_char() {
                     if ".[]()?+*!".contains(start) {
-                        write!(fmt, "\\{}", start)
+                        write!(fmt, "\\{start}")
                     } else {
-                        write!(fmt, "{}", start)
+                        write!(fmt, "{start}")
                     }
                 } else {
-                    write!(fmt, "[{:?}..={:?}]", start, end)
+                    write!(fmt, "[{start:?}..={end:?}]")
                 }
             }
             _ => write!(fmt, "[{:?}..]{:?}]", self.start(), self.end()),

--- a/lalrpop/src/lexer/nfa/test.rs
+++ b/lalrpop/src/lexer/nfa/test.rs
@@ -38,9 +38,9 @@ fn edge_iter() {
 #[test]
 fn identifier_regex() {
     let ident = re::parse_regex(r#"[a-zA-Z_][a-zA-Z0-9_]*"#).unwrap();
-    println!("{:#?}", ident);
+    println!("{ident:#?}");
     let nfa = Nfa::from_re(&ident).unwrap();
-    println!("{:#?}", nfa);
+    println!("{nfa:#?}");
     assert_eq!(interpret(&nfa, "0123"), None);
     assert_eq!(interpret(&nfa, "hello0123"), Some("hello0123"));
     assert_eq!(interpret(&nfa, "hello0123 abc"), Some("hello0123"));

--- a/lalrpop/src/lr1/build/test.rs
+++ b/lalrpop/src/lr1/build/test.rs
@@ -25,9 +25,9 @@ fn random_test<'g>(grammar: &Grammar, states: &'g [Lr1State<'g>], start_symbol: 
         let input_tree = generate::random_parse_tree(grammar, start_symbol.clone(), &mut rng);
         let output_tree = interpret(states, input_tree.terminals()).unwrap();
 
-        println!("test {}", i);
-        println!("input_tree = {}", input_tree);
-        println!("output_tree = {}", output_tree);
+        println!("test {i}");
+        println!("input_tree = {input_tree}");
+        println!("output_tree = {output_tree}");
 
         compare(output_tree, input_tree);
     }
@@ -139,13 +139,13 @@ grammar;
     // for now, just test that process does not result in an error
     // and yields expected number of states.
     let states = build_lr1_states(&grammar, nt("S")).unwrap();
-    println!("{:#?}", states);
+    println!("{states:#?}");
     assert_eq!(states.len(), if use_lane_table() { 9 } else { 16 });
 
     // execute it on some sample inputs.
     let tree = interpret(&states, tokens!["N", "-", "(", "N", "-", "N", ")"]).unwrap();
     assert_eq!(
-        &format!("{}", tree)[..],
+        &format!("{tree}")[..],
         r#"[S: [E: [E: [T: "N"]], "-", [T: "(", [E: [E: [T: "N"]], "-", [T: "N"]], ")"]]]"#
     );
 
@@ -160,9 +160,9 @@ grammar;
 
     // parens first:
     let tree = interpret(&states, tokens!["(", "N", "-", "N", ")", "-", "N"]).unwrap();
-    println!("{}", tree);
+    println!("{tree}");
     assert_eq!(
-        &format!("{}", tree)[..],
+        &format!("{tree}")[..],
         r#"[S: [E: [E: [T: "(", [E: [E: [T: "N"]], "-", [T: "N"]], ")"]], "-", [T: "N"]]]"#
     );
 
@@ -354,5 +354,5 @@ pub Query = SELECT r"[a-z]+";
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
 
     let states = build_lr0_states(&grammar, nt("Query")).expect("build states");
-    println!("states: {:?}", states);
+    println!("states: {states:?}");
 }

--- a/lalrpop/src/lr1/build_lalr/test.rs
+++ b/lalrpop/src/lr1/build_lalr/test.rs
@@ -39,11 +39,11 @@ fn figure9_23() {
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
 
     let states = build_lalr_states(&grammar, nt("S")).unwrap();
-    println!("{:#?}", states);
+    println!("{states:#?}");
 
     let tree = interpret(&states, tokens!["N", "-", "(", "N", "-", "N", ")"]).unwrap();
     assert_eq!(
-        &format!("{:?}", tree)[..],
+        &format!("{tree:?}")[..],
         r#"[S: [E: [E: [T: "N"]], "-", [T: "(", [E: [E: [T: "N"]], "-", [T: "N"]], ")"]]]"#
     );
 }

--- a/lalrpop/src/lr1/codegen/ascent.rs
+++ b/lalrpop/src/lr1/codegen/ascent.rs
@@ -946,8 +946,8 @@ impl<'ascent, 'grammar, W: Write>
     /// Emit a pattern that matches `id` but doesn't extract any data.
     fn match_terminal_pattern(&mut self, id: &TerminalString) -> String {
         let pattern = self.grammar.pattern(id).map(&mut |_| "_");
-        let pattern = format!("{}", pattern);
-        format!("(_, {}, _)", pattern)
+        let pattern = format!("{pattern}");
+        format!("(_, {pattern}, _)")
     }
 
     /// Emit a pattern that matches `id` and extracts its value, storing
@@ -960,7 +960,7 @@ impl<'ascent, 'grammar, W: Write>
             pattern_names.last().cloned().unwrap()
         });
 
-        let mut pattern = format!("{}", pattern);
+        let mut pattern = format!("{pattern}");
         if pattern_names.is_empty() {
             pattern_names.push(format!("{}tok", self.prefix));
             pattern = format!("{}tok @ {}", self.prefix, pattern);

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -213,7 +213,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
             // otherwise, we need an iterator of type `TOKENS`
             let mut user_type_parameters = String::new();
             for type_parameter in &self.grammar.type_parameters {
-                user_type_parameters.push_str(&format!("{}, ", type_parameter));
+                user_type_parameters.push_str(&format!("{type_parameter}, "));
             }
             type_parameters = vec![
                 format!(
@@ -349,7 +349,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
             .type_parameters
             .iter()
             .map(|tp| match *tp {
-                TypeParameter::Lifetime(ref l) => format!("&{} ()", l),
+                TypeParameter::Lifetime(ref l) => format!("&{l} ()"),
 
                 TypeParameter::Id(ref id) => id.to_string(),
             })

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -45,11 +45,11 @@ impl<T: fmt::Display> fmt::Display for Comment<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Comment::Goto(ref token, new_state) => {
-                write!(f, " // on {}, goto {}", token, new_state)
+                write!(f, " // on {token}, goto {new_state}")
             }
-            Comment::Error(ref token) => write!(f, " // on {}, error", token),
+            Comment::Error(ref token) => write!(f, " // on {token}, error"),
             Comment::Reduce(ref token, production) => {
-                write!(f, " // on {}, reduce `{:?}`", token, production)
+                write!(f, " // on {token}, reduce `{production:?}`")
             }
         }
     }
@@ -437,7 +437,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
             let name = match self.custom.variants.entry(ty.clone()) {
                 Entry::Occupied(entry) => entry.into_mut(),
                 Entry::Vacant(entry) => {
-                    let name = format!("Variant{}", len);
+                    let name = format!("Variant{len}");
 
                     rust!(self.out, "{}({}),", name, ty);
                     entry.insert(name)
@@ -456,7 +456,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
             let name = match self.custom.variants.entry(ty.clone()) {
                 Entry::Occupied(entry) => entry.into_mut(),
                 Entry::Vacant(entry) => {
-                    let name = format!("Variant{}", len);
+                    let name = format!("Variant{len}");
 
                     rust!(self.out, "{}({}),", name, ty);
                     entry.insert(name)
@@ -662,8 +662,8 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
                         ranges
                             .iter()
                             .format_with(" | ", |(start, end), f| match end {
-                                None => f(&format_args!("{}", start)),
-                                Some(end) => f(&format_args!("{}..={}", start, end)),
+                                None => f(&format_args!("{start}")),
+                                Some(end) => f(&format_args!("{start}..={end}")),
                             }),
                         next_state,
                     );
@@ -851,7 +851,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
                     });
                     first = false;
 
-                    format!("{}", pattern)
+                    format!("{pattern}")
                 })
                 .collect::<Vec<_>>();
 
@@ -924,10 +924,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
             .fn_header(&Visibility::Priv, format!("{}reduce", self.prefix))
             .with_grammar(self.grammar)
             .with_parameters(parameters)
-            .with_return_type(format!(
-                "Option<Result<{},{}>>",
-                success_type, parse_error_type
-            ))
+            .with_return_type(format!("Option<Result<{success_type},{parse_error_type}>>"))
             .emit()?;
         rust!(self.out, "{{");
 

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -195,14 +195,14 @@ impl Display for Token {
         match *self {
             Token::Eof => write!(fmt, "Eof"),
             Token::Error => write!(fmt, "Error"),
-            Token::Terminal(ref s) => write!(fmt, "{}", s),
+            Token::Terminal(ref s) => write!(fmt, "{s}"),
         }
     }
 }
 
 impl Debug for Token {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
-        write!(fmt, "{}", self)
+        write!(fmt, "{self}")
     }
 }
 

--- a/lalrpop/src/lr1/error/mod.rs
+++ b/lalrpop/src/lr1/error/mod.rs
@@ -438,14 +438,10 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
             ))
             .push(reduce.to_symbol_list(reduce.symbols.len(), styles))
             .wrap_text(format!(
-                "They could be reduced using the production on line {}:",
-                span1_line
+                "They could be reduced using the production on line {span1_line}:"
             ))
             .wrap_text(span1_str)
-            .wrap_text(format!(
-                "...or using the production on line {}:",
-                span2_line
-            ))
+            .wrap_text(format!("...or using the production on line {span2_line}:"))
             .wrap_text(span2_str)
             .end()
             .end()
@@ -498,7 +494,7 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
             .wrap_text("when in this state:")
             .indented();
         for item in self.states[conflict.state.0].items.vec.iter() {
-            builder = builder.text(format!("{:?}", item));
+            builder = builder.text(format!("{item:?}"));
         }
         let mut builder = builder
             .end()

--- a/lalrpop/src/lr1/error/test.rs
+++ b/lalrpop/src/lr1/error/test.rs
@@ -30,7 +30,7 @@ pub Ty: () = {
     let conflicts = super::token_conflicts(&err.conflicts);
     let conflict = &conflicts[0][0];
 
-    println!("conflict={:?}", conflict);
+    println!("conflict={conflict:?}");
 
     match cx.classify(conflict) {
         ConflictClassification::Precedence {
@@ -38,17 +38,14 @@ pub Ty: () = {
             reduce,
             nonterminal,
         } => {
-            println!(
-                "shift={:#?}, reduce={:#?}, nonterminal={:?}",
-                shift, reduce, nonterminal
-            );
+            println!("shift={shift:#?}, reduce={reduce:#?}, nonterminal={nonterminal:?}");
             assert_eq!(shift.symbols.len(), 5); // Ty -> Ty -> Ty
             assert_eq!(shift.cursor, 3); // Ty -> Ty -> Ty
             assert_eq!(shift.symbols, reduce.symbols);
             assert_eq!(shift.cursor, reduce.cursor);
             assert_eq!(nonterminal, nt("Ty"));
         }
-        r => panic!("wrong classification {:#?}", r),
+        r => panic!("wrong classification {r:#?}"),
     }
 }
 
@@ -72,11 +69,11 @@ pub Expr: () = {
     let conflicts = super::token_conflicts(&err.conflicts);
     let conflict = &conflicts[0][0];
 
-    println!("conflict={:?}", conflict);
+    println!("conflict={conflict:?}");
 
     match cx.classify(conflict) {
         ConflictClassification::InsufficientLookahead { .. } => {}
-        r => panic!("wrong classification {:#?}", r),
+        r => panic!("wrong classification {r:#?}"),
     }
 }
 
@@ -104,7 +101,7 @@ fn suggest_question_conflict() {
     let conflicts = super::token_conflicts(&err.conflicts);
     let conflict = &conflicts[0][0];
 
-    println!("conflict={:?}", conflict);
+    println!("conflict={conflict:?}");
 
     match cx.classify(conflict) {
         ConflictClassification::SuggestQuestion {
@@ -119,7 +116,7 @@ fn suggest_question_conflict() {
                 Symbol::Terminal(TerminalString::quoted(Atom::from("L")))
             );
         }
-        r => panic!("wrong classification {:#?}", r),
+        r => panic!("wrong classification {r:#?}"),
     }
 }
 
@@ -148,7 +145,7 @@ Ident = r#"[a-zA-Z][a-zA-Z0-9]*"#;
     let conflicts = super::token_conflicts(&err.conflicts);
     let conflict = &conflicts[0][0];
 
-    println!("conflict={:?}", conflict);
+    println!("conflict={conflict:?}");
 
     match cx.classify(conflict) {
         ConflictClassification::SuggestInline {
@@ -158,7 +155,7 @@ Ident = r#"[a-zA-Z][a-zA-Z0-9]*"#;
         } => {
             assert_eq!(nonterminal, nt("Path"));
         }
-        r => panic!("wrong classification {:#?}", r),
+        r => panic!("wrong classification {r:#?}"),
     }
 }
 
@@ -181,7 +178,7 @@ VarDecl = "let";
     let mut cx = ErrorReportingCx::new(&grammar, &err.states, &err.conflicts);
     let conflicts = super::token_conflicts(&err.conflicts);
     for conflict in conflicts.iter().flatten() {
-        println!("conflict={:?}", conflict);
+        println!("conflict={conflict:?}");
         cx.classify(conflict);
     }
 }

--- a/lalrpop/src/lr1/example/mod.rs
+++ b/lalrpop/src/lr1/example/mod.rs
@@ -81,7 +81,7 @@ impl Example {
         self.symbols
             .iter()
             .map(|s| match *s {
-                ExampleSymbol::Symbol(ref s) => format!("{}", s).chars().count(),
+                ExampleSymbol::Symbol(ref s) => format!("{s}").chars().count(),
                 ExampleSymbol::Epsilon => 1, // display as " "
             })
             .chain(Some(0))
@@ -175,7 +175,7 @@ impl Example {
             ref nonterminal,
         } in &self.reductions
         {
-            let nt_len = format!("{}", nonterminal).chars().count();
+            let nt_len = format!("{nonterminal}").chars().count();
 
             // Number of symbols we are reducing. This should always
             // be non-zero because even in the case of a \epsilon

--- a/lalrpop/src/lr1/interpret.rs
+++ b/lalrpop/src/lr1/interpret.rs
@@ -18,7 +18,7 @@ pub fn interpret<'grammar, L>(
 where
     L: LookaheadInterpret,
 {
-    println!("interpret(tokens={:?})", tokens);
+    println!("interpret(tokens={tokens:?})");
     let mut m = Machine::new(states);
     m.execute(tokens.into_iter())
 }
@@ -76,8 +76,8 @@ where
         while let Some(terminal) = token.clone() {
             let state = self.top_state();
 
-            println!("state={:?}", state);
-            println!("terminal={:?}", terminal);
+            println!("state={state:?}");
+            println!("terminal={terminal:?}");
 
             // check whether we can shift this token
             if let Some(&next_index) = state.shifts.get(&terminal) {
@@ -120,7 +120,7 @@ where
     }
 
     fn reduce(&mut self, production: &Production) -> bool {
-        println!("reduce={:?}", production);
+        println!("reduce={production:?}");
 
         let args = production.symbols.len();
 
@@ -166,7 +166,7 @@ impl Display for ParseTree {
             ParseTree::Nonterminal(ref id, ref trees) => {
                 write!(fmt, "[{}: {}]", id, Sep(", ", trees))
             }
-            ParseTree::Terminal(ref id) => write!(fmt, "{}", id),
+            ParseTree::Terminal(ref id) => write!(fmt, "{id}"),
         }
     }
 }

--- a/lalrpop/src/lr1/lane_table/table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/table/mod.rs
@@ -157,22 +157,22 @@ impl Debug for LaneTable<'_> {
             .collect();
 
         let header = iter::once("State".to_string())
-            .chain((0..self.conflicts).map(|i| format!("C{}", i)))
+            .chain((0..self.conflicts).map(|i| format!("C{i}")))
             .chain(Some("Successors".to_string()))
             .collect();
 
         let rows = indices.iter().map(|&index| {
-            iter::once(format!("{:?}", index))
+            iter::once(format!("{index:?}"))
                 .chain((0..self.conflicts).map(|i| {
                     self.lookaheads
                         .get(&(index, ConflictIndex::new(i)))
-                        .map(|token_set| format!("{:?}", token_set))
+                        .map(|token_set| format!("{token_set:?}"))
                         .unwrap_or_default()
                 }))
                 .chain(Some(
                     self.successors
                         .get(&index)
-                        .map(|c| format!("{:?}", c))
+                        .map(|c| format!("{c:?}"))
                         .unwrap_or_default(),
                 ))
                 .collect()

--- a/lalrpop/src/lr1/lane_table/test.rs
+++ b/lalrpop/src/lr1/lane_table/test.rs
@@ -146,7 +146,7 @@ fn build_table<'grammar>(
 
     // Extract conflicting items and trace the lanes, constructing a table
     let conflicting_items = super::conflicting_actions(inconsistent_state);
-    println!("conflicting_items={:#?}", conflicting_items);
+    println!("conflicting_items={conflicting_items:#?}");
     let first_sets = FirstSets::new(grammar);
     let state_graph = StateGraph::new(&lr0_err.states);
     let mut tracer = LaneTracer::new(
@@ -174,7 +174,7 @@ fn g0_conflict_1() {
     let grammar = paper_example_g0();
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let table = build_table(&grammar, "G", &["e"]);
-    println!("{:#?}", table);
+    println!("{table:#?}");
     // conflicting_actions={
     //     Shift("e") // C0
     //     Reduce(X = "e" => ActionFn(4)) // C1
@@ -197,7 +197,7 @@ fn paper_example_g1_conflict_1() {
     let grammar = paper_example_g1();
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let table = build_table(&grammar, "G", &["a", "e"]);
-    println!("{:#?}", table);
+    println!("{table:#?}");
     // conflicting_actions={
     //     Shift("e") // C0
     //     Reduce(X = "e" => ActionFn(6)) // C1
@@ -345,7 +345,7 @@ fn large_conflict_1() {
     let grammar = paper_example_large();
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let table = build_table(&grammar, "G", &["x", "s", "k", "t"]);
-    println!("{:#?}", table);
+    println!("{table:#?}");
 
     // conflicting_actions={
     //     Shift("s") // C0

--- a/lalrpop/src/lr1/lookahead.rs
+++ b/lalrpop/src/lr1/lookahead.rs
@@ -75,7 +75,7 @@ pub enum Token {
 
 impl Lookahead for TokenSet {
     fn fmt_as_item_suffix(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
-        write!(fmt, " {:?}", self)
+        write!(fmt, " {self:?}")
     }
 
     fn conflicts<'grammar>(this_state: &State<'grammar, Self>) -> Vec<Conflict<'grammar, Self>> {

--- a/lalrpop/src/lr1/report/mod.rs
+++ b/lalrpop/src/lr1/report/mod.rs
@@ -66,14 +66,14 @@ where
                 let (sr, rr, conflict_map) =
                     self.process_conflicts(&table_construction_error.conflicts);
                 if (sr > 0) {
-                    writeln!(self.out, "{}shift/reduce:  {}", INDENT_STRING, sr)?;
+                    writeln!(self.out, "{INDENT_STRING}shift/reduce:  {sr}")?;
                 }
                 if (rr > 0) {
-                    writeln!(self.out, "{}reduce/reduce: {}", INDENT_STRING, rr)?;
+                    writeln!(self.out, "{INDENT_STRING}reduce/reduce: {rr}")?;
                 }
                 write!(self.out, "States with conflicts: ")?;
                 for state in conflict_map.keys() {
-                    write!(self.out, " {}", state)?;
+                    write!(self.out, " {state}")?;
                 }
                 writeln!(self.out)?;
                 self.report_states(&table_construction_error.states, &conflict_map)?;
@@ -169,18 +169,13 @@ where
                     terminal.display_len(),
                     conflict.production.nonterminal.len(),
                 );
-                writeln!(self.out, "{}shift/reduce conflict", INDENT_STRING)?;
-                write!(self.out, "{}{}reduction ", INDENT_STRING, INDENT_STRING)?;
+                writeln!(self.out, "{INDENT_STRING}shift/reduce conflict")?;
+                write!(self.out, "{INDENT_STRING}{INDENT_STRING}reduction ")?;
                 self.write_production(conflict.production, max_width)?;
-                let sterminal = format!("{}", terminal);
+                let sterminal = format!("{terminal}");
                 writeln!(
                     self.out,
-                    "{}{}shift     {:width$}    shift and goto {}",
-                    INDENT_STRING,
-                    INDENT_STRING,
-                    sterminal,
-                    state,
-                    width = max_width
+                    "{INDENT_STRING}{INDENT_STRING}shift     {sterminal:max_width$}    shift and goto {state}"
                 )?;
             }
             Action::Reduce(other_production) => {
@@ -188,10 +183,10 @@ where
                     other_production.nonterminal.len(),
                     conflict.production.nonterminal.len(),
                 );
-                writeln!(self.out, "{}reduce/reduce conflict", INDENT_STRING)?;
-                write!(self.out, "{}{}reduction ", INDENT_STRING, INDENT_STRING)?;
+                writeln!(self.out, "{INDENT_STRING}reduce/reduce conflict")?;
+                write!(self.out, "{INDENT_STRING}{INDENT_STRING}reduction ")?;
                 self.write_production(conflict.production, max_width)?;
-                write!(self.out, "{}{}reduction ", INDENT_STRING, INDENT_STRING)?;
+                write!(self.out, "{INDENT_STRING}{INDENT_STRING}reduction ")?;
                 self.write_production(other_production, max_width)?;
             }
         }
@@ -216,10 +211,10 @@ where
     where
         L: Lookahead + LookaheadPrinter<W>,
     {
-        write!(self.out, "{}", INDENT_STRING)?;
+        write!(self.out, "{INDENT_STRING}")?;
         // stringize it first to allow handle :width by Display for string
         let s = format!("{}", item.production.nonterminal);
-        write!(self.out, "{:width$} ->", s, width = max_width)?;
+        write!(self.out, "{s:max_width$} ->")?;
         for i in 0..item.index {
             write!(self.out, " {}", item.production.symbols[i])?;
         }
@@ -238,7 +233,7 @@ where
         max_width: usize,
     ) -> io::Result<()> {
         for entry in shifts {
-            write!(self.out, "{}", INDENT_STRING)?;
+            write!(self.out, "{INDENT_STRING}")?;
             // stringize it first to allow handle :width by Display for string
             let s = format!("{}", entry.0);
             writeln!(
@@ -272,7 +267,7 @@ where
             width = max_width
         )?;
         for symbol in production.symbols.iter() {
-            write!(self.out, " {}", symbol)?;
+            write!(self.out, " {symbol}")?;
         }
         writeln!(self.out)?;
         Ok(())
@@ -287,7 +282,7 @@ where
         L: Lookahead + LookaheadPrinter<W>,
     {
         let production = reduction.1;
-        write!(self.out, "{}reduction ", INDENT_STRING)?;
+        write!(self.out, "{INDENT_STRING}reduction ")?;
         self.write_production(production, max_width)?;
         self.write_lookahead(&reduction.0)?;
         Ok(())
@@ -298,7 +293,7 @@ where
         L: Lookahead + LookaheadPrinter<W>,
     {
         if (lookahead.has_anything_to_print()) {
-            write!(self.out, "{}{}lookahead", INDENT_STRING, INDENT_STRING)?;
+            write!(self.out, "{INDENT_STRING}{INDENT_STRING}lookahead")?;
             lookahead.print(self.out)?;
             writeln!(self.out)?;
         }
@@ -311,7 +306,7 @@ where
         max_width: usize,
     ) -> io::Result<()> {
         for entry in gotos {
-            write!(self.out, "{}", INDENT_STRING)?;
+            write!(self.out, "{INDENT_STRING}")?;
             // stringize it first to allow handle :width by Display for string
             let s = format!("{}", entry.0);
             writeln!(self.out, "{:width$} goto {}", s, entry.1, width = max_width)?;
@@ -320,7 +315,7 @@ where
     }
 
     fn write_section_header(&mut self, title: &str) -> io::Result<()> {
-        writeln!(self.out, "\n{}", title)?;
+        writeln!(self.out, "\n{title}")?;
         writeln!(self.out, "----------------------------------------")?;
         Ok(())
     }
@@ -362,7 +357,7 @@ where
 {
     fn print(&self, out: &mut W) -> io::Result<()> {
         for i in self.iter() {
-            write!(out, " {}", i)?
+            write!(out, " {i}")?
         }
         Ok(())
     }

--- a/lalrpop/src/lr1/report/test.rs
+++ b/lalrpop/src/lr1/report/test.rs
@@ -35,6 +35,6 @@ fn test_report_generation() {
 
     assert!(report.contains("Constructed 5 states"));
     for i in 0..5 {
-        assert!(report.contains(&format!("State {}", i)));
+        assert!(report.contains(&format!("State {i}")));
     }
 }

--- a/lalrpop/src/lr1/trace/reduce/test.rs
+++ b/lalrpop/src/lr1/trace/reduce/test.rs
@@ -79,7 +79,7 @@ fn backtrace1() {
 
     let backtrace = tracer.backtrace_reduce(top_state, semi_item.to_lr0());
 
-    println!("{:#?}", backtrace);
+    println!("{backtrace:#?}");
 
     let pictures: Vec<_> = backtrace
         .lr0_examples(semi_item.to_lr0())
@@ -144,15 +144,15 @@ pub Ty: () = {
     let err = build_states(&grammar, nt("Ty")).unwrap_err();
     let tracer = Tracer::new(&first_sets, &err.states);
     let conflict = err.conflicts[0].clone();
-    println!("conflict={:?}", conflict);
+    println!("conflict={conflict:?}");
     let item = Item {
         production: conflict.production,
         index: conflict.production.symbols.len(),
         lookahead: conflict.lookahead.clone(),
     };
-    println!("item={:?}", item);
+    println!("item={item:?}");
     let backtrace = tracer.backtrace_reduce(conflict.state, item.to_lr0());
-    println!("{:#?}", backtrace);
+    println!("{backtrace:#?}");
     expect_debug(
         &backtrace,
         r#"
@@ -206,13 +206,13 @@ pub Ty: () = {
     let first_sets = FirstSets::new(&grammar);
     let err = build_states(&grammar, nt("Ty")).unwrap_err();
     let conflict = err.conflicts[0].clone();
-    println!("conflict={:?}", conflict);
+    println!("conflict={conflict:?}");
     let item = Item {
         production: conflict.production,
         index: conflict.production.symbols.len(),
         lookahead: conflict.lookahead.clone(),
     };
-    println!("item={:?}", item);
+    println!("item={item:?}");
     let tracer = Tracer::new(&first_sets, &err.states);
     let graph = tracer.backtrace_reduce(conflict.state, item.to_lr0());
     expect_debug(
@@ -299,7 +299,7 @@ fn backtrace_filter() {
 
     let backtrace = tracer.backtrace_reduce(top_state, lr1_item.to_lr0());
 
-    println!("{:#?}", backtrace);
+    println!("{backtrace:#?}");
 
     // With no filtering, we get examples with both `;` and `,` as
     // lookahead (though `ExprSuffix` is in the way).

--- a/lalrpop/src/lr1/trace/shift/test.rs
+++ b/lalrpop/src/lr1/trace/shift/test.rs
@@ -33,7 +33,7 @@ pub Ty: () = {
     let first_sets = FirstSets::new(&grammar);
     let err = build_states(&grammar, nt("Ty")).unwrap_err();
     let conflict = err.conflicts[0].clone();
-    println!("conflict={:?}", conflict);
+    println!("conflict={conflict:?}");
 
     // Gin up the LR0 item involved in the shift/reduce conflict:
     //
@@ -45,7 +45,7 @@ pub Ty: () = {
 
     assert!(conflict.production.symbols.len() == 3);
     let item = Item::lr0(conflict.production, 1);
-    println!("item={:?}", item);
+    println!("item={item:?}");
     let tracer = Tracer::new(&first_sets, &err.states);
     let graph = tracer.backtrace_shift(conflict.state, item);
     expect_debug(

--- a/lalrpop/src/normalize/macro_expand/mod.rs
+++ b/lalrpop/src/normalize/macro_expand/mod.rs
@@ -101,7 +101,7 @@ impl MacroExpander {
                         "@R",
                         ActionKind::Lookbehind,
                     )?),
-                    _ => panic!("don't know how to expand `{:?}`", sym),
+                    _ => panic!("don't know how to expand `{sym:?}`"),
                 }
             }
         }
@@ -134,7 +134,7 @@ impl MacroExpander {
     fn replace_symbol(&mut self, symbol: &mut Symbol) {
         match symbol.kind {
             SymbolKind::AmbiguousId(ref id) => {
-                panic!("ambiguous id `{}` encountered after name resolution", id)
+                panic!("ambiguous id `{id}` encountered after name resolution")
             }
             SymbolKind::Macro(ref mut m) => {
                 for sym in &mut m.args {
@@ -389,7 +389,7 @@ impl MacroExpander {
             SymbolKind::Lookbehind => SymbolKind::Lookbehind,
             SymbolKind::Error => SymbolKind::Error,
             SymbolKind::AmbiguousId(ref id) => {
-                panic!("ambiguous id `{}` encountered after name resolution", id)
+                panic!("ambiguous id `{id}` encountered after name resolution")
             }
         };
 

--- a/lalrpop/src/normalize/precedence/mod.rs
+++ b/lalrpop/src/normalize/precedence/mod.rs
@@ -339,7 +339,7 @@ fn replace_symbol<'a>(
 ) -> Substitution<'a> {
     match symbol.kind {
         SymbolKind::AmbiguousId(ref id) => {
-            panic!("ambiguous id `{}` encountered after name resolution", id)
+            panic!("ambiguous id `{id}` encountered after name resolution")
         }
         SymbolKind::Nonterminal(ref name) if name == target => match subst {
             Substitution::Every(sym_kind) => {

--- a/lalrpop/src/normalize/token_check/mod.rs
+++ b/lalrpop/src/normalize/token_check/mod.rs
@@ -259,10 +259,10 @@ impl Validator<'_> {
             }
             SymbolKind::Lookahead | SymbolKind::Lookbehind | SymbolKind::Error => {}
             SymbolKind::AmbiguousId(ref id) => {
-                panic!("ambiguous id `{}` encountered after name resolution", id)
+                panic!("ambiguous id `{id}` encountered after name resolution")
             }
             SymbolKind::Macro(..) => {
-                panic!("macro not removed: {:?}", symbol);
+                panic!("macro not removed: {symbol:?}");
             }
         }
 
@@ -291,8 +291,7 @@ impl Validator<'_> {
                 match *term {
                     TerminalString::Bare(_) => assert!(
                         match_block.match_user_names.contains(term),
-                        "bare terminal without match entry: {}",
-                        term
+                        "bare terminal without match entry: {term}"
                     ),
 
                     TerminalString::Literal(ref l) => {

--- a/lalrpop/src/normalize/token_check/test.rs
+++ b/lalrpop/src/normalize/token_check/test.rs
@@ -19,18 +19,17 @@ fn check_err(expected_err: &str, grammar: &str, span: &str) {
 fn check_intern_token(grammar: &str, expected_tokens: Vec<(&'static str, &'static str)>) {
     let parsed_grammar = validate_grammar(grammar).expect("validate");
     let intern_token = parsed_grammar.intern_token().expect("intern_token");
-    println!("intern_token: {:?}", intern_token);
+    println!("intern_token: {intern_token:?}");
     for (input, expected_user_name) in expected_tokens {
         let actual_user_name =
             interpret::interpret(&intern_token.dfa, input).map(|(index, text)| {
                 let user_name = &intern_token.match_entries[index.index()].user_name;
                 (user_name.clone(), text)
             });
-        let actual_user_name = format!("{:?}", actual_user_name);
+        let actual_user_name = format!("{actual_user_name:?}");
         if expected_user_name != actual_user_name {
             panic!(
-                "input `{}` matched `{}` but we expected `{}`",
-                input, actual_user_name, expected_user_name
+                "input `{input}` matched `{actual_user_name}` but we expected `{expected_user_name}`"
             );
         }
     }

--- a/lalrpop/src/normalize/tyinfer/test.rs
+++ b/lalrpop/src/normalize/tyinfer/test.rs
@@ -17,12 +17,12 @@ fn compare(g1: &str, expected: Vec<(&'static str, &'static str)>) {
     let grammar = token_check::validate(grammar).unwrap();
     let types = infer_types(&grammar).unwrap();
 
-    println!("types table: {:?}", types);
+    println!("types table: {types:?}");
 
     for (nt_id, nt_type) in expected {
         let id = NonterminalString(Atom::from(nt_id));
         let ty = type_repr(nt_type);
-        println!("expected type of {:?} is {:?}", id, ty);
+        println!("expected type of {id:?} is {ty:?}");
         assert_eq!(types.nonterminal_type(&id), &ty);
     }
 }

--- a/lalrpop/src/parser/test.rs
+++ b/lalrpop/src/parser/test.rs
@@ -16,11 +16,11 @@ fn match_block() {
 
     for block in blocks {
         let parsed = parser::parse_grammar(block)
-            .unwrap_or_else(|_| panic!("Invalid grammar; grammar={}", block));
+            .unwrap_or_else(|_| panic!("Invalid grammar; grammar={block}"));
         let first_item = parsed.items.first().expect("has item");
         match *first_item {
             GrammarItem::MatchToken(_) => (), // OK
-            _ => panic!("expected MatchToken, but was {:?}", first_item),
+            _ => panic!("expected MatchToken, but was {first_item:?}"),
         }
     }
 }
@@ -53,19 +53,19 @@ fn match_complex() {
             let item00 = contents0.items.first().unwrap();
             match *item00 {
                 MatchItem::Mapped(ref sym, ref mapping, _) => {
-                    assert_eq!(format!("{:?}", sym), "r#\"(?i)begin\"#");
-                    assert_eq!(format!("{}", mapping), "\"BEGIN\"");
+                    assert_eq!(format!("{sym:?}"), "r#\"(?i)begin\"#");
+                    assert_eq!(format!("{mapping}"), "\"BEGIN\"");
                 }
-                _ => panic!("expected MatchItem::Mapped, but was: {:?}", item00),
+                _ => panic!("expected MatchItem::Mapped, but was: {item00:?}"),
             };
             // r"(?i)end" => "END",
             let item01 = contents0.items.get(1).unwrap();
             match *item01 {
                 MatchItem::Mapped(ref sym, ref mapping, _) => {
-                    assert_eq!(format!("{:?}", sym), "r#\"(?i)end\"#");
-                    assert_eq!(format!("{}", mapping), "\"END\"");
+                    assert_eq!(format!("{sym:?}"), "r#\"(?i)end\"#");
+                    assert_eq!(format!("{mapping}"), "\"END\"");
                 }
-                _ => panic!("expected MatchItem::Mapped, but was: {:?}", item00),
+                _ => panic!("expected MatchItem::Mapped, but was: {item00:?}"),
             };
             // else { ... }
             let contents1 = data.contents.get(1).unwrap();
@@ -73,10 +73,10 @@ fn match_complex() {
             let item10 = contents1.items.first().unwrap();
             match *item10 {
                 MatchItem::Mapped(ref sym, ref mapping, _) => {
-                    assert_eq!(format!("{:?}", sym), "r#\"[a-zA-Z_][a-zA-Z0-9_]*\"#");
-                    assert_eq!(format!("{}", mapping), "IDENTIFIER");
+                    assert_eq!(format!("{sym:?}"), "r#\"[a-zA-Z_][a-zA-Z0-9_]*\"#");
+                    assert_eq!(format!("{mapping}"), "IDENTIFIER");
                 }
-                _ => panic!("expected MatchItem::Mapped, but was: {:?}", item10),
+                _ => panic!("expected MatchItem::Mapped, but was: {item10:?}"),
             };
             // else { ... }
             let contents2 = data.contents.get(2).unwrap();
@@ -84,18 +84,18 @@ fn match_complex() {
             let item20 = contents2.items.first().unwrap();
             match *item20 {
                 MatchItem::Unmapped(ref sym, _) => {
-                    assert_eq!(format!("{:?}", sym), "\"other\"");
+                    assert_eq!(format!("{sym:?}"), "\"other\"");
                 }
-                _ => panic!("expected MatchItem::Unmapped, but was: {:?}", item20),
+                _ => panic!("expected MatchItem::Unmapped, but was: {item20:?}"),
             };
             // _
             let item21 = contents2.items.get(1).unwrap();
             match *item21 {
                 MatchItem::CatchAll(_) => (),
-                _ => panic!("expected MatchItem::CatchAll, but was: {:?}", item20),
+                _ => panic!("expected MatchItem::CatchAll, but was: {item20:?}"),
             };
         }
-        _ => panic!("expected MatchToken, but was: {:?}", first_item),
+        _ => panic!("expected MatchToken, but was: {first_item:?}"),
     }
 }
 
@@ -120,8 +120,7 @@ fn where_clauses() {
     for santa in clauses {
         assert!(
             parser::parse_where_clauses(santa).is_ok(),
-            "should parse where clauses: {}",
-            santa
+            "should parse where clauses: {santa}"
         );
     }
 }

--- a/lalrpop/src/rust/mod.rs
+++ b/lalrpop/src/rust/mod.rs
@@ -255,7 +255,7 @@ impl<'me, W: Write> FnHeader<'me, W> {
 
     /// Add where clauses to the list.
     pub fn with_return_type(mut self, rt: impl Display) -> Self {
-        self.return_type = format!("{}", rt);
+        self.return_type = format!("{rt}");
         self
     }
 

--- a/lalrpop/src/session.rs
+++ b/lalrpop/src/session.rs
@@ -166,7 +166,7 @@ impl Session {
     pub fn emit_rerun_directive(&self, path: &path::Path) {
         if self.emit_rerun_directives {
             if let Some(display) = path.to_str() {
-                println!("cargo:rerun-if-changed={}", display)
+                println!("cargo:rerun-if-changed={display}")
             } else {
                 println!("cargo:warning=LALRPOP is unable to inform Cargo that {} is a dependency because its filename cannot be represented in UTF-8. This is probably because it contains an unpaired surrogate character on Windows. As a result, your build script will not be rerun when it changes.", path.to_string_lossy());
             }

--- a/lalrpop/src/test_util.rs
+++ b/lalrpop/src/test_util.rs
@@ -16,30 +16,30 @@ impl Debug for ExpectedDebug<'_> {
         // Ignore trailing commas in multiline Debug representation.
         // Needed to work around rust-lang/rust#59076.
         let s = self.0.replace(",\n", "\n");
-        write!(fmt, "{}", s)
+        write!(fmt, "{s}")
     }
 }
 
 pub fn expect_debug<D: Debug>(actual: D, expected: &str) {
     compare(
-        ExpectedDebug(&format!("{:#?}", actual)),
+        ExpectedDebug(&format!("{actual:#?}")),
         ExpectedDebug(expected),
     )
 }
 
 pub fn compare<D: Debug, E: Debug>(actual: D, expected: E) {
-    let actual_s = format!("{:?}", actual);
-    let expected_s = format!("{:?}", expected);
+    let actual_s = format!("{actual:?}");
+    let expected_s = format!("{expected:?}");
 
     if normalize(&actual_s) != normalize(&expected_s) {
-        let actual_s = format!("{:#?}", actual);
-        let expected_s = format!("{:#?}", expected);
+        let actual_s = format!("{actual:#?}");
+        let expected_s = format!("{expected:#?}");
 
         for diff in diff::lines(&normalize(&actual_s), &normalize(&expected_s)) {
             match diff {
-                diff::Result::Right(r) => println!("- {}", r),
-                diff::Result::Left(l) => println!("+ {}", l),
-                diff::Result::Both(l, _) => println!("  {}", l),
+                diff::Result::Right(r) => println!("- {r}"),
+                diff::Result::Left(l) => println!("+ {l}"),
+                diff::Result::Both(l, _) => println!("  {l}"),
             }
         }
 

--- a/lalrpop/src/tok/test.rs
+++ b/lalrpop/src/tok/test.rs
@@ -18,7 +18,7 @@ fn gen_test(input: &str, expected: Vec<(&str, Expectation<'_>)>) {
     for (token, (expected_span, expectation)) in tokenizer.zip(expected.into_iter()) {
         let expected_start = expected_span.find('~').unwrap();
         let expected_end = expected_span.rfind('~').unwrap() + 1;
-        println!("token: {:?}", token);
+        println!("token: {token:?}");
         match expectation {
             ExpectTok(expected_tok) => {
                 assert_eq!(Ok((expected_start, expected_tok, expected_end)), token);

--- a/lalrpop/src/util.rs
+++ b/lalrpop/src/util.rs
@@ -7,9 +7,9 @@ impl<S: Display> Display for Sep<&Vec<S>> {
         let &Sep(sep, vec) = self;
         let mut elems = vec.iter();
         if let Some(elem) = elems.next() {
-            write!(fmt, "{}", elem)?;
+            write!(fmt, "{elem}")?;
             for elem in elems {
-                write!(fmt, "{}{}", sep, elem)?;
+                write!(fmt, "{sep}{elem}")?;
             }
         }
         Ok(())
@@ -23,7 +23,7 @@ impl<S: Display> Display for Escape<S> {
         let tmp = format!("{}", self.0);
         for c in tmp.chars() {
             match c {
-                'a'..='z' | '0'..='9' | 'A'..='Z' => write!(fmt, "{}", c)?,
+                'a'..='z' | '0'..='9' | 'A'..='Z' => write!(fmt, "{c}")?,
                 '_' => write!(fmt, "__")?,
                 _ => write!(fmt, "_{:x}", c as usize)?,
             }
@@ -38,7 +38,7 @@ impl<S: Display> Display for Prefix<&[S]> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let &Prefix(prefix, vec) = self;
         for elem in vec.iter() {
-            write!(fmt, "{}{}", prefix, elem)?;
+            write!(fmt, "{prefix}{elem}")?;
         }
         Ok(())
     }


### PR DESCRIPTION
Nightly clippy has moved the uninlined-format-args lint from pedantic to style, so it's now triggering on our code.

https://github.com/rust-lang/rust-clippy/pull/14160

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->