### PR TITLE
fix: lalrpop file not exist error before create dirs

### DIFF
--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -137,13 +137,14 @@ fn process_file_into(
             "processing file `{}`",
             lalrpop_file.to_string_lossy()
         );
+
+        // Load the LALRPOP source text for this file:
+        let file_text = Rc::new(FileText::from_path(lalrpop_file.to_path_buf())?);
+
         if let Some(parent) = rs_file.parent() {
             fs::create_dir_all(parent)?;
         }
         remove_old_file(rs_file)?;
-
-        // Load the LALRPOP source text for this file:
-        let file_text = Rc::new(FileText::from_path(lalrpop_file.to_path_buf())?);
 
         // Store the session and file-text in TLS -- this is not
         // intended to be used in this high-level code, but it gives


### PR DESCRIPTION
Fix creating parent directory when .lalrpop file does not exist

```
$ lalrpop not_exist_dir/foo.lalrpop
processing file `not_exist_dir/foo.lalrpop`
Error encountered processing `not_exist_dir/foo.lalrpop`: No such file or directory (os error 2)
$ ls
not_exist_dir
```

**After this PR fixed**:

```
$ lalrpop not_exist_dir/foo.lalrpop
processing file `not_exist_dir/foo.lalrpop`
Error encountered processing `not_exist_dir/foo.lalrpop`: No such file or directory (os error 2)
$ ls
```