### PR TITLE
Correctly label lalrpop code blocks in the lexer tutorial

### DIFF
--- a/doc/src/lexer_tutorial/004_token_references.md
+++ b/doc/src/lexer_tutorial/004_token_references.md
@@ -97,7 +97,7 @@ the symbol it just parsed.
 
 We can then take a look at the corresponding parser with a new grammar:
 
-``` rust
+```lalrpop
 Term: Box<ExprSymbol<'input>> = {
     "num" => Box::new(ExprSymbol::NumSymbol(<>)),
     "(" <Expr> ")"
@@ -107,13 +107,13 @@ Term: Box<ExprSymbol<'input>> = {
 We need to pass the input to the parser so that the input's lifetime is known
 to the borrow checker when compiling the generated parser.
 
-``` rust
+```lalrpop
 grammar<'input>(input: &'input str);
 ```
 
 Then we just need to define the tokens the same as before :
 
-``` rust
+```lalrpop
 extern {
     type Location = usize;
     type Error = ();

--- a/doc/src/lexer_tutorial/005_external_lib.md
+++ b/doc/src/lexer_tutorial/005_external_lib.md
@@ -244,7 +244,7 @@ rules to reference the desired token.
 
 Finally, we can build our rules:
 
-```rust
+```lalrpop
 pub Script: Vec<ast::Statement> = {
   <stmts:Statement*> => stmts
 }


### PR DESCRIPTION
Blocks mislabeled as rust code could cause user confusion.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->