### PR TITLE
Fix typo in release notes for 0.23.1

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,7 +1,7 @@
 <a name="0.23.1"></a>
 ## 0.23.1  (2026-03-11)
 
-#### Bigfixes
+#### Bugfixes
 * Fix bug where windows paths were used based on target OS rather than host OS,
   breaking cross compile scenarios
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->