### PR TITLE
Revert "Revert "Stop using in_dir once we get to process_* family functions (…"

### DIFF
--- a/lalrpop/src/api/mod.rs
+++ b/lalrpop/src/api/mod.rs
@@ -5,8 +5,12 @@ use std::default::Default;
 use std::env;
 use std::env::current_dir;
 use std::error::Error;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
+
+#[cfg(test)]
+mod test;
 
 /// Configure various aspects of how LALRPOP works.
 /// Intended for use within a `build.rs` script.
@@ -208,6 +212,15 @@ impl Configuration {
     /// Process all files in the current directory, which -- unless you
     /// have changed it -- is typically the root of the crate being compiled.
     pub fn process_current_dir(&self) -> Result<(), Box<dyn Error>> {
+        // If we can get a current dir, check to make sure session.in_dir either *wasn't* set, or
+        // wasn't set to that dir.  If we can't get a current dir, we'll error out in a moment
+        // anyways, and that's the bigger problem.
+        if let Ok(current_dir) = current_dir() {
+            if self.session.in_dir.is_some() && self.session.in_dir != Some(current_dir) {
+                eprintln!("Error: \"process_current_dir()\" contradicts previously set in_dir");
+                return Err(Box::new(io::Error::new(io::ErrorKind::InvalidInput, "\"process_current_dir()\" contradicts previously set in_dir.  Either use `process()` instead, or omit `set_in_dir()`.  (Note: in previous versions of lalrpop, this combination could affect the parser output dir.  If you were relying on this behavior to output the parser in your source directory, you may want to use `set_out_dir()` to retain that behavior.")));
+            }
+        }
         self.process_dir(current_dir()?)
     }
 
@@ -215,14 +228,8 @@ impl Configuration {
     pub fn process_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Box<dyn Error>> {
         let mut session = self.session.clone();
 
-        // If in/out dir are empty, use cargo conventions by default.
+        // If out dir is empty, use cargo conventions by default.
         // See https://github.com/lalrpop/lalrpop/issues/280
-        if session.in_dir.is_none() {
-            let mut in_dir = env::current_dir()?;
-            in_dir.push("src");
-            session.in_dir = Some(in_dir);
-        }
-
         if session.out_dir.is_none() {
             let out_dir = env::var_os("OUT_DIR").ok_or("missing OUT_DIR variable")?;
             session.out_dir = Some(PathBuf::from(out_dir));

--- a/lalrpop/src/api/test.rs
+++ b/lalrpop/src/api/test.rs
@@ -1,0 +1,168 @@
+use std::env::{current_dir, set_current_dir, set_var, temp_dir};
+use std::fs;
+use std::path;
+use std::sync::{LockResult, Mutex, MutexGuard};
+
+use super::*;
+
+// tests may be run in parallel and these tests affect global state, so lock
+static API_TEST_MUTEX: Mutex<i32> = Mutex::new(0);
+
+const TEST_DIR: &str = "lalrpop-test";
+const CUSTOM_TEST_DIR: &str = "lalrpop-test2";
+
+#[derive(Debug, PartialEq)]
+enum GenFileLoc {
+    Src,
+    Other,
+    Root,
+    OutDir,
+    CustomOut,
+    DoesntExist,
+}
+
+// Set up for API tests.  The directory structure in test_files
+// is:
+//
+// outer.lalrpop
+// other
+//   - other.lalrpop
+// src
+//   - src.lalrpop
+//
+// So we want to set CWD to directly above that, and OUT_DIR to a temp directory
+fn setup() -> (path::PathBuf, LockResult<MutexGuard<'static, i32>>) {
+    let lock = API_TEST_MUTEX.lock();
+    let orig_dir = current_dir().unwrap();
+    set_current_dir(path::Path::new("./src/api/test_files")).unwrap();
+    let out_dir = temp_dir().join(TEST_DIR);
+    if fs::exists(&out_dir).unwrap() {
+        // unclean data from previous failed test run.  Clean up
+        fs::remove_dir_all(&out_dir).unwrap();
+    }
+    // If we have unclean state from a previous run, clean it up
+    remove_local_generated_files();
+
+    fs::create_dir(&out_dir).unwrap();
+    set_var("OUT_DIR", out_dir);
+    (orig_dir, lock)
+}
+
+fn teardown(orig_dir: PathBuf) {
+    remove_local_generated_files();
+    set_current_dir(orig_dir).unwrap();
+    let out_dir = temp_dir().join(TEST_DIR);
+    fs::remove_dir_all(out_dir).unwrap();
+    // The lock is automatically released when it goes out of scope
+}
+
+// Assumes CWD is test_files
+fn remove_local_generated_files() {
+    for f in ["src.rs", "other.rs", "outer.rs"] {
+        for loc in [".", "src", "other"] {
+            let file_path = path::Path::new(loc).join(f);
+            if fs::exists(&file_path).unwrap() {
+                fs::remove_file(file_path).unwrap();
+            }
+        }
+    }
+}
+
+// This is maybe a little nonintuitive at first.  We verify that the file exists where we expect
+// it, and nowhere else.  So fs::exists().unwrap() for a given location must be equal to our
+// expectation that it's in that location.
+fn verify_file(filename: &str, expected_location: GenFileLoc) {
+    println!("Checking the location of {}", filename);
+    assert_eq!(
+        fs::exists(path::Path::new("src").join(filename)).unwrap(),
+        expected_location == GenFileLoc::Src
+    );
+    assert_eq!(
+        fs::exists(path::Path::new("other").join(filename)).unwrap(),
+        expected_location == GenFileLoc::Other
+    );
+    assert_eq!(
+        fs::exists(filename).unwrap(),
+        expected_location == GenFileLoc::Root
+    );
+    if fs::exists(temp_dir().join(CUSTOM_TEST_DIR)).unwrap() {
+        // Some tests create a custom output directory here.  We only check for contents if it
+        // exists
+        assert_eq!(
+            fs::exists(temp_dir().join(CUSTOM_TEST_DIR).join(filename)).unwrap(),
+            expected_location == GenFileLoc::CustomOut
+        )
+    }
+    assert_eq!(
+        fs::exists(temp_dir().join(TEST_DIR).join(filename)).unwrap(),
+        expected_location == GenFileLoc::OutDir
+    );
+    // For GenFileLoc::DoesntExist, we should have returned false for all others.  There is nothing
+    // to positive test
+}
+
+#[test]
+fn test_process_root() {
+    let (orig_dir, _lock) = setup();
+
+    process_root().unwrap();
+
+    verify_file("src.rs", GenFileLoc::OutDir);
+    verify_file("other.rs", GenFileLoc::OutDir);
+    verify_file("outer.rs", GenFileLoc::OutDir);
+
+    teardown(orig_dir);
+}
+
+#[test]
+fn test_process_src() {
+    let (orig_dir, _lock) = setup();
+
+    process_src().unwrap();
+
+    verify_file("src.rs", GenFileLoc::OutDir);
+    verify_file("other.rs", GenFileLoc::DoesntExist);
+    verify_file("outer.rs", GenFileLoc::DoesntExist);
+
+    teardown(orig_dir);
+}
+
+#[test]
+fn test_explicit_in_out() {
+    let (orig_dir, _lock) = setup();
+
+    let custom_dir = temp_dir().join(CUSTOM_TEST_DIR);
+    if fs::exists(&custom_dir).unwrap() {
+        fs::remove_dir_all(&custom_dir).unwrap();
+    }
+    fs::create_dir(&custom_dir).unwrap();
+
+    Configuration::new()
+        .set_in_dir("other")
+        .set_out_dir(custom_dir.to_str().unwrap())
+        .process()
+        .unwrap();
+
+    verify_file("src.rs", GenFileLoc::DoesntExist);
+    verify_file("other.rs", GenFileLoc::CustomOut);
+    verify_file("outer.rs", GenFileLoc::DoesntExist);
+
+    fs::remove_dir_all(&custom_dir).unwrap();
+    teardown(orig_dir);
+}
+
+#[test]
+fn test_cargo_dir_conventions() {
+    let (orig_dir, _lock) = setup();
+
+    Configuration::new()
+        .use_cargo_dir_conventions()
+        .process()
+        .unwrap();
+
+    verify_file("src.rs", GenFileLoc::OutDir);
+    verify_file("other.rs", GenFileLoc::DoesntExist);
+    verify_file("outer.rs", GenFileLoc::DoesntExist);
+
+    teardown(orig_dir);
+}

--- a/lalrpop/src/api/test_files/other/other.lalrpop
+++ b/lalrpop/src/api/test_files/other/other.lalrpop
@@ -1,0 +1,5 @@
+grammar;
+
+pub Other: () = {
+	"a"
+};

--- a/lalrpop/src/api/test_files/outer.lalrpop
+++ b/lalrpop/src/api/test_files/outer.lalrpop
@@ -1,0 +1,5 @@
+grammar;
+
+pub Outer: () = {
+	"a"
+};

--- a/lalrpop/src/api/test_files/src/src.lalrpop
+++ b/lalrpop/src/api/test_files/src/src.lalrpop
@@ -1,0 +1,5 @@
+grammar;
+
+pub Src: () = {
+	"a"
+};

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -74,15 +74,10 @@ fn resolve_report_file(session: &Session, lalrpop_file: &Path) -> io::Result<Pat
 }
 
 fn gen_resolve_file(session: &Session, lalrpop_file: &Path, ext: &str) -> io::Result<PathBuf> {
-    let in_dir = if let Some(ref d) = session.in_dir {
-        d.as_path()
-    } else {
-        Path::new(".")
-    };
     let out_dir = if let Some(ref d) = session.out_dir {
         d.as_path()
     } else {
-        in_dir
+        lalrpop_file.parent().unwrap_or_else(|| Path::new("."))
     };
 
     // Ideally we do something like syn::parse_str::<syn::Ident>(lalrpop_file.file_name())?;
@@ -115,11 +110,12 @@ fn gen_resolve_file(session: &Session, lalrpop_file: &Path, ext: &str) -> io::Re
         ));
     }
 
-    // If the lalrpop file is not in in_dir, the result is that the
-    // .rs file is created in the same directory as the lalrpop file
-    // for compatibility reasons
     Ok(out_dir
-        .join(lalrpop_file.strip_prefix(in_dir).unwrap_or(lalrpop_file))
+        .join(
+            lalrpop_file
+                .file_name()
+                .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidInput))?,
+        )
         .with_extension(ext))
 }
 


### PR DESCRIPTION
Reverts lalrpop/lalrpop#1077

To have this as an open pr so it isn't lost. @dburgener can close this in favor of his own pr.

Either way, the main change that needs to be made is that the generated lalrpop file should be in the correct location.