### PR TITLE
Expose Parse Tree for processed LALRPOP grammar files

### DIFF
--- a/lalrpop/src/api/mod.rs
+++ b/lalrpop/src/api/mod.rs
@@ -1,4 +1,6 @@
 use crate::build;
+use crate::collections::Map;
+use crate::grammar::parse_tree::Grammar;
 use crate::log::Level;
 use crate::session::{ColorConfig, Session};
 use std::default::Default;
@@ -211,10 +213,26 @@ impl Configuration {
         self.process_dir(self.get_in_dir())
     }
 
+    /// Process all files according to the `set_in_dir` and
+    /// `set_out_dir` configuration.
+    ///
+    /// Returns a map of processed grammar files with their corresponding AST.
+    pub fn process_with_grammar(&self) -> Result<Map<PathBuf, Grammar>, Box<dyn Error>> {
+        self.process_dir_with_grammar(self.get_in_dir())
+    }
+
     /// Process all files in the current directory, which -- unless you
     /// have changed it -- is typically the root of the crate being compiled.
     pub fn process_current_dir(&self) -> Result<(), Box<dyn Error>> {
         self.process_dir(current_dir()?)
+    }
+
+    /// Process all files in the current directory, which -- unless you
+    /// have changed it -- is typically the root of the crate being compiled.
+    ///
+    /// Returns a map of processed grammar files with their corresponding AST.
+    pub fn process_current_dir_with_grammar(&self) -> Result<Map<PathBuf, Grammar>, Box<dyn Error>> {
+        self.process_dir_with_grammar(current_dir()?)
     }
 
     // The user should only use set_in_dir() with process(), not process_*() functions which
@@ -268,6 +286,15 @@ impl Configuration {
         Ok(())
     }
 
+    /// Process all `.lalrpop` files in `path`.
+    ///
+    /// Returns a map of processed grammar files
+    /// with their corresponding AST.
+    pub fn process_dir_with_grammar<P: AsRef<Path>>(&self, path: P) -> Result<Map<PathBuf, Grammar>, Box<dyn Error>> {
+        let session = Rc::new(self.prepare_session(&path)?);
+        Ok(build::process_dir(session, path)?)
+    }
+
     /// Process the given `.lalrpop` file.
     pub fn process_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Box<dyn Error>> {
         let session = Rc::new(self.session.clone());
@@ -276,6 +303,16 @@ impl Configuration {
         self.verify_no_in_dir_conflict(None)?;
         build::process_file(session, path)?;
         Ok(())
+    }
+
+    /// Process the given `.lalrpop` file.
+    ///
+    /// Returns the corresponding AST for
+    /// the given file if processed.
+    pub fn process_file_with_grammar<P: AsRef<Path>>(&self, path: P) -> Result<Option<Grammar>, Box<dyn Error>> {
+        let session = Rc::new(self.session.clone());
+        self.verify_no_in_dir_conflict(None)?;
+        Ok(build::process_file(session, path)?)
     }
 }
 
@@ -290,6 +327,14 @@ pub fn process_root() -> Result<(), Box<dyn Error>> {
     Configuration::new().process_current_dir()
 }
 
+/// See [`process_root`] for details.
+///
+/// Returns a map of processed grammar
+/// files with their corresponding AST.
+pub fn process_root_with_grammar() -> Result<Map<PathBuf, Grammar>, Box<dyn Error>> {
+    Configuration::new().process_current_dir_with_grammar()
+}
+
 /// Process all files in ./src.
 ///
 /// In many cargo projects which build only one crate, this is the normal
@@ -298,6 +343,14 @@ pub fn process_root() -> Result<(), Box<dyn Error>> {
 /// See `Configuration` if you would like more fine-grain control over lalrpop.
 pub fn process_src() -> Result<(), Box<dyn Error>> {
     Configuration::new().set_in_dir("./src").process()
+}
+
+/// See [`process_src`] for details.
+///
+/// Returns a map of processed grammar
+/// files with their corresponding AST.
+pub fn process_src_with_grammar() -> Result<Map<PathBuf, Grammar>, Box<dyn Error>> {
+    Configuration::new().set_in_dir("./src").process_with_grammar()
 }
 
 /// Deprecated in favor of `Configuration`.

--- a/lalrpop/src/api/mod.rs
+++ b/lalrpop/src/api/mod.rs
@@ -198,15 +198,17 @@ impl Configuration {
         self
     }
 
+    fn get_in_dir(&self) -> &Path {
+        match self.session.in_dir {
+            Some(ref root) => root.as_path(),
+            None => Path::new("."),
+        }
+    }
+
     /// Process all files according to the `set_in_dir` and
     /// `set_out_dir` configuration.
     pub fn process(&self) -> Result<(), Box<dyn Error>> {
-        let root = if let Some(ref d) = self.session.in_dir {
-            d.as_path()
-        } else {
-            Path::new(".")
-        };
-        self.process_dir(root)
+        self.process_dir(self.get_in_dir())
     }
 
     /// Process all files in the current directory, which -- unless you
@@ -229,8 +231,7 @@ impl Configuration {
         Ok(())
     }
 
-    /// Process all `.lalrpop` files in `path`.
-    pub fn process_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Box<dyn Error>> {
+    fn prepare_session<P: AsRef<Path>>(&self, path: P) -> Result<Session, Box<dyn Error>> {
         let mut session = self.session.clone();
 
         self.verify_no_in_dir_conflict(Some(path.as_ref().to_path_buf()))?;
@@ -257,7 +258,12 @@ impl Configuration {
             );
         }
 
-        let session = Rc::new(session);
+        Ok(session)
+    }
+
+    /// Process all `.lalrpop` files in `path`.
+    pub fn process_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Box<dyn Error>> {
+        let session = Rc::new(self.prepare_session(&path)?);
         build::process_dir(session, path)?;
         Ok(())
     }

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -180,7 +180,8 @@ fn process_file_into(
         // generation fails at some point, we don't leave a partial
         // file behind.
         {
-            let grammar = parse_and_normalize_grammar(&session, &file_text)?;
+            let grammar = parse_grammar(&file_text)?;
+            let grammar = normalize_grammar(&session, &file_text, grammar)?;
             let buffer = emit_recursive_ascent(&session, &grammar, report_file)?;
             let mut output_file = fs::File::create(rs_file)?;
             writeln!(output_file, "{LALRPOP_VERSION_HEADER}")?;
@@ -287,10 +288,12 @@ fn lalrpop_files<P: AsRef<Path>>(root_dir: P) -> io::Result<Vec<PathBuf>> {
     Ok(result)
 }
 
-fn parse_and_normalize_grammar(session: &Session, file_text: &FileText) -> io::Result<r::Grammar> {
-    let grammar = parser::parse_grammar(file_text.text())
-        .map_err(|error| report_parse_error(file_text, error, report_error))?;
+fn parse_grammar(file_text: &FileText) -> io::Result<pt::Grammar> {
+    parser::parse_grammar(file_text.text())
+        .map_err(|error| report_parse_error(file_text, error, report_error))
+}
 
+fn normalize_grammar(session: &Session, file_text: &FileText, grammar: pt::Grammar) -> io::Result<r::Grammar> {
     match normalize::normalize(session, grammar) {
         Ok(grammar) => Ok(grammar),
         Err(error) => Err(report_error(file_text, error.span, &error.message))?,

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -62,6 +62,10 @@ pub fn process_file<P: AsRef<Path>>(session: Rc<Session>, lalrpop_file: P) -> io
     let lalrpop_file = lalrpop_file.as_ref();
     let rs_file = resolve_rs_file(&session, lalrpop_file)?;
     let report_file = resolve_report_file(&session, lalrpop_file)?;
+    session.emit_rerun_directive(lalrpop_file);
+    if !(session.force_build || needs_rebuild(lalrpop_file, &rs_file)?) {
+        return Ok(());
+    }
     process_file_into(session, lalrpop_file, &rs_file, &report_file)
 }
 
@@ -151,44 +155,40 @@ fn process_file_into(
     rs_file: &Path,
     report_file: &Path,
 ) -> io::Result<()> {
-    session.emit_rerun_directive(lalrpop_file);
-    if session.force_build || needs_rebuild(lalrpop_file, rs_file)? {
-        log!(
-            session,
-            Informative,
-            "processing file `{}`",
-            lalrpop_file.to_string_lossy()
-        );
+    log!(
+        session,
+        Informative,
+        "processing file `{}`",
+        lalrpop_file.to_string_lossy()
+    );
 
-        // Load the LALRPOP source text for this file:
-        let file_text = Rc::new(FileText::from_path(lalrpop_file.to_path_buf())?);
+    // Load the LALRPOP source text for this file:
+    let file_text = Rc::new(FileText::from_path(lalrpop_file.to_path_buf())?);
 
-        if let Some(parent) = rs_file.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        remove_old_file(rs_file)?;
-
-        // Store the session and file-text in TLS -- this is not
-        // intended to be used in this high-level code, but it gives
-        // easy access to this information pervasively in the
-        // low-level LR(1) and grammar normalization code. This is
-        // particularly useful for error-reporting.
-        let _tls = Tls::install(session.clone(), file_text.clone());
-
-        // Do the LALRPOP processing itself and write the resulting
-        // buffer into a file. We use a buffer so that if LR(1)
-        // generation fails at some point, we don't leave a partial
-        // file behind.
-        {
-            let grammar = parse_grammar(&file_text)?;
-            let grammar = normalize_grammar(&session, &file_text, grammar)?;
-            let buffer = emit_recursive_ascent(&session, &grammar, report_file)?;
-            let mut output_file = fs::File::create(rs_file)?;
-            writeln!(output_file, "{LALRPOP_VERSION_HEADER}")?;
-            writeln!(output_file, "{}", hash_file(lalrpop_file)?)?;
-            output_file.write_all(&buffer)?;
-        }
+    if let Some(parent) = rs_file.parent() {
+        fs::create_dir_all(parent)?;
     }
+    remove_old_file(rs_file)?;
+
+    // Store the session and file-text in TLS -- this is not
+    // intended to be used in this high-level code, but it gives
+    // easy access to this information pervasively in the
+    // low-level LR(1) and grammar normalization code. This is
+    // particularly useful for error-reporting.
+    let _tls = Tls::install(session.clone(), file_text.clone());
+
+    // Do the LALRPOP processing itself and write the resulting
+    // buffer into a file. We use a buffer so that if LR(1)
+    // generation fails at some point, we don't leave a partial
+    // file behind.
+    let grammar = parse_grammar(&file_text)?;
+    let normalized_grammar = normalize_grammar(&session, &file_text, grammar)?;
+    let buffer = emit_recursive_ascent(&session, &normalized_grammar, report_file)?;
+    let mut output_file = fs::File::create(rs_file)?;
+    writeln!(output_file, "{LALRPOP_VERSION_HEADER}")?;
+    writeln!(output_file, "{}", hash_file(lalrpop_file)?)?;
+    output_file.write_all(&buffer)?;
+
     Ok(())
 }
 

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -1,5 +1,6 @@
 //! Utilities for running in a build script.
 
+use crate::collections::Map;
 use crate::file_text::FileText;
 use crate::grammar::parse_tree as pt;
 use crate::grammar::repr as r;
@@ -50,23 +51,26 @@ fn hash_file(file: &Path) -> io::Result<String> {
     Ok(format!("// sha3: {:02x}", output.iter().format("")))
 }
 
-pub fn process_dir<P: AsRef<Path>>(session: Rc<Session>, root_dir: P) -> io::Result<()> {
+pub fn process_dir<P: AsRef<Path>>(session: Rc<Session>, root_dir: P) -> io::Result<Map<PathBuf, pt::Grammar>> {
     let lalrpop_files = lalrpop_files(root_dir)?;
+    let mut result = Map::new();
     for lalrpop_file in lalrpop_files {
-        process_file(session.clone(), lalrpop_file)?;
+        if let Some(grammar) = process_file(session.clone(), &lalrpop_file)? {
+            result.insert(lalrpop_file, grammar);
+        }
     }
-    Ok(())
+    Ok(result)
 }
 
-pub fn process_file<P: AsRef<Path>>(session: Rc<Session>, lalrpop_file: P) -> io::Result<()> {
+pub fn process_file<P: AsRef<Path>>(session: Rc<Session>, lalrpop_file: P) -> io::Result<Option<pt::Grammar>> {
     let lalrpop_file = lalrpop_file.as_ref();
     let rs_file = resolve_rs_file(&session, lalrpop_file)?;
     let report_file = resolve_report_file(&session, lalrpop_file)?;
     session.emit_rerun_directive(lalrpop_file);
     if !(session.force_build || needs_rebuild(lalrpop_file, &rs_file)?) {
-        return Ok(());
+        return Ok(None);
     }
-    process_file_into(session, lalrpop_file, &rs_file, &report_file)
+    Ok(Some(process_file_into(session, lalrpop_file, &rs_file, &report_file)?))
 }
 
 fn resolve_rs_file(session: &Session, lalrpop_file: &Path) -> io::Result<PathBuf> {
@@ -154,7 +158,7 @@ fn process_file_into(
     lalrpop_file: &Path,
     rs_file: &Path,
     report_file: &Path,
-) -> io::Result<()> {
+) -> io::Result<pt::Grammar> {
     log!(
         session,
         Informative,
@@ -182,14 +186,14 @@ fn process_file_into(
     // generation fails at some point, we don't leave a partial
     // file behind.
     let grammar = parse_grammar(&file_text)?;
-    let normalized_grammar = normalize_grammar(&session, &file_text, grammar)?;
+    let normalized_grammar = normalize_grammar(&session, &file_text, grammar.clone())?;
     let buffer = emit_recursive_ascent(&session, &normalized_grammar, report_file)?;
     let mut output_file = fs::File::create(rs_file)?;
     writeln!(output_file, "{LALRPOP_VERSION_HEADER}")?;
     writeln!(output_file, "{}", hash_file(lalrpop_file)?)?;
     output_file.write_all(&buffer)?;
 
-    Ok(())
+    Ok(grammar)
 }
 
 fn remove_old_file(rs_file: &Path) -> io::Result<()> {

--- a/lalrpop/src/grammar/parse_tree.rs
+++ b/lalrpop/src/grammar/parse_tree.rs
@@ -1,6 +1,7 @@
+#![allow(missing_docs, reason = "The AST and fields should be pretty self-explanatory")]
+
 //! The "parse-tree" is what is produced by the parser. We use it do
 //! some pre-expansion and so forth before creating the proper AST.
-
 use crate::grammar::consts::{INPUT_LIFETIME, LALR, RECURSIVE_ASCENT, TABLE_DRIVEN, TEST_ALL};
 use crate::grammar::pattern::Pattern;
 use crate::grammar::repr::{self as r, NominalTypeRepr, TypeRepr};

--- a/lalrpop/src/lib.rs
+++ b/lalrpop/src/lib.rs
@@ -48,4 +48,5 @@ pub use crate::api::process_root;
 #[allow(deprecated)]
 pub use crate::api::process_root_unconditionally;
 pub use crate::api::process_src;
+pub use crate::grammar::parse_tree;
 use ascii_canvas::style;


### PR DESCRIPTION
# Expose Parse Tree (Grammar AST) Through the Public API

Exposes the AST for parsed `.lalrpop` files as part of the public API.

## Motivation

LALRPOP is primarily used as a parser generator — it consumes `.lalrpop` grammar
files and emits Rust source code. However, the parsed grammar AST (the
`parse_tree::Grammar`) contains all the structural information about the
grammar such as nonterminals, productions, alternatives, token definitions,
action code, attributes, etc. This information is valuable beyond code
generation.

**Use cases include:**

- **Programmatic grammar analysis** — A `build.rs` script or standalone tool can
  inspect the grammar's structure to generate additional artifacts (e.g.,
  `tmLanguage.json` syntax highlighting files for editors, documentation, type
  definitions for other languages, etc.).
- **Tooling integration** — Grammar authors can validate conventions, extract
  metadata, or generate cross-references by accessing the AST directly.
- **Downstream processing** — The raw parse tree can be consumed by other
  transformers or generators without having to re-parse the `.lalrpop` file
  themselves.

Previously, the internal `process_file_into` function
parsed the grammar, passed it through `normalize`, and
then discarded the `Grammar`. The public API methods on
`Configuration` and the free functions
(`process_root`, `process_src`) all returned
`Result<()>`, losing the AST.

## Changes

### Core refactor: `build/mod.rs`

The internal processing pipeline in `build/mod.rs` was refactored
to return the `Grammar` value instead of discarding it:

| Function            | Before           | After                                   |
|---------------------|------------------|-----------------------------------------|
| `process_file_into` | `io::Result<()>` | `io::Result<pt::Grammar>`               |
| `process_file`      | `io::Result<()>` | `io::Result<Option<pt::Grammar>>`       |
| `process_dir`       | `io::Result<()>` | `io::Result<Map<PathBuf, pt::Grammar>>` |

**Specific changes:**

1. **`process_file_into`** — Now returns the parsed `pt::Grammar`. The
   `force_build` / `needs_rebuild` check was moved up to the caller
   (`process_file`), so `process_file_into` always parses and returns an AST
   if invoked.

2. **`process_file`** — Now returns `Option<pt::Grammar>`:
   - `Some(grammar)` when the file was actually processed (parsed + code
     generated).
   - `None` when the cached output (`.rs` file) was up-to-date and no
     processing was necessary.

   The `needs_rebuild` / `force_build` check is performed here; if the file is
   already up-to-date, the function returns `None` without parsing. This
   preserves the incremental build optimization: if a caller does not need the
   AST, they pay nothing extra.

3. **`process_dir`** — Now returns `Map<PathBuf, pt::Grammar>`.
   Each key is the full path of the processed
   `.lalrpop` file, and the value is its corresponding AST. Files that did not
   need rebuilding are omitted from the map (since `process_file` returned
   `None` for them).

4. **`process_dir` collects results** — Iterates over `process_file` results
   and only inserts entries where a grammar was returned.

5. **`parse_and_normalize_grammar`** was split into two distinct helpers:
   - **`parse_grammar`** — Parses raw text into `pt::Grammar`.
   - **`normalize_grammar`** — Takes ownership of a `pt::Grammar` and normalizes
     it into `r::Grammar`.

   This allows for the intermediary AST to be cloned for use elsewhere before being
   normalizes.

### Public API additions: `api/mod.rs`

New methods were added to `Configuration` and as free
functions. All existing method signatures remain **unchanged** for full backward
compatibility.

#### Private helpers

Aims to reduce duplicated code in existing and new functions.

- **`Configuration::get_in_dir(&self) -> &Path`** — Extracted from `process()`.
- **`Configuration::prepare_session<P>(&self, path: P) -> Result<Session, Box<dyn Error>>`** —
  Extracted from `process_dir`.
  
### `lib.rs`

Makes the `parse_tree` module public for use in libraries to consume the AST.

### `grammar/parse_tree.rs`

Added `#![allow(missing_docs)]` to suppress warning about missing docs on public types.
What an AST does should be pretty self-explanatory

#### New `Configuration` methods

| Method | Return Type | Description |
|---|---|---|
| `process_with_grammar(&self)` | `Result<Map<PathBuf, Grammar>>` | Like `process()`, returns all processed grammars keyed by path. |
| `process_current_dir_with_grammar(&self)` | `Result<Map<PathBuf, Grammar>>` | Like `process_current_dir()`, returns grammars keyed by path. |
| `process_dir_with_grammar<P>(&self, path)` | `Result<Map<PathBuf, Grammar>>` | Like `process_dir()`, returns grammars keyed by path. |
| `process_file_with_grammar<P>(&self, path)` | `Result<Option<Grammar>>` | Like `process_file()`, returns `None` if cached. |

#### New free functions

| Function | Return Type | Description |
|---|---|---|
| `process_root_with_grammar()` | `Result<Map<PathBuf, Grammar>>` | Free-function version of `process_current_dir_with_grammar`. |
| `process_src_with_grammar()` | `Result<Map<PathBuf, Grammar>>` | Free-function version of `process_with_grammar` with in_dir set to `./src`. |

## Usage Examples

### In a `build.rs` to generate a `tmLanguage.json`

```rust
// build.rs
use lalrpop::Configuration;
use std::env;
use std::fs;
use std::path::PathBuf;

fn main() {
    // Process all grammar files and get their ASTs
    let grammars = Configuration::new()
        .use_cargo_dir_conventions()
        .process_with_grammar()
        .unwrap();

    for (path, grammar) in &grammars {
        // Extract terminal/token information from the grammar
        let keywords: Vec<_> = grammar
            .items
            .iter()
            .filter_map(|item| item.as_match_token())
            .flat_map(|mt| &mt.contents)
            .flat_map(|mc| &mc.items)
            .filter_map(|mi| /* extract terminal literals */ None)
            .collect();

        // Generate a TextMate grammar from the parsed grammar
        let tm_language = generate_tmlanguage(&grammar);
        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap())
            .join(path.file_stem().unwrap())
            .with_extension("tmLanguage.json");
        fs::write(&out_path, &tm_language).unwrap();
    }
}
```

### Selective processing with caching awareness

```rust
// Only process a single file, respecting incremental build
if let Some(grammar) = Configuration::new()
    .process_file_with_grammar("src/parser.lalrpop")
    .unwrap()
{
    // File was processed; grammar is fresh
    analyze_grammar(&grammar);
} else {
    // File was already up-to-date; no grammar returned
    println!("No rebuild necessary");
}
```

## Design Decisions

1. **Backward compatibility** — All existing public functions retain their exact
   signatures, return types, and behavior. No breaking changes to the public
   API.

2. **`Option<Grammar>` for `process_file`** — Since `process_file_into` only
   processes when needed, the API honestly reflects that no grammar is available
   when a rebuild was skipped. Callers who always need the grammar can use
   `process_file_with_grammar` and handle `None`, or call
   `force_build(true)` before processing.

3. **`Map<PathBuf, Grammar>` for directory methods** — Using the full
   `PathBuf` as key avoids ambiguity (multiple files may have the
   same filename stem in different subdirectories) and makes it trivial to map
   results back to input files.

5. **Split `parse_and_normalize_grammar`** — Separating parse from normalization
   gives the caller control over whether to normalize at all.

---

**Disclaimer:** This summary was written with the help of AI (LLM)
after the code was edited by hand. None of the contributed code has been
generated by AI.
