### PR TITLE
Enable running tests with cargo-nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,6 @@
+[test-groups]
+api = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'test(api::)'
+test-group = 'api'

--- a/lalrpop/src/api/test.rs
+++ b/lalrpop/src/api/test.rs
@@ -66,6 +66,10 @@ fn remove_local_generated_files() {
             }
         }
     }
+    let custom_dir = temp_dir().join(CUSTOM_TEST_DIR);
+    if fs::exists(&custom_dir).unwrap() {
+        fs::remove_dir_all(&custom_dir).unwrap();
+    }
 }
 
 // This is maybe a little nonintuitive at first.  We verify that the file exists where we expect
@@ -132,9 +136,6 @@ fn test_explicit_in_out() {
     let (orig_dir, _lock) = setup();
 
     let custom_dir = temp_dir().join(CUSTOM_TEST_DIR);
-    if fs::exists(&custom_dir).unwrap() {
-        fs::remove_dir_all(&custom_dir).unwrap();
-    }
     fs::create_dir(&custom_dir).unwrap();
 
     Configuration::new()


### PR DESCRIPTION
* Clean up CUSTOM_TEST_DIR appropriately after failures
* Set up nextest config to run api tests in serial

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->