### PR TITLE
Fix minimum versions test

### DIFF
--- a/doc/lexer/Cargo.toml
+++ b/doc/lexer/Cargo.toml
@@ -12,7 +12,7 @@ lalrpop = { version = "0.22.2", path = "../../lalrpop" }
 lalrpop-util = { version = "0.22.2", path = "../../lalrpop-util", features = [
     "unicode",
 ] }
-logos = "0.15.0"
+logos = "0.15.1"
 
 [features]
 default = []


### PR DESCRIPTION
I've written a somewhat detailed explanation here: https://github.com/maciejhirsz/logos/issues/496

It's technically a semver breakage on logos's end I think, but we are doing something kinda weird so I don't think it's that crazy. I'm not sure we've done a similar kind of breakage in the past but maybe we should also express an exact version constraint between lalrpop and lalrpop-util. I vaguely remember https://github.com/lalrpop/lalrpop/issues/883 where I think I user accidentally did a similar thing?