### PR TITLE
Markdownlint "fixed line length detection"

### DIFF
--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -1,3 +1,3 @@
 all
-rule 'MD013', :ignore_code_blocks => true, :tables => false
+rule 'MD013', :line_length => 120, :ignore_code_blocks => true, :tables => false
 rule 'MD026', :punctuation => ".,;:!"

--- a/doc/src/location_tracking.md
+++ b/doc/src/location_tracking.md
@@ -21,11 +21,11 @@ Symbol = {
 }
 ```
 
-You can also see another example in [this test](https://github.com/lalrpop/lalrpop/blob/master/lalrpop-test/src/intern_tok.lalrpop),
+You can also see another example in [this test][intern_tok],
 where location tracking is wrapped in a macro.
 
 Since `@R2` binds to the index of the byte immediately to the right of the
-token, this makes the bound values suitable to immediately construct a [Range](https://doc.rust-lang.org/std/ops/struct.Range.html)
+token, this makes the bound values suitable to immediately construct a [Range][range]
 which is bounded inclusively above and exclusively below:
 
 ```lalrpop
@@ -35,3 +35,6 @@ Symbol: Range<usize> = {
     }
 }
 ```
+
+[intern_tok]: https://github.com/lalrpop/lalrpop/blob/master/lalrpop-test/src/intern_tok.lalrpop
+[range]: https://doc.rust-lang.org/std/ops/struct.Range.html

--- a/doc/src/tutorial/index.md
+++ b/doc/src/tutorial/index.md
@@ -26,10 +26,11 @@ Here are some topics that I aim to cover when I get time to write about them:
   [this test](https://github.com/lalrpop/lalrpop/blob/master/lalrpop-test/src/expr_arena.lalrpop)
   invoked [from here]).
 - Conditional macros (no good test to point you at yet, sorry)
-- Converting to use `LALR(1)` instead of `LR(1)` (see e.g. [this test](https://github.com/lalrpop/lalrpop/blob/master/lalrpop-test/src/expr_lalr.lalrpop)
+- Converting to use `LALR(1)` instead of `LR(1)` (see e.g. [this test][expr_lalr]
   invoked [from here]).
 - Plans for future features
 
 [Crash course on parsers]: ../crash_course.md
 [from here]: https://github.com/lalrpop/lalrpop/blob/master/lalrpop-test/src/lib.rs
 [doc section]: https://github.com/lalrpop/lalrpop/tree/master/doc
+[expr_lalr]: https://github.com/lalrpop/lalrpop/blob/master/lalrpop-test/src/expr_lalr.lalrpop


### PR DESCRIPTION
https://github.com/markdownlint/markdownlint/blob/main/CHANGELOG.md#fixed-1

The a recent update of markdownlint started detecting a fair number of lines in our docs as being too long(discovered in #1129). I set the limit to be 120 which covered most of the cases(and I think is a good modern default). The 3 remaining cases were converted into ref-style links.
