### PR TITLE
Bump itertools dependency to 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -442,7 +442,7 @@ dependencies = [
  "bit-set",
  "diff",
  "ena",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lalrpop-util",
  "petgraph",
  "pico-args",

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -23,7 +23,7 @@ doctest = false
 ascii-canvas = { version = "4.0", default-features = false }
 bit-set = { version = "0.10", default-features = false }
 ena = { version = "0.14", default-features = false }
-itertools = { version = "0.14", default-features = false, features = [
+itertools = { version = "0.15", default-features = false, features = [
     "use_std",
 ] }
 petgraph = { version = "0.8", default-features = false }


### PR DESCRIPTION
Changelog is here https://github.com/rust-itertools/itertools/blob/master/CHANGELOG.md

Nothing breaking seems to affect lalrpop's usage of itertools.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->