### PR TITLE
Forward port 0.22.2 release notes to main branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "calculator"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "cfg"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-test"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "diff",
  "lalrpop",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "regex-automata",
 ]
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "whitespace"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "lalrpop",
  "lalrpop-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "2"
 repository = "https://github.com/lalrpop/lalrpop"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0 OR MIT"
-version = "0.22.1" # LALRPOP
+version = "0.22.2" # LALRPOP
 edition = "2021"
 # This is (very) soft limit of the minimum supported version.
 # Please update it when lalrpop requires a new feature.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,5 @@
 <a name="0.22.2"></a>
-## 0.22.2  (2025-02-25)
+## 0.22.2  (2025-05-22)
 
 #### Features
 * Support \0 and \x## ASCII escape sequences in grammars

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,9 @@
 * Support \0 and \x## ASCII escape sequences in grammars
 * Documentation updates
 
+#### Bugfixes
+* Avoid clippy warnings for uninlined format strings in generated code
+
 <a name="0.22.1"></a>
 ## 0.22.1  (2025-01-21)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,10 @@
+<a name="0.22.2"></a>
+## 0.22.2  (2025-02-25)
+
+#### Features
+* Support \0 and \x## ASCII escape sequences in grammars
+* Documentation updates
+
 <a name="0.22.1"></a>
 ## 0.22.1  (2025-01-21)
 

--- a/doc/calculator/Cargo.toml
+++ b/doc/calculator/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "calculator"
-version = "0.22.1"
+version = "0.22.2"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 workspace = "../.." # <-- We added this and everything after!
 edition = "2021"
 publish = false
 
 [build-dependencies]
-lalrpop = { version = "0.22.1", path = "../../lalrpop" }
+lalrpop = { version = "0.22.2", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.22.1", path = "../../lalrpop-util", features = [
+lalrpop-util = { version = "0.22.2", path = "../../lalrpop-util", features = [
     "lexer",
     "unicode",
 ] }

--- a/doc/cfg/Cargo.toml
+++ b/doc/cfg/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "cfg"
-version = "0.22.1"
+version = "0.22.2"
 authors = ["Mathis Brossier <mathis.brossier@gmail.com>"]
 workspace = "../.." # <-- We added this and everything after!
 edition = "2021"
 publish = false
 
 [build-dependencies]
-lalrpop = { version = "0.22.1", path = "../../lalrpop" }
+lalrpop = { version = "0.22.2", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.22.1", path = "../../lalrpop-util", features = [
+lalrpop-util = { version = "0.22.2", path = "../../lalrpop-util", features = [
     "lexer",
 ] }
 

--- a/doc/lexer-modes/Cargo.toml
+++ b/doc/lexer-modes/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Neal H. Walfield <neal@sequoia-pgp.org>"]
 publish = false
 
 [build-dependencies]
-lalrpop = { version = "0.22.1", path = "../../lalrpop" }
+lalrpop = { version = "0.22.2", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.22.1", path = "../../lalrpop-util" }
+lalrpop-util = { version = "0.22.2", path = "../../lalrpop-util" }

--- a/doc/lexer/Cargo.toml
+++ b/doc/lexer/Cargo.toml
@@ -6,10 +6,10 @@ authors = ["Patrick LaFontaine <32135464+Pat-Lafon@users.noreply.github.com>"]
 publish = false
 
 [build-dependencies]
-lalrpop = { version = "0.22.1", path = "../../lalrpop" }
+lalrpop = { version = "0.22.2", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.22.1", path = "../../lalrpop-util", features = [
+lalrpop-util = { version = "0.22.2", path = "../../lalrpop-util", features = [
     "unicode",
 ] }
 logos = "0.15.0"

--- a/doc/nobol/Cargo.toml
+++ b/doc/nobol/Cargo.toml
@@ -7,10 +7,10 @@ workspace = "../.."
 publish = false
 
 [build-dependencies]
-lalrpop = { version = "0.22.1", path = "../../lalrpop" }
+lalrpop = { version = "0.22.2", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.22.1", path = "../../lalrpop-util", features = [
+lalrpop-util = { version = "0.22.2", path = "../../lalrpop-util", features = [
     "lexer",
     "unicode",
 ] }

--- a/doc/pascal/lalrpop/Cargo.toml
+++ b/doc/pascal/lalrpop/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 publish = false
 
 [build-dependencies]
-lalrpop = { version = "0.22.1", path = "../../../lalrpop" }
+lalrpop = { version = "0.22.2", path = "../../../lalrpop" }
 
 [dependencies]
 pico-args = "0.5"
 
 [dependencies.lalrpop-util]
-version = "0.22.1"
+version = "0.22.2"
 path = "../../../lalrpop-util"
 features = ["lexer"]

--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -11,14 +11,14 @@ the following lines to your `Cargo.toml`:
 ```toml
 # The generated code depends on lalrpop-util.
 [dependencies]
-lalrpop-util = "0.22.1"
+lalrpop-util = "0.22.2"
 
 # Add a build-time dependency on the lalrpop library:
 [build-dependencies]
-lalrpop = "0.22.1"
+lalrpop = "0.22.2"
 # If you are supplying your own external lexer you can disable default features so that the
 # built-in lexer feature is not included
-# lalrpop = { version = "0.22.1", default-features = false }
+# lalrpop = { version = "0.22.2", default-features = false }
 ```
 
 Next create a [`build.rs`](https://doc.rust-lang.org/cargo/reference/build-scripts.html)

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -31,7 +31,7 @@ authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2021"
 
 [build-dependencies] # <-- We added this and everything after!
-lalrpop = "0.22.1"
+lalrpop = "0.22.2"
 
 [dependencies]
 lalrpop-util = { version = "0.21.0", features = ["lexer", "unicode"] }

--- a/doc/whitespace/Cargo.toml
+++ b/doc/whitespace/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "whitespace"
-version = "0.22.1"
+version = "0.22.2"
 authors = ["Mako <jlauve@rsmw.net>"]
 edition = "2021"
 publish = false
 
 [build-dependencies.lalrpop]
-version = "0.22.1"
+version = "0.22.2"
 path = "../../lalrpop"
 
 [dependencies.lalrpop-util]
-version = "0.22.1"
+version = "0.22.2"
 path = "../../lalrpop-util"

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -39,7 +39,7 @@ walkdir = "2.4.0"
 # library, disable it in your project by setting default-features = false.
 pico-args = { version = "0.5", default-features = false, optional = true }
 
-lalrpop-util = { path = "../lalrpop-util", version = "0.22.1", default-features = false }
+lalrpop-util = { path = "../lalrpop-util", version = "0.22.2", default-features = false }
 
 [dev-dependencies]
 diff = { workspace = true }

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -1,4 +1,4 @@
-// auto-generated: "lalrpop 0.22.1"
+// auto-generated: "lalrpop 0.22.2"
 // sha3: f47daa431ba103316047ba86b3c78f39a981940447c550b2a48c2bd30fd64fc7
 use string_cache::DefaultAtom as Atom;
 use crate::grammar::parse_tree::*;


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

One note is that this also brings forward the version numbers across the board to 0.22.2 instead of 0.22.1.  I think that's fine, since 0.22.2 is a strict subset of master right now.  Just highlighting it, since it's a little weird given that 0.22.2 exists on the 0.22.x branch, but not the master branch.