### PR TITLE
Fix uninlined format strings in generated code

### DIFF
--- a/doc/calculator/src/calculator2b.lalrpop
+++ b/doc/calculator/src/calculator2b.lalrpop
@@ -4,7 +4,7 @@ pub Term = {
     Num,
     "(" <Term> ")",
     "22" => "Twenty-two!".to_string(),
-    ID => format!("Id({})", <>),
+    ID => format!("Id({<>})"),
 };
 
 Num: String = r"[0-9]+" => <>.to_string();

--- a/doc/lexer-modes/src/grammar.lalrpop
+++ b/doc/lexer-modes/src/grammar.lalrpop
@@ -68,7 +68,7 @@ Decimal: usize = {
         let count = count.parse::<usize>()
             .map_err(|err| {
                 LexicalError::LengthOverflow(
-                    format!("Parsing {}: {}", count, err))
+                    format!("Parsing {count}: {err}"))
             })?;
 
         Ok(count)

--- a/lalrpop-test/src/error_recovery.lalrpop
+++ b/lalrpop-test/src/error_recovery.lalrpop
@@ -19,6 +19,6 @@ pub Item: String = {
     "+" => '+'.to_string(),
     "-" "-" "-" => "-".to_string(),
     "-" "-" <err: !> => { errors.borrow_mut().push(err); "!".to_string() },
-    "(" <i: Item> ")" => format!("({})", i),
+    "(" <i: Item> ")" => format!("({i})"),
     "(" <err: !> ")" => { errors.borrow_mut().push(err); "()".to_string() },
 };

--- a/lalrpop-test/src/error_recovery_span.lalrpop
+++ b/lalrpop-test/src/error_recovery_span.lalrpop
@@ -24,7 +24,7 @@ pub Expr: String = {
     // the `"+"` to recover.
     <n:Expr> "-" <l:@L> ! <r:@R> => {
         errors.push((l, r));
-        format!("{} -!", n)
+        format!("{n} -!")
     },
 
     <n:Expr> <l:@L> ! <r:@R> => {
@@ -43,6 +43,6 @@ Expr1: String = {
 };
 
 Expr2: String = {
-    Num => format!("{:?}", <>),
-    "(" <Expr> ")" => format!("({})", <>),
+    Num => format!("{<>:?}"),
+    "(" <Expr> ")" => format!("({<>})"),
 };

--- a/lalrpop-test/src/where_clause_with_forall.lalrpop
+++ b/lalrpop-test/src/where_clause_with_forall.lalrpop
@@ -4,14 +4,14 @@ grammar<F>(logger: &mut F) where F: for<'a> FnMut(&'a str);
 
 pub Term: i32 = {
     <n:Num> => {
-        let msg = format!("just parsed {}", n);
+        let msg = format!("just parsed {n}");
         logger(&msg);
         n
     },
     "(" <t:Term> ")" => {
         logger("propagating...");
         {
-            let msg = format!("... {}", t);
+            let msg = format!("... {t}");
             logger(&msg);
         }
         t

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -970,7 +970,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
         }
         rust!(
             self.out,
-            "_ => panic!(\"invalid action code {{}}\", {}action)",
+            "_ => panic!(\"invalid action code {{{}action}}\")",
             self.prefix
         );
         rust!(self.out, "}};");
@@ -1324,7 +1324,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
         }
         rust!(
             self.out,
-            "_ => panic!(\"invalid reduction index {{}}\", {}reduce_index)",
+            "_ => panic!(\"invalid reduction index {{{}reduce_index}}\",)",
             self.prefix,
         );
         rust!(self.out, "}}"); // end match

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -6458,7 +6458,7 @@ nonterminal_produced: 171,
 }
 }
 524 => ___state_machine::SimulatedReduce::Accept,
-_ => panic!("invalid reduction index {}", ___reduce_index)
+_ => panic!("invalid reduction index {___reduce_index}",)
 }
 }
 pub struct TopParser {
@@ -8172,7 +8172,7 @@ let ___end = ___sym0.2;
 let ___nt = super::___action0::<>(text, ___sym0);
 return Some(Ok(___nt));
 }
-_ => panic!("invalid action code {}", ___action)
+_ => panic!("invalid action code {___action}")
 };
 let ___states_len = ___states.len();
 ___states.truncate(___states_len - ___pop_states);


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->