### PR TITLE
Address new clippy denials in 1.97

### DIFF
--- a/doc/whitespace/src/main.rs
+++ b/doc/whitespace/src/main.rs
@@ -7,9 +7,9 @@ fn main() {
             use std::fs::File;
 
             File::open(&filename)
-                .unwrap_or_else(|_| panic!("Can't open {}", &filename))
+                .unwrap_or_else(|_| panic!("Can't open {}", filename))
                 .read_to_string(&mut source)
-                .unwrap_or_else(|_| panic!("Can't read contents of {}", &filename));
+                .unwrap_or_else(|_| panic!("Can't read contents of {}", filename));
         }
 
         None => {


### PR DESCRIPTION
The useless borrows in formatting check
(https://rust-lang.github.io/rust-clippy/master/index.html#useless_borrows_in_formatting) says we shouldn't borrow things that are already references when passing them into format strings, because that prevents certain compiler optimizations.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->