### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ The `lalrpop` crate already includes an auto-generated parser
 in `lalrpop/src/parser/lrgrammar.rs` that end-users use.
 Small (meh), (relatively) fast to compile, easy to use (really, for end-users).
 
-That said, if you changes don't affect LALRPOP's own grammar
+That said, if your changes don't affect LALRPOP's own grammar
 (`lalrpop/src/parser/lrgrammar.lalrpop`) your workflow is simple
 
 ```sh
@@ -84,7 +84,7 @@ maintained until the release of version 0.23.  A critical bug may warrant a
 later backport to the 0.22.x series, but in general, we will stop backporting
 and focus efforts on the 0.23 series as soon as 0.23 is released.
 
-Regarding Minumum Supported Rust Version (msrv) bumps, the guidance in the rust
+Regarding Minimum Supported Rust Version (msrv) bumps, the guidance in the rust
 community is that msrv bumps are not necessarily breaking, but should be bundled
 with breaking changes if possible. Our msrv strategy follows this guidance,
 attempting to bundle msrv bumps with breaking releases.  We prefer to keep the

--- a/lalrpop-test/src/non_hash_user_error.lalrpop
+++ b/lalrpop-test/src/non_hash_user_error.lalrpop
@@ -3,7 +3,7 @@
 /// Floating points, because they contain multiple possible Nan values, are not hashable
 /// by default in Rust.
 /// This test is intended to catch any unexpected breaking changes related to
-//Lalrpop requring the error type to be hashable.
+//Lalrpop requiring the error type to be hashable.
 use lalrpop_util::ParseError;
 
 grammar;

--- a/lalrpop/src/normalize/prevalidate/test.rs
+++ b/lalrpop/src/normalize/prevalidate/test.rs
@@ -128,7 +128,7 @@ fn expandable_expression_requires_named_variables() {
 fn mixing_names_and_anonymous_values() {
     check_err(
         r#"anonymous symbols like this one cannot be combined with named symbols like `b:B`"#,
-        r#"grammar; Term = { <A> <b:B> => Alien: Eighth passanger of Nostromo};"#,
+        r#"grammar; Term = { <A> <b:B> => Alien: Eighth passenger of Nostromo};"#,
         r#"                  ~~~                                               "#,
     );
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

Fixes #1071. And playing with `typos-cli` gives us three more typos.