### PR TITLE
style: remove long match in `lalrpop/src/tok/mod.rs`

### DIFF
--- a/lalrpop/src/tok/mod.rs
+++ b/lalrpop/src/tok/mod.rs
@@ -771,8 +771,8 @@ impl<'input> Tokenizer<'input> {
     fn expect_char(&mut self, c: char) -> Option<Result<usize, Error>> {
         let (idx0, cc) = self.lookahead?;
 
+        self.bump();
         if c == cc {
-            self.bump();
             Some(Ok(idx0))
         } else {
             Some(error(UnrecognizedToken, idx0))


### PR DESCRIPTION
Hi! I re-format some match statement in `lalrpop/src/tok/mod.rs` . Now it can be more friendly for people

### Before

```rust
match self.lookahead {
    Some((idx0, '&')) => {...}
    Some((idx0, '!')) => {...}
    Some((idx0, ':')) => {...}
    ...
    None => None
}
```

### After

```rust
let (idx0, c) = self.lookahead?;

match c {
    '&' => {...}
    '!' => {...}
    ':' => {...}
    ...
}
```

No behavioural changes, no logic moved.
Thanks for review!