### PR TITLE
Mark the correct versions in deprecated attributes

### DIFF
--- a/lalrpop/src/api/mod.rs
+++ b/lalrpop/src/api/mod.rs
@@ -308,7 +308,7 @@ pub fn process_src() -> Result<(), Box<dyn Error>> {
 /// ```
 ///
 #[deprecated(
-    since = "1.0.0",
+    since = "0.20.2",
     note = "use `Configuration::new().force_build(true).process_current_dir()` instead"
 )]
 pub fn process_root_unconditionally() -> Result<(), Box<dyn Error>> {

--- a/lalrpop/src/lexer/dfa/mod.rs
+++ b/lalrpop/src/lexer/dfa/mod.rs
@@ -22,7 +22,7 @@ pub struct Dfa {
 }
 
 #[allow(clippy::upper_case_acronyms)]
-#[deprecated(since = "1.0.0", note = "use `Dfa` instead")]
+#[deprecated(since = "0.20.0", note = "use `Dfa` instead")]
 pub type DFA = Dfa;
 
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
@@ -40,7 +40,7 @@ pub enum DfaConstructionError {
     Ambiguity { match0: NfaIndex, match1: NfaIndex },
 }
 
-#[deprecated(since = "1.0.0", note = "use `DfaConstructionError` instead")]
+#[deprecated(since = "0.20.0", note = "use `DfaConstructionError` instead")]
 pub type DFAConstructionError = DfaConstructionError;
 
 pub fn build_dfa(
@@ -91,13 +91,13 @@ pub enum Kind {
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NfaIndex(usize);
 
-#[deprecated(since = "1.0.0", note = "use `NfaIndex` instead")]
+#[deprecated(since = "0.20.0", note = "use `NfaIndex` instead")]
 pub type NFAIndex = NfaIndex;
 
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DfaStateIndex(usize);
 
-#[deprecated(since = "1.0.0", note = "use `DfaStateIndex` instead")]
+#[deprecated(since = "0.20.0", note = "use `DfaStateIndex` instead")]
 pub type DFAStateIndex = DfaStateIndex;
 
 type DfaKernelSet = KernelSet<DfaItemSet>;

--- a/lalrpop/src/lexer/nfa/mod.rs
+++ b/lalrpop/src/lexer/nfa/mod.rs
@@ -23,7 +23,7 @@ pub struct Nfa {
 }
 
 #[allow(clippy::upper_case_acronyms)]
-#[deprecated(since = "1.0.0", note = "Use `Nfa` instead")]
+#[deprecated(since = "0.20.0", note = "Use `Nfa` instead")]
 pub type NFA = Nfa;
 
 /// An edge label representing a range of characters, inclusive. Note
@@ -79,7 +79,7 @@ pub enum StateKind {
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NfaStateIndex(usize);
 
-#[deprecated(since = "1.0.0", note = "Use `NfaStateIndex` instead")]
+#[deprecated(since = "0.20.0", note = "Use `NfaStateIndex` instead")]
 pub type NFAStateIndex = NfaStateIndex;
 
 /// A set of edges for the state machine. Edges are kept sorted by the
@@ -119,7 +119,7 @@ pub enum NfaConstructionError {
     ByteRegex,
 }
 
-#[deprecated(since = "1.0.0", note = "Use `NfaConstructionError` instead")]
+#[deprecated(since = "0.20.0", note = "Use `NfaConstructionError` instead")]
 pub type NFAConstructionError = NfaConstructionError;
 
 impl Nfa {

--- a/lalrpop/src/lr1/lookahead.rs
+++ b/lalrpop/src/lr1/lookahead.rs
@@ -129,7 +129,7 @@ impl Lookahead for TokenSet {
 }
 
 impl Token {
-    #[deprecated(since = "1.0.0", note = "use `Eof` instead")]
+    #[deprecated(since = "0.20.0", note = "use `Eof` instead")]
     pub const EOF: Self = Self::Eof;
 
     pub fn unwrap_terminal(&self) -> &TerminalString {


### PR DESCRIPTION
As far as I can tell, the "since" field isn't actually used anywhere, it's only there for people browsing source.  Clippy checks that it's valid semver.

There was prior discussion on this here: https://github.com/orgs/lalrpop/discussions/823#discussioncomment-6703836

The main reasons to avoid fixing the numbers there were to avoid code churn, and to not make things start as deprecated in a non-breaking release.

The main things that have changed since then are that 1.0.0 seems less imminent, and that we are gearing up for a breaking release.

So let's take the opportunity and fix these to reflect the actual history.  That will help us make future judgments about possibly dropping the deprecated items in a future breaking release.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->