### PR TITLE
Addressing Issue1085

### DIFF
--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -1237,3 +1237,18 @@ fn test_zero_length_match() {
     let res = zero_length_match::AParser::new().parse("B");
     assert!(matches!(res, Err(ParseError::InvalidToken { location: _ })));
 }
+
+#[derive(Clone, Debug)]
+enum Token<'s> {
+    Foo(&'s str),
+}
+
+lalrpop_mod!(
+    #[allow(unused_variables)]
+    parser
+);
+
+#[test]
+fn test_issue1085() {
+    let _ = parser::PParser::new().parse(std::iter::once((0, Token::Foo(""), 0)));
+}

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -1238,7 +1238,7 @@ fn test_zero_length_match() {
     assert!(matches!(res, Err(ParseError::InvalidToken { location: _ })));
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 enum Token<'s> {
     Foo(&'s str),
 }

--- a/lalrpop-test/src/parser.lalrpop
+++ b/lalrpop-test/src/parser.lalrpop
@@ -1,0 +1,15 @@
+use super::Token;
+grammar<'s>;
+
+extern {
+    type Location = usize;
+    enum Token<'s>  {
+        // Foo => Token::Foo(<&'s str>) <-- fix for 0.22
+         Foo => Token::Foo(s)
+    }
+}
+
+// pub P: &'s str <-- fix for 0.22
+pub P: Token<'s> = {
+    <t:Foo> => t,
+}


### PR DESCRIPTION
Related to #1085.

Caused by a forced warning of unused variables in https://github.com/lalrpop/lalrpop/pull/961. The easy thing to do is just remove the `warn` and push our allowing of unused variables closer to the lalrpop code that needs it. I do want to think about this first to see if there is a more fundamental problem/solution we can address here.

@dburgener touched this last if you have any thoughts.