### PR TITLE
Bump versions and add changelog for 0.23.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ checksum = "c81d250916401487680ed13b8b675660281dcfc3ab0121fe44c94bcab9eae2fb"
 
 [[package]]
 name = "calculator"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "cfg"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-test"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "criterion",
  "diff",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "regex-automata",
 ]
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "whitespace"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "lalrpop",
  "lalrpop-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "3"
 repository = "https://github.com/lalrpop/lalrpop"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0 OR MIT"
-version = "0.23.0" # LALRPOP
+version = "0.23.1" # LALRPOP
 edition = "2024"
 # This is (very) soft limit of the minimum supported version.
 # Please update it when lalrpop requires a new feature.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,10 @@
+<a name="0.23.1"></a>
+## 0.23.1  (2026-03-11)
+
+#### Bigfixes
+* Fix bug where windows paths were used based on target OS rather than host OS,
+  breaking cross compile scenarios
+
 <a name="0.23.0"></a>
 ## 0.23.0  (2026-02-12)
 

--- a/doc/calculator/Cargo.toml
+++ b/doc/calculator/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "calculator"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 workspace = "../.." # <-- We added this and everything after!
 edition = "2024"
 publish = false
 
 [build-dependencies]
-lalrpop = { version = "0.23.0", path = "../../lalrpop" }
+lalrpop = { version = "0.23.1", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.23.0", path = "../../lalrpop-util", features = [
+lalrpop-util = { version = "0.23.1", path = "../../lalrpop-util", features = [
     "lexer",
     "unicode",
 ] }

--- a/doc/cfg/Cargo.toml
+++ b/doc/cfg/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "cfg"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["Mathis Brossier <mathis.brossier@gmail.com>"]
 workspace = "../.." # <-- We added this and everything after!
 edition = "2024"
 publish = false
 
 [build-dependencies]
-lalrpop = { version = "0.23.0", path = "../../lalrpop" }
+lalrpop = { version = "0.23.1", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.23.0", path = "../../lalrpop-util", features = [
+lalrpop-util = { version = "0.23.1", path = "../../lalrpop-util", features = [
     "lexer",
 ] }
 

--- a/doc/lexer-modes/Cargo.toml
+++ b/doc/lexer-modes/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Neal H. Walfield <neal@sequoia-pgp.org>"]
 publish = false
 
 [build-dependencies]
-lalrpop = { version = "0.23.0", path = "../../lalrpop" }
+lalrpop = { version = "0.23.1", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.23.0", path = "../../lalrpop-util" }
+lalrpop-util = { version = "0.23.1", path = "../../lalrpop-util" }

--- a/doc/lexer/Cargo.toml
+++ b/doc/lexer/Cargo.toml
@@ -6,10 +6,10 @@ authors = ["Patrick LaFontaine <32135464+Pat-Lafon@users.noreply.github.com>"]
 publish = false
 
 [build-dependencies]
-lalrpop = { version = "0.23.0", path = "../../lalrpop" }
+lalrpop = { version = "0.23.1", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.23.0", path = "../../lalrpop-util", features = [
+lalrpop-util = { version = "0.23.1", path = "../../lalrpop-util", features = [
     "unicode",
 ] }
 logos = "0.15.1"

--- a/doc/nobol/Cargo.toml
+++ b/doc/nobol/Cargo.toml
@@ -7,10 +7,10 @@ workspace = "../.."
 publish = false
 
 [build-dependencies]
-lalrpop = { version = "0.23.0", path = "../../lalrpop" }
+lalrpop = { version = "0.23.1", path = "../../lalrpop" }
 
 [dependencies]
-lalrpop-util = { version = "0.23.0", path = "../../lalrpop-util", features = [
+lalrpop-util = { version = "0.23.1", path = "../../lalrpop-util", features = [
     "lexer",
     "unicode",
 ] }

--- a/doc/pascal/lalrpop/Cargo.toml
+++ b/doc/pascal/lalrpop/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2024"
 publish = false
 
 [build-dependencies]
-lalrpop = { version = "0.23.0", path = "../../../lalrpop" }
+lalrpop = { version = "0.23.1", path = "../../../lalrpop" }
 
 [dependencies]
 pico-args = "0.5"
 
 [dependencies.lalrpop-util]
-version = "0.23.0"
+version = "0.23.1"
 path = "../../../lalrpop-util"
 features = ["lexer"]

--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -11,18 +11,18 @@ the following lines to your `Cargo.toml`:
 ```toml
 # The generated code depends on lalrpop-util.
 [dependencies]
-lalrpop-util = "0.23.0"
+lalrpop-util = "0.23.1"
 
 # Add a build-time dependency on the lalrpop library:
 [build-dependencies]
-lalrpop = "0.23.0"
+lalrpop = "0.23.1"
 # If you are supplying your own external lexer you can disable default features so that the
 # built-in lexer feature is not included
 # [dependencies]
-# lalrpop-util = { version = "0.23.0", default-features = false }
+# lalrpop-util = { version = "0.23.1", default-features = false }
 #
 # [build-dependencies]
-# lalrpop = { version = "0.23.0", default-features = false }
+# lalrpop = { version = "0.23.1", default-features = false }
 ```
 
 It's important to note that your version and features for `lalrpop` and

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -31,7 +31,7 @@ authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2024"
 
 [build-dependencies] # <-- We added this and everything after!
-lalrpop = "0.23.0"
+lalrpop = "0.23.1"
 
 [dependencies]
 lalrpop-util = { version = "0.21.0", features = ["lexer", "unicode"] }

--- a/doc/whitespace/Cargo.toml
+++ b/doc/whitespace/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "whitespace"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["Mako <jlauve@rsmw.net>"]
 edition = "2024"
 publish = false
 
 [build-dependencies.lalrpop]
-version = "0.23.0"
+version = "0.23.1"
 path = "../../lalrpop"
 
 [dependencies.lalrpop-util]
-version = "0.23.0"
+version = "0.23.1"
 path = "../../lalrpop-util"

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -39,7 +39,7 @@ walkdir = "2.4.0"
 # library, disable it in your project by setting default-features = false.
 pico-args = { version = "0.5", default-features = false, optional = true }
 
-lalrpop-util = { path = "../lalrpop-util", version = "0.23.0", default-features = false }
+lalrpop-util = { path = "../lalrpop-util", version = "0.23.1", default-features = false }
 
 [dev-dependencies]
 diff = { workspace = true }

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -1,4 +1,4 @@
-// auto-generated: "lalrpop 0.23.0"
+// auto-generated: "lalrpop 0.23.1"
 // sha3: 5e8ffc3aef6c16a84fdea60b91ebe93a2cba830360325338d8aebb2427f18259
 use string_cache::DefaultAtom as Atom;
 use crate::grammar::parse_tree::*;


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->