### PR TITLE
pin mdbook version in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: 'latest'
+          mdbook-version: '0.4.52'
 
       - name: Install and build mdbook
         run: |


### PR DESCRIPTION
A follow up on #1105 which only pinned the mdbook version in the book workflow. When this pr was merged, master broke because the deploy workflow only runs on a push to master(understandably, we wouldn't want anyone making a pr to be able to deploy something to the documentation).