### PR TITLE
Regression noted in #1114?

### DIFF
--- a/lalrpop-test/build.rs
+++ b/lalrpop-test/build.rs
@@ -11,5 +11,9 @@ fn main() {
         .emit_comments(false)
         .force_build(true)
         .process_dir("benches")
-        .unwrap()
+        .unwrap();
+
+    lalrpop::Configuration::new()
+        .process_dir("issue1114")
+        .expect("unwrap");
 }

--- a/lalrpop-test/issue1114/test_grammar.lalrpop
+++ b/lalrpop-test/issue1114/test_grammar.lalrpop
@@ -1,0 +1,2 @@
+grammar;
+pub Num: i32 = <s:r"[0-9]+"> => s.parse().unwrap();

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -20,6 +20,8 @@ macro_rules! lalrpop_mod_test {
     }
 }
 
+lalrpop_mod!(pub grammar, "issue1114/test_grammar.rs");
+
 /// Tests for pattern in arguments
 lalrpop_mod_test!(arg_pattern);
 

--- a/lalrpop/src/api/mod.rs
+++ b/lalrpop/src/api/mod.rs
@@ -234,13 +234,20 @@ impl Configuration {
         let mut session = self.session.clone();
 
         self.verify_no_in_dir_conflict(Some(path.as_ref().to_path_buf()))?;
+        let flag = session.in_dir.is_none() && current_dir().unwrap() != path.as_ref();
         session.in_dir = Some(path.as_ref().to_path_buf());
 
         // If out dir is empty, use cargo conventions by default.
         // See https://github.com/lalrpop/lalrpop/issues/280
         if session.out_dir.is_none() {
             let out_dir = env::var_os("OUT_DIR").ok_or("missing OUT_DIR variable")?;
-            session.out_dir = Some(PathBuf::from(out_dir));
+            let mut p = PathBuf::from(out_dir);
+
+            if path.as_ref().file_stem().unwrap() != "src" && flag {
+                p.extend(path.as_ref());
+            }
+
+            session.out_dir = Some(p);
         }
 
         if self.session.features.is_none() {

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -52,6 +52,9 @@ fn hash_file(file: &Path) -> io::Result<String> {
 
 pub fn process_dir<P: AsRef<Path>>(session: Rc<Session>, root_dir: P) -> io::Result<()> {
     let lalrpop_files = lalrpop_files(root_dir)?;
+    if lalrpop_files.is_empty() {
+        return Err(io::Error::other("No lalrpop files were found in directory"));
+    }
     for lalrpop_file in lalrpop_files {
         process_file(session.clone(), lalrpop_file)?;
     }


### PR DESCRIPTION
I had a chance to look at #1114, let me first run the failing test case in this pr

Edit: I pushed my local fix but I wasn't running `cargo test -p lalrpop-test --benches` which has similar behavior to the issue of note. Here, we call lalrpop on the benches directory, and then we load the grammars from
```rust
lalrpop_mod!(pub json, "parsers/json.rs");
pub mod json_val;
lalrpop_mod!(pub json_ref, "parsers/json_ref.rs");
```

Which notably skips a bunch of the directory structure as each lalrpop file is actually in `benches/src/parsers/*.lalrpop`. I think the reason we don't notice is because the files are named differently so there isn't a collision(unlike in the issue linked).

I'll have to think more about this since this seems a bit tricky and I don't want to rush ones way into another regression. I'll also note that my attempted fix is a bit of a hack currently. I'll try to look at this again tomorrow