### PR TITLE
Clippy lint 1.95

### DIFF
--- a/lalrpop/src/tok/test.rs
+++ b/lalrpop/src/tok/test.rs
@@ -15,7 +15,7 @@ fn gen_test(input: &str, expected: Vec<(&str, Expectation<'_>)>) {
 
     let tokenizer = Tokenizer::new(&input, 0);
     let len = expected.len();
-    for (token, (expected_span, expectation)) in tokenizer.zip(expected.into_iter()) {
+    for (token, (expected_span, expectation)) in tokenizer.zip(expected) {
         let expected_start = expected_span.find('~').unwrap();
         let expected_end = expected_span.rfind('~').unwrap() + 1;
         println!("token: {token:?}");


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->

I updated rand to 0.10.1 based on https://github.com/rust-random/rand/releases/tag/0.10.1 and a security warning from dependabot(though we don't use the log feature so I don't think this is an issue for lalrpop?)