### PR TITLE
Pin on mdbook 0.4

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: 'latest'
+          mdbook-version: '0.4.52'
 
       - name: Install mdbook-linkcheck
         run: |


### PR DESCRIPTION
We would like to migrate to the recently released mdbook 0.5, but have encountered blocking issues for now.

See https://github.com/lalrpop/lalrpop/issues/1104 for mdbook 0.5 status

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->