### PR TITLE
Bump lalrpop-util version in tutorial to match lalrpop version

### DIFF
--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -34,7 +34,7 @@ edition = "2024"
 lalrpop = "0.23.1"
 
 [dependencies]
-lalrpop-util = { version = "0.21.0", features = ["lexer", "unicode"] }
+lalrpop-util = { version = "0.23.1", features = ["lexer", "unicode"] }
 ```
 
 Cargo can run [build scripts] as a pre-processing step,


### PR DESCRIPTION
In the previous commit f67f874, only the version of lalrpop and not lalrpop-util was bumped in the tutorial.