### PR TITLE
Reproducer of breaking example from benchmark pr

### DIFF
--- a/lalrpop/src/api/test.rs
+++ b/lalrpop/src/api/test.rs
@@ -192,6 +192,20 @@ fn test_process_src() {
 }
 
 #[test]
+fn test_process_file() {
+    let _state = setup();
+
+    // This test is noting that with cargo_dir_conventions, "src/src.lalrpop"
+    // will work, but prepending "../test_files" does not as it is an unexpected
+    // file prefix.
+    Configuration::new().use_cargo_dir_conventions().process_file("../test_files/src/src.lalrpop").unwrap();
+
+    verify_file("src.rs", GenFileLoc::OutDir);
+    verify_file("other.rs", GenFileLoc::DoesntExist);
+    verify_file("outer.rs", GenFileLoc::DoesntExist);
+}
+
+#[test]
 fn test_explicit_in_out() {
     let _state = setup();
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

I was poking around #981 and noticed an odd panic which I sourced to https://github.com/lalrpop/lalrpop/blob/dd7196feb26cfa494438f2943bd3ee9ee2dbb9ad/lalrpop-test/benches/src/compile_benches.rs . I'm starting this pr off with a simple reproducer. I'm not sure of the clean solution yet.

Note the error is that the file path is : `../lalrpop/src/parser/lrgrammar.lalrpop` but the in_dir is `src`(which in this case is wrong, in the reproducer is actually correct, but then a small prefix is added which breaks the assumption that in_dir is a prefix of the file path). This leads to an unwrap on None panic.