### PR TITLE
Make the lexer feature a default feature for lalrpop-util

### DIFF
--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -18,8 +18,18 @@ lalrpop-util = "0.22.2"
 lalrpop = "0.22.2"
 # If you are supplying your own external lexer you can disable default features so that the
 # built-in lexer feature is not included
+# [dependencies]
+# lalrpop-util = { version = "0.22.2", default-features = false }
+#
+# [build-dependencies]
 # lalrpop = { version = "0.22.2", default-features = false }
 ```
+
+It's important to note that your version and features for `lalrpop` and
+`lalrpop-util` should always remain in sync.  Using different major or minor
+version levels for `lalrpop` and `lalrpop-util` is not supported.  Using
+different patch version levels should work in theory, but is challenging to
+test and therefore prone to breakage.
 
 Next create a [`build.rs`](https://doc.rust-lang.org/cargo/reference/build-scripts.html)
 file that looks like:

--- a/lalrpop-util/Cargo.toml
+++ b/lalrpop-util/Cargo.toml
@@ -20,7 +20,7 @@ regex-automata = { workspace = true, optional = true }
 lexer = ["dep:regex-automata"]
 unicode = ["regex-automata?/unicode"]
 std = ["regex-automata/perf"]
-default = ["std", "unicode"]
+default = ["std", "unicode", "lexer"]
 
 [package.metadata.docs.rs]
 features = ["lexer"]


### PR DESCRIPTION
The assumption in the code seems to have been that because lalrpop depends on lalrpop-util, we can let lalrpop set the feature and depend on feature unification to keep them in sync.  This simplifies things for the end user since they only need to set the feature in one place. However, resolver version 2 breaks this approach by keeping build dependencies and normal dependencies from performing feature unification with each other.  So the result is that a user who enables the lexer feature on lalrpop, but not lalrpop-util, will get a build-dependency of lalrpop-util with the feature enabled, but not a runtime dependency, when they use lalrpop-util in their own code.  For this reason, it is necessary to control these features together.

The documentation in the quick start guide reflects this assumption that changing just lalrpop is sufficient to turn off the built in lexer.  As of resolver version 2, that assumption is false.  Fix the documentation to accord with the state of this PR - that the lexer is on by default in lalrpop-util, and must be disabled in two places.

It's worth noting explicitly the user-visible aspects of this PR.  Prior to this PR, with resolver version 2, a user using the built in lexer would need to enable it for lalrpop-util, but could rely on the default for lalrpop.  A user using a custom lexer would only need to disable it in lalrpop.  After this PR, the user using the built in lexer needs no special steps, the default features will work.  A user using a custom lexer needs to disable the feature in two places.  This change is desirable because 1. It shifts the burden onto users with more complex use cases and keeps the "easy path" of using the built in lexer easy. 2. It has consistent behavior for both libraries.

fixed #1073

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->